### PR TITLE
test: Add smoke test check for templating tags

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/files/template-file.txt
+++ b/packages/insomnia-smoke-test/fixtures/files/template-file.txt
@@ -1,0 +1,1 @@
+File Tag Test

--- a/packages/insomnia-smoke-test/fixtures/template-tag-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/template-tag-collection.yaml
@@ -66,6 +66,7 @@ collection:
         {% base64 'encode', 'normal', 'insomnia-test' %}
         {% base64 'decode', 'normal', 'aW5zb21uaWEtdGVzdA==' %}
         {% faker 'guid' %}
+        {% file '__TEMPLATE_TAG_FILE_PATH' %}
         {% hash 'md5', 'hex', 'insomnia-test' %}
         {% os 'arch', '' %}
         {% jsonpath '{"foo":"bar"}', 'b64::JC5mb28=::46b' %}

--- a/packages/insomnia-smoke-test/fixtures/template-tag-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/template-tag-collection.yaml
@@ -1,0 +1,194 @@
+type: collection.insomnia.rest/5.0
+name: Template Tag Collection
+meta:
+  id: wrk_cd3c229026474b7fae20da41d66ba3ab
+  created: 1748314417144
+  modified: 1748314417144
+collection:
+  - name: FolderWithRequest
+    meta:
+      id: fld_6e809c3828564b0c834039df29a22531
+      created: 1748315205407
+      modified: 1748315205407
+      sortKey: -1748315205407
+    children:
+      - url: http://127.0.0.1:4010/echo
+        name: Request Tag
+        meta:
+          id: req_205aa10dc11c4914bd73d8194c8d1e81
+          created: 1748315231656
+          modified: 1748327301424
+          isPrivate: false
+          sortKey: -1748315231656
+        method: GET
+        body:
+          mimeType: text/plain
+          text: |+
+            {% request 'name', '', '' %}
+            {% request 'folder', '', '' %}
+            {% request 'url', '', '' %}
+            {% request 'parameter', 'foo', '' %}
+            {% request 'cookie', 'from', '' %}
+
+        parameters:
+          - id: pair_10b0769f64bd47e5953e446085d801b1
+            name: foo
+            value: bar
+            disabled: false
+        headers:
+          - name: Content-Type
+            value: text/plain
+          - name: User-Agent
+            value: insomnia/11.1.0
+        authentication:
+          type: oauth2
+          grantType: authorization_code
+        settings:
+          renderRequestBody: true
+          encodeUrl: true
+          followRedirects: global
+          cookies:
+            send: true
+            store: true
+          rebuildPath: true
+  - url: http://127.0.0.1:4010/echo
+    name: Common Tag
+    meta:
+      id: req_901db4952ceb478cbf3e8a067ebe69a7
+      created: 1748327288726
+      modified: 1748329418160
+      isPrivate: false
+      sortKey: -1748327288726
+    method: GET
+    body:
+      mimeType: text/plain
+      text: |
+        {% base64 'encode', 'normal', 'insomnia-test' %}
+        {% base64 'decode', 'normal', 'aW5zb21uaWEtdGVzdA==' %}
+        {% faker 'guid' %}
+        {% hash 'md5', 'hex', 'insomnia-test' %}
+        {% os 'arch', '' %}
+        {% jsonpath '{"foo":"bar"}', 'b64::JC5mb28=::46b' %}
+        {% now 'millis', '' %}
+        {% uuid 'v4' %}
+        {% cookie 'http://127.0.0.1/echo', 'from' %}
+    headers:
+      - name: Content-Type
+        value: text/plain
+      - name: User-Agent
+        value: insomnia/11.1.0
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: http://127.0.0.1:4010/echo
+    name: Response Tag
+    meta:
+      id: req_71794e4f43f5498e8b7e87d98be8d21b
+      created: 1748331291452
+      modified: 1748331512535
+      isPrivate: false
+      sortKey: -1748331291452
+    method: GET
+    body:
+      mimeType: text/plain
+      text: >-
+        {% response 'body', 'req_60295920e8a9459fb32cacb739a261f5',
+        'b64::JC5tZXRob2Q=::46b', 'never', 60 %}
+
+        {% response 'header', 'req_60295920e8a9459fb32cacb739a261f5',
+        'b64::Y29udGVudC10eXBl::46b', 'never', 60 %}
+
+        {% response 'url', 'req_60295920e8a9459fb32cacb739a261f5', '', 'never',
+        60 %}
+    headers:
+      - name: Content-Type
+        value: text/plain
+      - name: User-Agent
+        value: insomnia/11.1.0
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: http://127.0.0.1:4010/echo
+    name: Prompt Tag
+    meta:
+      id: req_05ce27906a824071ad138cb6d99248d0
+      created: 1748335221312
+      modified: 1748336216272
+      isPrivate: false
+      sortKey: -1748335221312
+    method: GET
+    body:
+      mimeType: text/plain
+      text: "{% prompt 'prompt test', '', 'test', 'insomnia-test', false, true %}"
+    headers:
+      - name: Content-Type
+        value: text/plain
+      - name: User-Agent
+        value: insomnia/11.1.0
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: http://127.0.0.1:4010/echo
+    name: Base Response
+    meta:
+      id: req_60295920e8a9459fb32cacb739a261f5
+      created: 1748331328603
+      modified: 1748331472232
+      isPrivate: false
+      sortKey: -1748331328603
+    method: GET
+    body:
+      mimeType: application/x-www-form-urlencoded
+      params:
+        - id: pair_a1beae72f2964d85b87bc35f1b9fd401
+          name: foo
+          value: bar
+          disabled: false
+    headers:
+      - name: User-Agent
+        value: insomnia/11.1.0
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true      
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_f7254814b5365cfdd815f6ed8523b2a92d0f19e1
+    created: 1748314417147
+    modified: 1748314417147
+  cookies:
+    - id: 179e1b5e-1fd4-49b6-b506-62d469c4cd93
+      key: from
+      value: cookie
+      domain: 127.0.0.1
+      path: /echo
+      expires: 2038-12-31T12:00:00.000Z
+      secure: false
+      httpOnly: false
+environments:
+  name: Base Environment
+  meta:
+    id: env_f7254814b5365cfdd815f6ed8523b2a92d0f19e1
+    created: 1748314417145
+    modified: 1748314417145
+    isPrivate: false

--- a/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
@@ -1,0 +1,140 @@
+import os from 'node:os';
+
+import { expect } from '@playwright/test';
+
+import { loadFixture, getFixturePath } from '../../playwright/paths';
+import { test } from '../../playwright/test';
+
+interface TemplateTagTestCase {
+  tagPrefix: string;
+  expectedResult: string | ((result: string) => boolean);
+}
+const templateTagTestCases: Record<string, TemplateTagTestCase[]> = {
+  base64: [{ tagPrefix: "{% base64 'encode', 'normal', 'insomnia-test' %}", expectedResult: 'aW5zb21uaWEtdGVzdA==' }],
+  cookie: [{ tagPrefix: "{% cookie 'http://127.0.0.1/echo', 'from' %}", expectedResult: 'cookie' }],
+  faker: [{ tagPrefix: "{% faker 'guid' %}", expectedResult: result => result.length === 36 }],
+  hash: [{ tagPrefix: "{% hash 'md5', 'hex', 'insomnia-test' %}", expectedResult: 'b9c076eabf32fa4cdd7573a6df12d33c' }],
+  jsonPath: [{ tagPrefix: '{% jsonpath', expectedResult: 'bar' }],
+  os: [{ tagPrefix: "{% os 'arch', '' %}", expectedResult: os.arch() }],
+  timeStamp: [
+    { tagPrefix: "{% now 'millis', '' %}", expectedResult: result => !isNaN(Number(result)) && result.length === 13 },
+  ],
+  uuid: [{ tagPrefix: "{% uuid 'v4' %}", expectedResult: result => result.length === 36 }],
+  request: [
+    { tagPrefix: "{% request 'name'", expectedResult: 'Request Tag' },
+    { tagPrefix: "{% request 'folder', '', '' %}", expectedResult: 'FolderWithRequest' },
+    { tagPrefix: "{% request 'url'", expectedResult: 'http://127.0.0.1:4010/echo?foo=bar' },
+    { tagPrefix: "{% request 'parameter'", expectedResult: 'bar' },
+    { tagPrefix: "{% request 'cookie'", expectedResult: 'cookie' },
+  ],
+  response: [
+    {
+      tagPrefix: "{% response 'body'",
+      expectedResult: 'GET',
+    },
+    {
+      tagPrefix: "{% response 'header'",
+      expectedResult: 'application/json; charset=utf-8',
+    },
+    {
+      tagPrefix: "{% response 'url'",
+      expectedResult: 'http://127.0.0.1:4010/echo',
+    },
+  ],
+  prompt: [
+    {
+      tagPrefix: "{% prompt 'prompt test', '', 'test', 'insomnia-test', false, true %}",
+      expectedResult: 'insomnia-test',
+    },
+  ],
+};
+
+test('Critical Path For Template Tags Interactions', async ({ page, app }) => {
+  // import request collection
+  const text = await loadFixture('template-tag-collection.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+
+  await page.getByLabel('Import').click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  await page.getByLabel('Template Tag Collection').click();
+
+  // test common template tags
+  await page.getByLabel('Request Collection').getByTestId('Common Tag').press('Enter');
+  await page.getByText('Body', { exact: true }).click();
+  let commonTagTestCases: TemplateTagTestCase[] = [];
+  Object.keys(templateTagTestCases)
+    .filter(key => key !== 'request' && key !== 'response' && key !== 'prompt')
+    .forEach(tagName => (commonTagTestCases = commonTagTestCases.concat(templateTagTestCases[tagName])));
+  const testCases = commonTagTestCases;
+  for (const { tagPrefix, expectedResult } of testCases) {
+    await page.locator(`[data-template^="${tagPrefix}"]`).click();
+    const modal = page.getByRole('dialog');
+    const previewResult = modal.getByLabel('Live Preview');
+    // wait for render complete
+    await expect.soft(previewResult).not.toHaveText('rendering...');
+    const previewText = await previewResult.textContent();
+    expect
+      .soft(
+        typeof expectedResult === 'function'
+          ? expectedResult(previewText || '')
+          : previewText?.includes(expectedResult),
+      )
+      .toBeTruthy();
+    // close modal
+    await modal.getByRole('button', { name: 'Done' }).click();
+  }
+
+  // test request template tags
+  await page.getByLabel('Request Collection').getByTestId('Request Tag').press('Enter');
+  await page.getByText('Body', { exact: true }).click();
+  for (const { tagPrefix, expectedResult } of templateTagTestCases.request) {
+    await page.locator(`[data-template^="${tagPrefix}"]`).click();
+    const modal = page.getByRole('dialog');
+    const previewResult = modal.getByLabel('Live Preview');
+    // wait for render complete
+    await expect.soft(previewResult).not.toHaveText('rendering...');
+    await expect.soft(previewResult).toHaveText(typeof expectedResult === 'string' ? expectedResult : '');
+    // close modal
+    await modal.getByRole('button', { name: 'Done' }).click();
+  }
+
+  // test response template tags
+  // send request first to populate response
+  await page.getByLabel('Request Collection').getByTestId('Base Response').press('Enter');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await page.getByLabel('Request Collection').getByTestId('Response Tag').press('Enter');
+  await page.getByText('Body', { exact: true }).click();
+  for (const { tagPrefix, expectedResult } of templateTagTestCases.response) {
+    await page.locator(`[data-template^="${tagPrefix}"]`).click();
+    const modal = page.getByRole('dialog');
+    const previewResult = modal.getByLabel('Live Preview');
+    // wait for render complete
+    await expect.soft(previewResult).not.toHaveText('rendering...');
+    await expect.soft(previewResult).toHaveText(typeof expectedResult === 'string' ? expectedResult : '');
+    // close modal
+    await modal.getByRole('button', { name: 'Done' }).click();
+  }
+
+  // test prompt template tags
+  await page.getByLabel('Request Collection').getByTestId('Prompt Tag').press('Enter');
+  await page.getByText('Body', { exact: true }).click();
+  const { tagPrefix } = templateTagTestCases.prompt[0];
+  await page.locator(`[data-template^="${tagPrefix}"]`).isVisible();
+  await page.getByRole('button', { name: 'Send' }).click();
+  // prompt is not allowed to use by default
+  await expect.soft(page.getByText('Unexpected Request Failure')).toBeVisible();
+  await page.getByRole('dialog').getByRole('button', { name: 'OK' }).click();
+  // elevate access for plugins
+  await page.getByTestId('settings-button').click();
+  await page.getByRole('tab', { name: 'Plugins' }).click();
+  await page.locator('text=Allow elevated access for plugins').click();
+  await page.locator('.app').press('Escape');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await page.getByRole('dialog').locator('#prompt-input').fill('prompt-value');
+  await page.getByRole('dialog').getByRole('button', { name: 'Submit' }).click();
+  await page.click('text=Console');
+  const responsePane = page.getByTestId('response-pane');
+  await expect.soft(responsePane).toContainText('prompt-value');
+});

--- a/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
@@ -13,6 +13,12 @@ const templateTagTestCases: Record<string, TemplateTagTestCase[]> = {
   base64: [{ tagPrefix: "{% base64 'encode', 'normal', 'insomnia-test' %}", expectedResult: 'aW5zb21uaWEtdGVzdA==' }],
   cookie: [{ tagPrefix: "{% cookie 'http://127.0.0.1/echo', 'from' %}", expectedResult: 'cookie' }],
   faker: [{ tagPrefix: "{% faker 'guid' %}", expectedResult: result => result.length === 36 }],
+  file: [
+    {
+      tagPrefix: `{% file '${getFixturePath('files/template-file.txt')}' %}`,
+      expectedResult: 'File Tag Test',
+    },
+  ],
   hash: [{ tagPrefix: "{% hash 'md5', 'hex', 'insomnia-test' %}", expectedResult: 'b9c076eabf32fa4cdd7573a6df12d33c' }],
   jsonPath: [{ tagPrefix: '{% jsonpath', expectedResult: 'bar' }],
   os: [{ tagPrefix: "{% os 'arch', '' %}", expectedResult: os.arch() }],
@@ -50,8 +56,11 @@ const templateTagTestCases: Record<string, TemplateTagTestCase[]> = {
 };
 
 test('Critical Path For Template Tags Interactions', async ({ page, app }) => {
-  // import request collection
-  const text = await loadFixture('template-tag-collection.yaml');
+  // import request collection and replace the template tag file path with the actual fixture file path
+  const text = (await loadFixture('template-tag-collection.yaml')).replace(
+    '__TEMPLATE_TAG_FILE_PATH',
+    getFixturePath('files/template-file.txt'),
+  );
   await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
 
   await page.getByLabel('Import').click();

--- a/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
@@ -103,10 +103,13 @@ test('Critical Path For Template Tags Interactions', async ({ page, app }) => {
   // test response template tags
   // send request first to populate response
   await page.getByLabel('Request Collection').getByTestId('Base Response').press('Enter');
+  // Wait for tab appear
+  await expect.soft(page.getByLabel('Insomnia Tabs').getByText('Base Response', { exact: true })).toBeVisible();
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
   await expect.soft(statusTag).toContainText('200 OK');
   await page.getByLabel('Request Collection').getByTestId('Response Tag').press('Enter');
+  await expect.soft(page.getByLabel('Insomnia Tabs').getByText('Response Tag', { exact: true })).toBeVisible();
   await page.getByText('Body', { exact: true }).click();
   for (const { tagPrefix, expectedResult } of templateTagTestCases.response) {
     await page.locator(`[data-template^="${tagPrefix}"]`).click();

--- a/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
@@ -103,7 +103,9 @@ test('Critical Path For Template Tags Interactions', async ({ page, app }) => {
   // test response template tags
   // send request first to populate response
   await page.getByLabel('Request Collection').getByTestId('Base Response').press('Enter');
-  await page.getByRole('button', { name: 'Send' }).click();
+  await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+  const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
+  await expect.soft(statusTag).toContainText('200 OK');
   await page.getByLabel('Request Collection').getByTestId('Response Tag').press('Enter');
   await page.getByText('Body', { exact: true }).click();
   for (const { tagPrefix, expectedResult } of templateTagTestCases.response) {
@@ -122,7 +124,7 @@ test('Critical Path For Template Tags Interactions', async ({ page, app }) => {
   await page.getByText('Body', { exact: true }).click();
   const { tagPrefix } = templateTagTestCases.prompt[0];
   await page.locator(`[data-template^="${tagPrefix}"]`).isVisible();
-  await page.getByRole('button', { name: 'Send' }).click();
+  await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   // prompt is not allowed to use by default
   await expect.soft(page.getByText('Unexpected Request Failure')).toBeVisible();
   await page.getByRole('dialog').getByRole('button', { name: 'OK' }).click();
@@ -131,7 +133,7 @@ test('Critical Path For Template Tags Interactions', async ({ page, app }) => {
   await page.getByRole('tab', { name: 'Plugins' }).click();
   await page.locator('text=Allow elevated access for plugins').click();
   await page.locator('.app').press('Escape');
-  await page.getByRole('button', { name: 'Send' }).click();
+  await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await page.getByRole('dialog').locator('#prompt-input').fill('prompt-value');
   await page.getByRole('dialog').getByRole('button', { name: 'Submit' }).click();
   await page.click('text=Console');

--- a/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
@@ -2,7 +2,7 @@ import os from 'node:os';
 
 import { expect } from '@playwright/test';
 
-import { loadFixture, getFixturePath } from '../../playwright/paths';
+import { getFixturePath, loadFixture } from '../../playwright/paths';
 import { test } from '../../playwright/test';
 
 interface TemplateTagTestCase {


### PR DESCRIPTION
**Changes**
Add smoke test of templating tags critical path
- [x] base64
- [x] cookie
- [x] faker
- [x] hash
- [x] jsonpath
- [x] os
- [x] timeStamp
- [x] uuid
- [x] request
- [x] response
- [x] prompt (both elevated access and non-elevated access)
- [x] file

