### PR TITLE
fix: Insomnia application showing incorrect warnings about Git Projects when Storage Controls set for Git Storage only [INS-5602]]

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/project-dropdown.tsx
@@ -31,7 +31,8 @@ export const ProjectDropdown: FC<Props> = ({ project, organizationId, storageRul
   const updateProjectFetcher = useFetcher();
 
   const isRemoteProjectInconsistent = isRemoteProject(project) && !storageRules.enableCloudSync;
-  const isLocalProjectInconsistent = !isRemoteProject(project) && !storageRules.enableLocalVault;
+  const isLocalProjectInconsistent =
+    !isRemoteProject(project) && !isGitProject(project) && !storageRules.enableLocalVault;
   const isGitProjectInconsistent = isGitProject(project) && !storageRules.enableGitSync;
   const isProjectInconsistent = isRemoteProjectInconsistent || isLocalProjectInconsistent || isGitProjectInconsistent;
 

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -191,7 +191,7 @@ export const ProjectSettingsForm: FC<Props> = ({
   };
 
   return (
-    <div className="flex max-w-[600px] flex-col gap-4">
+    <div className="flex w-full max-w-[600px] flex-col gap-4">
       {error && (
         <div className="flex items-center gap-2 rounded-sm bg-[rgba(var(--color-danger-rgb),0.5)] px-2 py-1 text-sm text-[--color-font-danger]">
           <Icon icon="triangle-exclamation" />
@@ -509,7 +509,7 @@ export const ProjectSettingsForm: FC<Props> = ({
                 </>
               ) : (
                 <>
-                  <Icon icon="git-alt" className="" />
+                  <Icon icon={['fab', 'git-alt']} />
                   <span>{insomniaFiles.length > 0 ? 'Import all' : 'Clone'}</span>
                 </>
               )}

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -831,6 +831,8 @@ const ProjectRoute: FC = () => {
 
   const isGitSyncEnabled = features.gitSync.enabled;
 
+  console.log({ isGitSyncEnabled, activeProject, storageRules });
+
   const createInProjectActionList: {
     id: string;
     name: string;
@@ -921,7 +923,8 @@ const ProjectRoute: FC = () => {
   ];
 
   const isRemoteProjectInconsistent = activeProject && isRemoteProject(activeProject) && !storageRules.enableCloudSync;
-  const isLocalProjectInconsistent = activeProject && !isRemoteProject(activeProject) && !storageRules.enableLocalVault;
+  const isLocalProjectInconsistent =
+    activeProject && !isRemoteProject(activeProject) && !isGitProject(activeProject) && !storageRules.enableLocalVault;
   const isGitSyncProjectInconsistent = activeProject && isGitProject(activeProject) && !storageRules.enableGitSync;
   const isProjectInconsistent =
     isRemoteProjectInconsistent || isLocalProjectInconsistent || isGitSyncProjectInconsistent;

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -831,8 +831,6 @@ const ProjectRoute: FC = () => {
 
   const isGitSyncEnabled = features.gitSync.enabled;
 
-  console.log({ isGitSyncEnabled, activeProject, storageRules });
-
   const createInProjectActionList: {
     id: string;
     name: string;


### PR DESCRIPTION
<img width="2000" alt="image" src="https://github.com/user-attachments/assets/ed525734-6491-4489-9b94-0e483acd6740" />

Closes INS-5602