### PR TITLE
chore: change the script error displaying behavior - INS-5470

### DIFF
--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -604,7 +604,7 @@ export const tryToExecuteScript = async (
       script,
     };
   } catch (err) {
-    const errMessage = `Detected error in Pre-request or After-response Script:\n${err.message || err}`
+    const errMessage = eventName === 'prerequest' ? `Error executing pre-request script:\n${err.message || err}` : `Error executing after-response script:\n${err.message || err}`
     await fs.promises.appendFile(
       timelinePath,
       serializeNDJSON([
@@ -621,7 +621,6 @@ export const tryToExecuteScript = async (
       // in pre-request script
       // all errors are regarded as fatal error
       const requestId = request._id;
-      // stack trace is ignored as it is always from preload
 
       const responsePatch = {
         _id: responseId,

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -426,7 +426,13 @@ export async function savePatchesMadeByScript(patches: {
   });
 }
 
-export const tryToExecuteScript = async (context: RequestAndContextAndOptionalResponse) => {
+type TryToExecuteScriptResult =
+  | (RequestAndContextAndOptionalResponse & { requestTestResults: RequestTestResult[] | undefined })
+  | { error: string };
+
+export const tryToExecuteScript = async (
+  context: RequestAndContextAndOptionalResponse,
+): Promise<TryToExecuteScriptResult> => {
   const {
     script,
     request,
@@ -592,28 +598,53 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
       execution: output.execution,
       transientVariables,
       parentFolders: output.parentFolders,
+      timelinePath,
+      ancestors,
+      responseId,
+      script,
     };
   } catch (err) {
+    const errMessage = `Detected error in Pre-request or After-response Script:\n${err.message || err}`
     await fs.promises.appendFile(
       timelinePath,
-      serializeNDJSON([{ value: err.message, name: 'Text', timestamp: Date.now() }]),
+      serializeNDJSON([
+        {
+          value: errMessage,
+          name: 'Text',
+          timestamp: Date.now(),
+        },
+      ]),
     );
 
-    const requestId = request._id;
-    // stack trace is ignored as it is always from preload
-    const errMessage = err.message ? err.message : err;
-    const responsePatch = {
-      _id: responseId,
-      parentId: requestId,
-      environemntId: environment._id,
-      globalEnvironmentId: globals?._id,
-      timelinePath,
-      statusMessage: 'Error',
-      error: errMessage,
+    // errors are handled differently in pre-request and after-response scripts
+    if (response === undefined) {
+      // in pre-request script
+      // all errors are regarded as fatal error
+      const requestId = request._id;
+      // stack trace is ignored as it is always from preload
+
+      const responsePatch = {
+        _id: responseId,
+        parentId: requestId,
+        environemntId: environment._id,
+        globalEnvironmentId: globals?._id,
+        timelinePath,
+        statusMessage: 'Error',
+        error: errMessage,
+      };
+      const res = await models.response.create(responsePatch, settings.maxHistoryResponses);
+      models.requestMeta.updateOrCreateByParentId(requestId, { activeResponseId: res._id });
+      return {
+        error: errMessage,
+      };
+    }
+
+    // in after-response script
+    // error will only be displayed in console, instead of preview INS-5470
+    return {
+      ...context,
+      requestTestResults: undefined,
     };
-    const res = await models.response.create(responsePatch, settings.maxHistoryResponses);
-    models.requestMeta.updateOrCreateByParentId(requestId, { activeResponseId: res._id });
-    return { error: errMessage };
   }
 };
 
@@ -679,6 +710,7 @@ export async function tryToExecuteAfterResponseScript(context: RequestAndContext
     return {
       error: `Execute after-response script failed: ${postMutatedContext?.error}`,
       ...context,
+      requestTestResults: new Array<RequestTestResult>(),
     };
   }
 

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -617,7 +617,7 @@ export const tryToExecuteScript = async (
     );
 
     // errors are handled differently in pre-request and after-response scripts
-    if (response === undefined) {
+    if (eventName === 'prerequest') {
       // in pre-request script
       // all errors are regarded as fatal error
       const requestId = request._id;

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -702,19 +702,6 @@ export const sendActionImplementation = async (options: {
     iterationCount,
     runtime,
   });
-  if ('error' in postMutatedContext) {
-    throw {
-      response: await responseTransform(
-        response,
-        requestData.activeEnvironmentId,
-        renderedRequest,
-        renderedResult.context,
-      ),
-      maxHistoryResponses: requestData.settings.maxHistoryResponses,
-      requestMeta,
-      error: postMutatedContext.error,
-    };
-  }
 
   window.main.completeExecutionStep({ requestId });
 
@@ -832,7 +819,6 @@ export const deleteAllResponsesAction: ActionFunction = async ({ params }) => {
   }
   return null;
 };
-
 export const deleteResponseAction: ActionFunction = async ({ request, params }) => {
   const { workspaceId, requestId } = params;
   invariant(typeof requestId === 'string', 'Request ID is required');

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -702,6 +702,19 @@ export const sendActionImplementation = async (options: {
     iterationCount,
     runtime,
   });
+  if ('error' in postMutatedContext && postMutatedContext.error.includes("Executing script timeout")) {
+    throw {
+      response: await responseTransform(
+        response,
+        requestData.activeEnvironmentId,
+        renderedRequest,
+        renderedResult.context,
+      ),
+      maxHistoryResponses: requestData.settings.maxHistoryResponses,
+      requestMeta,
+      error: postMutatedContext.error,
+    };
+  }
 
   window.main.completeExecutionStep({ requestId });
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Check ticket for the detail: INS-5470

### Changes
- If there's pre-request script error, error will be displayed in preview, console, and status code region.
- If there's after-response script error (Exception: if the script timeout, the error will be displayed):
  - The error will displayed only in console
  - The status code region displays response code
  - The preview pane displays response body

#8671