### PR TITLE
Chore(E2E): Remove arbitrary waits in e2e test

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
@@ -67,11 +67,10 @@ test.describe('Environment Editor', () => {
     await page.getByTestId('CodeEditor').getByRole('textbox').fill('"testNumber":9000,');
     await page.getByTestId('CodeEditor').getByRole('textbox').press('Enter');
     await page.getByTestId('CodeEditor').getByRole('textbox').fill('"testString":"Gandalf",');
-    // Let debounce finish
-    await page.waitForTimeout(1500);
 
     // Open request
-    await page.getByRole('button', { name: 'Close' }).click();
+    // Delay the click to let debounce finish
+    await page.getByRole('button', { name: 'Close' }).click({ delay: 200 });
     await page.getByLabel('Manage collection environments').press('Escape');
     await page.getByLabel('Request Collection').getByTestId('New Request').press('Enter');
 
@@ -96,28 +95,26 @@ test.describe('Environment Editor', () => {
     await page.keyboard.type('exampleString');
     await firstRow.getByTestId('OneLineEditor').nth(1).click();
     await page.keyboard.type('kvstring');
-    // wait for editor update
-    await page.waitForTimeout(1000);
     // add one more row
-    await page.getByRole('button', { name: 'Add Row' }).click();
+    // Delay the click to let debounce finish
+    await page.getByRole('button', { name: 'Add Row' }).click({ delay: 200 });
     const secondRow = kvTable.getByRole('option').nth(1);
     await secondRow.getByTestId('OneLineEditor').first().click();
     await page.keyboard.type('exampleObject');
-    await page.waitForTimeout(500);
     // change type to json
-    await secondRow.getByRole('button', { name: 'Type Selection' }).click();
+    // Delay the click to let debounce finish
+    await secondRow.getByRole('button', { name: 'Type Selection' }).click({ delay: 200 });
     await page.getByRole('menuitemradio', { name: 'JSON' }).click();
     await secondRow.getByRole('button', { name: 'Edit JSON' }).click();
     // wait for modal to show
-    await page.waitForTimeout(500);
+    await expect.soft(page.getByRole('dialog').getByTestId('CodeEditor')).toBeVisible();
     const bodyEditor = page.getByTestId('CodeEditor').getByRole('textbox');
     // move cursor right and input json string
     await bodyEditor.focus();
     await bodyEditor.press('ArrowRight');
     await bodyEditor.fill('"anotherString":"kvAnotherStr","anotherNumber": 12345');
-    await page.getByRole('button', { name: 'Modal Submit' }).click();
-    // Let debounce finish
-    await page.waitForTimeout(1500);
+    // Delay the click to let debounce finish
+    await page.getByRole('button', { name: 'Modal Submit' }).click({ delay: 200 });
 
     // Open request
     await page.getByRole('button', { name: 'Close' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
@@ -93,7 +93,7 @@ test.describe('Environment Editor', () => {
     firstRow = kvTable.getByRole('option').first();
     await firstRow.getByTestId('OneLineEditor').first().click();
     await page.keyboard.type('exampleString');
-    await firstRow.getByTestId('OneLineEditor').nth(1).click();
+    await firstRow.getByTestId('OneLineEditor').nth(1).click({ delay: 200 });
     await page.keyboard.type('kvstring');
     // add one more row
     // Delay the click to let debounce finish

--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
@@ -110,10 +110,10 @@ test.describe('Check vault used in environment', () => {
     const firstRow = kvTable.getByRole('option').first();
     await firstRow.getByTestId('OneLineEditor').first().click();
     await page.keyboard.type('foo');
-    await firstRow.getByTestId('OneLineEditor').nth(1).click();
+    await firstRow.getByTestId('OneLineEditor').nth(1).click({ delay: 200 });
     await page.keyboard.type('bar');
-    await page.waitForTimeout(500);
-    await firstRow.getByRole('button', { name: 'Type Selection' }).click();
+    // Delay the click to let debounce finish
+    await firstRow.getByRole('button', { name: 'Type Selection' }).click({ delay: 200 });
     await page.getByRole('menuitemradio', { name: 'Secret' }).click();
     await expect.soft(firstRow.locator('.fa-eye-slash')).toBeVisible();
     await firstRow.locator('.fa-eye-slash').click();
@@ -125,10 +125,10 @@ test.describe('Check vault used in environment', () => {
     const secondRow = kvTable.getByRole('option').nth(1);
     await secondRow.getByTestId('OneLineEditor').first().click();
     await page.keyboard.type('hello');
-    await secondRow.getByTestId('OneLineEditor').nth(1).click();
+    await secondRow.getByTestId('OneLineEditor').nth(1).click({ delay: 200 });
     await page.keyboard.type('world');
-    await page.waitForTimeout(500);
-    await secondRow.getByRole('button', { name: 'Type Selection' }).click();
+    // Delay the click to let debounce finish
+    await secondRow.getByRole('button', { name: 'Type Selection' }).click({ delay: 200 });
     await page.getByRole('menuitemradio', { name: 'Secret' }).click();
 
     // go back
@@ -160,7 +160,6 @@ test.describe('Check vault used in environment', () => {
     await page.locator('text=Insomnia Preferences').first().click();
     await page.locator('text=Enable vault in scripts').click();
     await page.locator('.app').press('Escape');
-    await page.waitForTimeout(500);
 
     // activate global private vault environment from import
     await page.getByLabel('Manage Environments').click();
@@ -173,6 +172,8 @@ test.describe('Check vault used in environment', () => {
     await page.getByTestId('underlay').click();
     // activate request
     await page.getByTestId('legacy-array-vault').getByLabel('GET legacy-array-vault', { exact: true }).click();
+    // Wait for tab appear
+    await expect.soft(page.getByLabel('Insomnia Tabs').getByText('legacy-array-vault', { exact: true })).toBeVisible();
     await page.getByRole('button', { name: 'Send' }).click();
     await page.getByRole('tab', { name: 'Console' }).click();
     await page.getByText('password').click();
@@ -187,6 +188,7 @@ test.describe('Check vault used in environment', () => {
     await page.getByTestId('underlay').click();
     // activate request
     await page.getByTestId('legacy-object-vault').getByLabel('GET legacy-object-vault', { exact: true }).click();
+    await expect.soft(page.getByLabel('Insomnia Tabs').getByText('legacy-object-vault', { exact: true })).toBeVisible();
     await page.getByRole('button', { name: 'Send' }).click();
 
     await page.getByRole('tab', { name: 'Console' }).click();


### PR DESCRIPTION
**Changes**
- Add a delay for the click action to replace the arbitrary wait for editor debounce to take effect
- Add expecting a change for new request tab/modal to appear rather than arbitrary waits
