### PR TITLE
feat(Tests): Add require interceptor in tests

### DIFF
--- a/packages/insomnia-inso/src/cli.test.ts
+++ b/packages/insomnia-inso/src/cli.test.ts
@@ -33,6 +33,7 @@ const shouldReturnSuccessCode = [
   '$PWD/packages/insomnia-inso/bin/inso run test -w packages/insomnia-inso/src/db/fixtures/nedb -e env_env_ca046a --reporter min uts_fe901c',
   '$PWD/packages/insomnia-inso/bin/inso run test -w packages/insomnia-inso/src/db/fixtures/git-repo -e env_env_ca046a uts_fe901c',
   '$PWD/packages/insomnia-inso/bin/inso run test -w packages/insomnia-inso/src/db/fixtures/insomnia-v4/insomnia_v4.yaml -e env_env_0e4670 spc_3b2850',
+
   // export file, request can inherit auth headers and variables from folder, also test --disableCertValidation with local https smoke test server
   '$PWD/packages/insomnia-inso/bin/inso run test -w packages/insomnia-inso/src/examples/folder-inheritance-document.yml spc_a8144e --verbose --disableCertValidation',
 
@@ -58,6 +59,8 @@ const shouldReturnErrorCode = [
   '$PWD/packages/insomnia-inso/bin/inso run test -w packages/insomnia-inso/src/db/fixtures/git-repo -e env_env_ca046a uts_7f0f85',
   '$PWD/packages/insomnia-inso/bin/inso lint spec -w packages/insomnia-inso/src/db/fixtures/git-repo-malformed-spec spc_46c5a4',
   '$PWD/packages/insomnia-inso/bin/inso lint spec packages/insomnia-inso/src/db/fixtures/insomnia-v4/malformed.yaml',
+  // With require
+  '$PWD/packages/insomnia-inso/bin/inso run test -w packages/insomnia-inso/src/db/fixtures/insomnia-v5/with-tests.yaml -e env_env_7c2769 uts_1c6207',
   // after-response script and test
   '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/after-response-failed-test.yml wrk_616795 --verbose',
 ];

--- a/packages/insomnia-inso/src/db/fixtures/insomnia-v5/with-tests.yaml
+++ b/packages/insomnia-inso/src/db/fixtures/insomnia-v5/with-tests.yaml
@@ -1,0 +1,284 @@
+type: spec.insomnia.rest/5.0
+name: Endpoint Security 1.2
+meta:
+  id: wrk_d58fc511fbf1495591e9939627cf4b9a
+  created: 1639600546875
+  modified: 1639600569168
+collection:
+  - url: mock.insomnia.run
+    name: Simple request
+    meta:
+      id: req_01e2be4c819d44948d045c9a7ee5c02c
+      created: 1748258822451
+      modified: 1748352624154
+      isPrivate: false
+      sortKey: -1748258822451
+    method: GET
+    headers:
+      - name: User-Agent
+        value: insomnia/11.1.0
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_7c2769239b7a889ba348c82883908cdf238ed89a
+    created: 1747824499497
+    modified: 1748352396643
+  cookies:
+    - key: AEC
+      value: AVh_V2g1A9_EwAqx29_jG23KRcQDGWRpcHQiD9558-GKVpB0rTF47IiU8w
+      domain: google.com
+      path: /
+      secure: true
+      httpOnly: true
+      hostOnly: false
+      creation: 2025-05-26T11:27:07.118Z
+      lastAccessed: 2025-05-27T13:26:36.643Z
+      sameSite: lax
+      id: d917923c-defa-4a7e-8832-b88a020d1abf
+environments:
+  name: Base environment
+  meta:
+    id: env_7c2769239b7a889ba348c82883908cdf238ed89a
+    created: 1639600546883
+    modified: 1639600569167
+    isPrivate: false
+  data:
+    base_url: "{{ scheme }}://{{ host }}{{ base_path }}"
+  subEnvironments:
+    - name: OpenAPI env
+      meta:
+        id: env_env_7c2769239b7a889ba348c82883908cdf238ed89a_sub
+        created: 1639600569165
+        modified: 1639600569165
+        isPrivate: false
+        sortKey: 1639600569165
+      data:
+        scheme: https
+        base_path: /v1
+        host: api.server.test
+        xApiKey: xApiKey
+        xAppVersion: xAppVersion
+        cookieName: cookieName
+        anotherCookieName: anotherCookieName
+        key: key
+        anotherKey: anotherKey
+        httpUsername: username
+        httpPassword: password
+        bearerToken: bearerToken
+        oauth2ClientId: clientId
+        oauth2ClientSecret: clientSecret
+        oauth2Username: username
+        oauth2Password: password
+spec:
+  contents:
+    openapi: 3.0.6
+    info:
+      title: Endpoint Security
+      version: "1.2"
+    servers:
+      - url: https://api.server.test/v3
+    components:
+      securitySchemes:
+        Basic:
+          type: http
+          scheme: basic
+        Bearer:
+          type: http
+          scheme: bearer
+        Key-Header:
+          type: apiKey
+          name: x-api_key
+          in: header
+        AnotherKey-Header:
+          type: apiKey
+          name: x-app-version
+          in: header
+        Key-Cookie:
+          type: apiKey
+          name: CookieName
+          in: cookie
+        AnotherKey-Cookie:
+          type: apiKey
+          name: AnotherCookieName
+          in: cookie
+        Key-Query:
+          type: apiKey
+          name: key
+          in: query
+        AnotherKey-Query:
+          type: apiKey
+          name: another_key
+          in: query
+        OAuth2-AuthorizationCode:
+          type: oauth2
+          scheme: bearer
+          flows:
+            authorizationCode:
+              authorizationUrl: https://api.server.test/v1/auth
+              tokenUrl: https://api.server.test/v1/token
+              scopes:
+                read:something: Read all the data
+                write:something: Write all the data
+        OAuth2-Implicit:
+          type: oauth2
+          scheme: bearer
+          flows:
+            implicit:
+              authorizationUrl: https://api.server.test/v1/auth
+              scopes:
+                read:something: Read all the data
+                write:something: Write all the data
+        OAuth2-ClientCredentials:
+          type: oauth2
+          scheme: bearer
+          flows:
+            clientCredentials:
+              tokenUrl: https://api.server.test/v1/token
+              scopes:
+                read:something: Read all the data
+                write:something: Write all the data
+        OAuth2-Password:
+          type: oauth2
+          scheme: bearer
+          flows:
+            password:
+              tokenUrl: https://api.server.test/v1/token
+              scopes:
+                read:something: Read all the data
+                write:something: Write all the data
+    paths:
+      /none:
+        get:
+          responses:
+            "200":
+              description: OK
+      /none/basic:
+        get:
+          responses:
+            "200":
+              description: OK
+      /basic:
+        get:
+          responses:
+            "200":
+              description: OK
+      /bearer:
+        get:
+          responses:
+            "200":
+              description: OK
+      /key/header:
+        get:
+          responses:
+            "200":
+              description: OK
+      /key/cookie:
+        get:
+          responses:
+            "200":
+              description: OK
+      /key/query:
+        get:
+          responses:
+            "200":
+              description: OK
+      /oauth2/authorization-code:
+        get:
+          responses:
+            "200":
+              description: OK
+      /oauth2/implicit:
+        get:
+          responses:
+            "200":
+              description: OK
+      /oauth2/client-credentials:
+        get:
+          responses:
+            "200":
+              description: OK
+      /oauth2/password:
+        get:
+          responses:
+            "200":
+              description: OK
+      /all:
+        get:
+          responses:
+            "200":
+              description: OK
+  meta:
+    id: spc_5eb712667d224bad81878f64e08415ec
+    created: 1639600546876
+    modified: 1748348769663
+testSuites:
+  - name: Testing the tests
+    meta:
+      id: uts_1c62076507fe4d1da10a420ec8ed5c23
+      created: 1748258613202
+      modified: 1748352456417
+      sortKey: -1748258613202
+    tests:
+      - name: Passes using chai-json-schema
+        meta:
+          id: ut_d96b3abaa29a401aa6651b54246ed5a8
+          created: 1748258614657
+          modified: 1748352500897
+          sortKey: -1748258614657
+        requestId: req_01e2be4c819d44948d045c9a7ee5c02c
+        code: |-
+          var goodApple = {
+            skin: 'thin',
+            colors: ['red', 'green', 'yellow'],
+            taste: 10
+          };
+          var badApple = {
+            colors: ['brown'],
+            taste: 0,
+            worms: 2
+          };
+          var fruitSchema = {
+            title: 'fresh fruit schema v1',
+            type: 'object',
+            required: ['skin', 'colors', 'taste'],
+            properties: {
+              colors: {
+                type: 'array',
+                minItems: 1,
+                uniqueItems: true,
+                items: {
+                  type: 'string'
+                }
+              },
+              skin: {
+                type: 'string'
+              },
+              taste: {
+                type: 'number',
+                minimum: 5
+              }
+            }
+          };
+
+          //bdd style
+          expect(goodApple).to.be.jsonSchema(fruitSchema);
+          expect(badApple).to.not.be.jsonSchema(fruitSchema);
+      - name: Fails because it tries to require this module
+        meta:
+          id: ut_23b3800039454613aa58b5a6c410d25d
+          created: 1748352244627
+          modified: 1748352486644
+          sortKey: -1748352244627
+        requestId: req_01e2be4c819d44948d045c9a7ee5c02c
+        code: |-
+          const cp = require('child_process')
+          const response1 = await insomnia.send();
+          expect(response1.status).to.equal(200);

--- a/packages/insomnia-inso/src/examples/folder-inheritance-document.yml
+++ b/packages/insomnia-inso/src/examples/folder-inheritance-document.yml
@@ -106,9 +106,6 @@ resources:
     name: Returns 200
     code: |-
       const response1 = await insomnia.send();
-      const timelineString = await require('fs/promises').readFile(response1.timelinePath, 'utf8');
-      const timeline = timelineString.split('\n').filter(e => e?.trim()).map(e => JSON.parse(e).value).join(' ');
-      console.log(timeline);
 
       const body = JSON.parse(response1.data)
       console.log(body.headers)

--- a/packages/insomnia-testing/src/run/run.ts
+++ b/packages/insomnia-testing/src/run/run.ts
@@ -14,7 +14,7 @@ import { JavaScriptReporter } from './javascript-reporter';
 
 function prependInterceptedRequireToSource(source: string): string {
   const injectScript = `
-  const externalModules = new Map([['chai', global.chai], ['chai-json-schema', global.require('chai-json-schema')]]);
+  const externalModules = new Map([['chai', global.chai], ['chai-json-schema', global.chaiJSONSchema]]);
 
   const requireInterceptor = (moduleName) => {
     if (
@@ -74,6 +74,8 @@ const runInternal = async <TReturn, TNetworkResponse>(
     chai.use(require('chai-json-schema'));
     // @ts-expect-error -- global hack
     global.chai = chai;
+    // @ts-expect-error -- global hack
+    global.chaiJSONSchema = require('chai-json-schema');
 
     const mocha: Mocha = new Mocha({
       //       ms   * sec * min
@@ -98,6 +100,8 @@ const runInternal = async <TReturn, TNetworkResponse>(
         delete global.insomnia;
         // @ts-expect-error -- global hack
         delete global.chai;
+        // @ts-expect-error -- global hack
+        delete global.chaiJSONSchema;
 
         if (keepFile && mocha.files.length) {
           console.log(`Test files: ${JSON.stringify(mocha.files)}.`);

--- a/packages/insomnia-testing/src/run/run.ts
+++ b/packages/insomnia-testing/src/run/run.ts
@@ -14,7 +14,7 @@ import { JavaScriptReporter } from './javascript-reporter';
 
 function prependInterceptedRequireToSource(source: string): string {
   const injectScript = `
-  const externalModules = new Map([['chai', chai]]);
+  const externalModules = new Map([['chai', global.chai], ['chai-json-schema', global.require('chai-json-schema')]]);
 
   const requireInterceptor = (moduleName) => {
     if (
@@ -50,7 +50,6 @@ function prependInterceptedRequireToSource(source: string): string {
   };
 
   require = requireInterceptor;
-  global.require = requireInterceptor;
   `;
 
   // Ensure that the require is at the top of the file

--- a/packages/insomnia-testing/src/run/run.ts
+++ b/packages/insomnia-testing/src/run/run.ts
@@ -12,6 +12,51 @@ import type { InsomniaOptions } from './insomnia';
 import { Insomnia } from './insomnia';
 import { JavaScriptReporter } from './javascript-reporter';
 
+function prependInterceptedRequireToSource(source: string): string {
+  const injectScript = `
+  const externalModules = new Map([['chai', chai]]);
+
+  const requireInterceptor = (moduleName) => {
+    if (
+      [
+        // node.js modules
+        'path',
+        'assert',
+        'buffer',
+        'util',
+        'url',
+        'punycode',
+        'querystring',
+        'string_decoder',
+        'stream',
+        'timers',
+        'events',
+        // follows should be npm modules
+        // but they are moved to here to avoid introducing additional dependencies
+      ].includes(moduleName)
+    ) {
+      return require(moduleName);
+    } else if (['atob', 'btoa'].includes(moduleName)) {
+      return moduleName === 'atob' ? atob : btoa;
+    } else if (externalModules.has(moduleName)) {
+      const externalModule = externalModules.get(moduleName);
+      if (!externalModule) {
+        throw Error(\`no module is found for "$\{moduleName}"\`);
+      }
+      return externalModule;
+    }
+  
+    throw Error(\`no module is found for "$\{moduleName}"\`);
+  };
+
+  require = requireInterceptor;
+  global.require = requireInterceptor;
+  `;
+
+  // Ensure that the require is at the top of the file
+  return `${injectScript}\n${source}`;
+}
+
 // declare var insomnia: Insomnia;
 const runInternal = async <TReturn, TNetworkResponse>(
   testSrc: string | string[],
@@ -42,7 +87,7 @@ const runInternal = async <TReturn, TNetworkResponse>(
 
     const sources = Array.isArray(testSrc) ? testSrc : [testSrc];
     sources.forEach(source => {
-      mocha.addFile(writeTempFile(source));
+      mocha.addFile(writeTempFile(prependInterceptedRequireToSource(source)));
     });
 
     try {

--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -79,8 +79,6 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository }) => {
       ? gitRepoDataFetcher.data.legacyInsomniaWorkspace
       : null;
 
-  console.log({ isMigrationModalOpen, gitRepository, legacyInsomniaWorkspace });
-
   // Only fetch the repo status if we have a repo uri and we don't have the status already
   const shouldFetchGitRepoStatus = Boolean(
     gitRepository?.uri &&


### PR DESCRIPTION
Highlights:

- [x] Adds the same requireInterceptor we use in pre-request/after-response scripts to mocha tests
- [x] Adds an e2e test to verify that arbitarty require doesn't work in tests and that dependencies like chai-json-schema are loaded properly