### PR TITLE
fix(script): Insomnia.global.set is not updating environment when only global base environment is activated[INS-5795]

### DIFF
--- a/packages/insomnia-scripting-environment/src/objects/insomnia.ts
+++ b/packages/insomnia-scripting-environment/src/objects/insomnia.ts
@@ -147,8 +147,11 @@ export async function initInsomniaObject(rawObj: RequestContext, log: (...args: 
   // Mapping rule for the global environment:
   // - If global base environment is selected, both `baseGlobals` and `globals` point to the selected one.
   // - If one global sub environment is selected,  `baseGlobals` points to the base env of the selected one and `globals` points to the selected one.
-  const baseGlobals = new Environment('baseGlobals', rawObj.baseGlobals || {});
-  const globals = new Environment('globals', rawObj.globals || {}); // could be undefined
+  const baseGlobals = new Environment('baseGlobals', rawObj.baseGlobals?.data || {});
+  const globals =
+    rawObj.globals?.id === rawObj.baseGlobals?.id
+      ? baseGlobals
+      : new Environment('globals', rawObj.globals?.data || {});
   // Mapping rule for the environment and base environment:
   // - If base environment is selected, both `baseEnvironment` and `environment` point to the selected one.
   // - If one sub environment is selected,  `baseEnvironment` points to the base env and `environment` points to the selected one.

--- a/packages/insomnia-scripting-environment/src/objects/insomnia.ts
+++ b/packages/insomnia-scripting-environment/src/objects/insomnia.ts
@@ -147,11 +147,11 @@ export async function initInsomniaObject(rawObj: RequestContext, log: (...args: 
   // Mapping rule for the global environment:
   // - If global base environment is selected, both `baseGlobals` and `globals` point to the selected one.
   // - If one global sub environment is selected,  `baseGlobals` points to the base env of the selected one and `globals` points to the selected one.
-  const baseGlobals = new Environment('baseGlobals', rawObj.baseGlobals?.data || {});
+  const baseGlobals = new Environment(rawObj.baseGlobals?.name || 'baseGlobals', rawObj.baseGlobals?.data || {});
   const globals =
     rawObj.globals?.id === rawObj.baseGlobals?.id
       ? baseGlobals
-      : new Environment('globals', rawObj.globals?.data || {});
+      : new Environment(rawObj.globals?.name || 'globals', rawObj.globals?.data || {});
   // Mapping rule for the environment and base environment:
   // - If base environment is selected, both `baseEnvironment` and `environment` point to the selected one.
   // - If one sub environment is selected,  `baseEnvironment` points to the base env and `environment` points to the selected one.

--- a/packages/insomnia-scripting-environment/src/objects/interfaces.ts
+++ b/packages/insomnia-scripting-environment/src/objects/interfaces.ts
@@ -24,8 +24,8 @@ export interface RequestContext {
   vault?: IEnvironment;
   collectionVariables?: object;
   // globals are optional because they are activated only when selected
-  globals?: object;
-  baseGlobals?: object;
+  globals?: IEnvironment;
+  baseGlobals?: IEnvironment;
   iterationData?: Omit<IEnvironment, 'id'>;
   timeout: number;
   settings: Settings;

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -532,6 +532,7 @@ test.describe('pre-request features tests', () => {
     expect.soft(globalBaseBodyJson).toEqual({
       // if select global base environment, both globals and baseGlobals set method will point to global base environment
       __env_source: 'base',
+      __fromGlobals: 'selectedGlobal',
       __fromBaseGlobals: 'selectedBaseGlobal',
     });
 
@@ -551,22 +552,13 @@ test.describe('pre-request features tests', () => {
     await page.getByLabel('Manage Environments').click();
     await page.getByLabel('Manage global environment').click();
     await page.getByLabel('Environment name').getByText('Sub Script Env').first().click();
-    let globalSubEditor = page.getByTestId('CodeEditor').locator('.CodeMirror-line');
-    let globalSubRows = await globalSubEditor.allInnerTexts();
-    let globalSubBodyJson = JSON.parse(globalSubRows.join(' '));
+    const globalSubEditor = page.getByTestId('CodeEditor').locator('.CodeMirror-line');
+    const globalSubRows = await globalSubEditor.allInnerTexts();
+    const globalSubBodyJson = JSON.parse(globalSubRows.join(' '));
     expect.soft(globalSubBodyJson).toEqual({
       // if select global sub environment, globals will point to the selected sub environment
       __env_source: 'sub',
       __fromGlobals: 'selectedGlobal',
-    });
-    await page.getByLabel('Environment name').getByText('Base Script Env').click();
-    globalSubEditor = page.getByTestId('CodeEditor').locator('.CodeMirror-line');
-    globalSubRows = await globalSubEditor.allInnerTexts();
-    globalSubBodyJson = JSON.parse(globalSubRows.join(' '));
-    expect.soft(globalSubBodyJson).toEqual({
-      // if select global sub environment, baseGlobals will point to the base environment of the selected one
-      __env_source: 'base',
-      __fromBaseGlobals: 'selectedBaseGlobal',
     });
   });
 

--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -170,10 +170,14 @@ export async function buildRenderContext({
     finalRenderContext = await renderSubContext(envObject, finalRenderContext);
   }
 
-  finalRenderContext[vaultEnvironmentPath] = await maskOrDecryptVaultDataIfNecessary(
+  const vaultEnvironmentData = await maskOrDecryptVaultDataIfNecessary(
     finalRenderContext[vaultEnvironmentPath],
     renderContext?.getPurpose(),
   );
+  if (vaultEnvironmentData) {
+    // avoid add undefined data to render context
+    finalRenderContext[vaultEnvironmentPath] = vaultEnvironmentData;
+  }
   // Merge all vault environments under vaultEnvironmentPath to vaultEnvironmentRuntimePath which is more human readable.
   // This will also keep all legacy environment variables defined under the vaultEnvironmentRuntimePath.
   if (finalRenderContext[vaultEnvironmentPath]) {

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -130,20 +130,16 @@ const runScript = async ({ script, context }: { script: string; context: Request
     settings: updatedSettings,
     clientCertificates: updatedCertificates,
     cookieJar: updatedCookieJar,
-    globals: context.globals
-      ? {
-          id: context.globals.id,
-          name: context.globals.name,
-          data: mutatedContextObject.globals,
-        }
-      : undefined,
-    baseGlobals: context.baseGlobals
-      ? {
-          id: context.baseGlobals.id,
-          name: context.baseGlobals.name,
-          data: mutatedContextObject.baseGlobals,
-        }
-      : undefined,
+    globals: context.globals && {
+      id: context.globals.id,
+      name: context.globals.name,
+      data: mutatedContextObject.globals,
+    },
+    baseGlobals: context.baseGlobals && {
+      id: context.baseGlobals.id,
+      name: context.baseGlobals.name,
+      data: mutatedContextObject.baseGlobals,
+    },
     requestTestResults: mutatedContextObject.requestTestResults,
     logs: scriptConsole.dumpLogsAsArray(),
     parentFolders: mutatedContextObject.parentFolders,

--- a/packages/insomnia/src/hidden-window.ts
+++ b/packages/insomnia/src/hidden-window.ts
@@ -130,8 +130,20 @@ const runScript = async ({ script, context }: { script: string; context: Request
     settings: updatedSettings,
     clientCertificates: updatedCertificates,
     cookieJar: updatedCookieJar,
-    globals: mutatedContextObject.globals,
-    baseGlobals: mutatedContextObject.baseGlobals,
+    globals: context.globals
+      ? {
+          id: context.globals.id,
+          name: context.globals.name,
+          data: mutatedContextObject.globals,
+        }
+      : undefined,
+    baseGlobals: context.baseGlobals
+      ? {
+          id: context.baseGlobals.id,
+          name: context.baseGlobals.name,
+          data: mutatedContextObject.baseGlobals,
+        }
+      : undefined,
     requestTestResults: mutatedContextObject.requestTestResults,
     logs: scriptConsole.dumpLogsAsArray(),
     parentFolders: mutatedContextObject.parentFolders,

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -508,20 +508,16 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
         },
         response,
         vault,
-        globals: globals
-          ? {
-              id: globals._id,
-              name: globals.name,
-              data: globals.data || {},
-            }
-          : undefined,
-        baseGlobals: baseGlobals
-          ? {
-              id: baseGlobals._id,
-              name: baseGlobals.name,
-              data: baseGlobals.data || {},
-            }
-          : undefined,
+        globals: globals && {
+          id: globals._id,
+          name: globals.name,
+          data: globals.data || {},
+        },
+        baseGlobals: baseGlobals && {
+          id: baseGlobals._id,
+          name: baseGlobals.name,
+          data: baseGlobals.data || {},
+        },
         iterationData: userUploadEnvironment
           ? {
               name: userUploadEnvironment.name,

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -419,7 +419,7 @@ export async function savePatchesMadeByScript(patches: {
   }
 
   if (activeGlobalBaseEnvironment) {
-    invariant(mutatedContext.baseGlobals, 'global base env must be defined when there is selected one');
+    invariant(mutatedContext.baseGlobals, 'baseGlobals must be defined when there is active global base environment');
     await updateEnvironment(activeGlobalBaseEnvironment, mutatedContext.baseGlobals);
   }
 
@@ -508,8 +508,20 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
         },
         response,
         vault,
-        globals: globals?.data || undefined,
-        baseGlobals: baseGlobals?.data || undefined,
+        globals: globals
+          ? {
+              id: globals._id,
+              name: globals.name,
+              data: globals.data || {},
+            }
+          : undefined,
+        baseGlobals: baseGlobals
+          ? {
+              id: baseGlobals._id,
+              name: baseGlobals.name,
+              data: baseGlobals.data || {},
+            }
+          : undefined,
         iterationData: userUploadEnvironment
           ? {
               name: userUploadEnvironment.name,
@@ -547,21 +559,21 @@ export const tryToExecuteScript = async (context: RequestAndContextAndOptionalRe
 
     if (globals) {
       const globalEnvPropertyOrder = orderedJSON.parse(
-        JSON.stringify(output.globals || {}),
+        JSON.stringify(output.globals?.data || {}),
         JSON_ORDER_PREFIX,
         JSON_ORDER_SEPARATOR,
       );
-      globals.data = output.globals || {};
+      globals.data = output.globals?.data || {};
       globals.dataPropertyOrder = globalEnvPropertyOrder.map;
     }
 
     if (baseGlobals) {
       const globalBaseEnvPropertyOrder = orderedJSON.parse(
-        JSON.stringify(output.baseGlobals || {}),
+        JSON.stringify(output.baseGlobals?.data || {}),
         JSON_ORDER_PREFIX,
         JSON_ORDER_SEPARATOR,
       );
-      baseGlobals.data = output.baseGlobals || {};
+      baseGlobals.data = output.baseGlobals?.data || {};
       baseGlobals.dataPropertyOrder = globalBaseEnvPropertyOrder.map;
     }
 

--- a/packages/insomnia/src/scriptExecutor.ts
+++ b/packages/insomnia/src/scriptExecutor.ts
@@ -95,20 +95,16 @@ export const runScript = async ({
     settings: updatedSettings,
     clientCertificates: updatedCertificates,
     cookieJar: updatedCookieJar,
-    globals: context.globals
-      ? {
-          id: context.environment.id,
-          name: context.environment.name,
-          data: mutatedContextObject.globals,
-        }
-      : undefined,
-    baseGlobals: context.baseGlobals
-      ? {
-          id: context.baseEnvironment.id,
-          name: context.baseEnvironment.name,
-          data: mutatedContextObject.baseGlobals,
-        }
-      : undefined,
+    globals: context.globals && {
+      id: context.environment.id,
+      name: context.environment.name,
+      data: mutatedContextObject.globals,
+    },
+    baseGlobals: context.baseGlobals && {
+      id: context.baseEnvironment.id,
+      name: context.baseEnvironment.name,
+      data: mutatedContextObject.baseGlobals,
+    },
     requestTestResults: mutatedContextObject.requestTestResults,
     execution: mutatedContextObject.execution,
     parentFolders: mutatedContextObject.parentFolders,

--- a/packages/insomnia/src/scriptExecutor.ts
+++ b/packages/insomnia/src/scriptExecutor.ts
@@ -95,7 +95,20 @@ export const runScript = async ({
     settings: updatedSettings,
     clientCertificates: updatedCertificates,
     cookieJar: updatedCookieJar,
-    globals: mutatedContextObject.globals,
+    globals: context.globals
+      ? {
+          id: context.environment.id,
+          name: context.environment.name,
+          data: mutatedContextObject.globals,
+        }
+      : undefined,
+    baseGlobals: context.baseGlobals
+      ? {
+          id: context.baseEnvironment.id,
+          name: context.baseEnvironment.name,
+          data: mutatedContextObject.baseGlobals,
+        }
+      : undefined,
     requestTestResults: mutatedContextObject.requestTestResults,
     execution: mutatedContextObject.execution,
     parentFolders: mutatedContextObject.parentFolders,


### PR DESCRIPTION
**Highlights:**
Fix the issue that Insomnia.global.set is not updating environment when global base environment is activated.
Modify Insomnia script to make globals and baseGlobals point to the same environment object when global base environment is activated.

Closes https://github.com/Kong/insomnia/issues/8789