### PR TITLE
optimize(Git): move long-running git operations to a separate process to prevent blocking main thread

### DIFF
--- a/packages/insomnia/esbuild.main.ts
+++ b/packages/insomnia/esbuild.main.ts
@@ -71,7 +71,24 @@ export default async function build(options: Options) {
     ],
   });
 
-  return Promise.all([main, preload, hiddenBrowserWindowPreload]);
+  const gitWorker = esbuild.build({
+    entryPoints: ['./src/git-worker.ts'],
+    outfile: path.join(outdir, 'git-worker.js'),
+    target: 'esnext',
+    bundle: true,
+    platform: 'node',
+    sourcemap: true,
+    format: 'cjs',
+    external: [
+      'electron',
+      '@getinsomnia/node-libcurl',
+      'fsevents',
+      ...Object.keys(pkg.dependencies),
+      ...Object.keys(builtinModules),
+    ],
+  });
+
+  return Promise.all([main, preload, hiddenBrowserWindowPreload, gitWorker]);
 }
 
 // Build if ran as a cli script

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -336,7 +336,7 @@ export const database = {
     }
 
     delete db._empty;
-    electron.ipcMain.on('db.fn', async (e, fnName, replyChannel, ...args) => {
+    electron.ipcMain?.on('db.fn', async (e, fnName, replyChannel, ...args) => {
       try {
         // @ts-expect-error -- mapping unsoundness
         const result = await database[fnName](...args);

--- a/packages/insomnia/src/git-worker.ts
+++ b/packages/insomnia/src/git-worker.ts
@@ -1,29 +1,36 @@
 import { database } from './common/database';
-import { type GitServiceAPI, gitServiceAPI, type WorkerCommandList } from './main/git-service';
+import { gitServiceAPI } from './main/git-service';
 import { type ErrorMessage, readyMessage, type ResultMessage } from './main/git-service-register';
+import { type GitWorkerServiceAPI, gitWorkerServiceAPI, type GitWorkerServiceAPIKeys } from './main/git-worker-service';
 import * as models from './models';
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 process.parentPort.once('message', async message => {
   const [port] = message.ports;
 
   port.on('message', async message => {
     const data = message.data as {
-      type: WorkerCommandList;
+      type: GitWorkerServiceAPIKeys;
       payload: {
-        args: Parameters<GitServiceAPI[WorkerCommandList]>[0];
+        args: Parameters<GitWorkerServiceAPI[GitWorkerServiceAPIKeys]>[0];
       };
     };
+
+    await sleep(10000); // Allow time for the port to be ready
 
     try {
       const args = data.payload.args;
       await database.init(models.types());
       await gitServiceAPI.loadGitRepository(args);
 
-      // gitServiceAPI is a constant, so we can safely cast it to a Record type to avoid TypeScript errors
+      // gitWorkerServiceAPI is a constant, so we can safely cast it to a Record type to avoid TypeScript errors
       const result = await (
-        gitServiceAPI as Record<
-          WorkerCommandList,
-          (...args: Parameters<GitServiceAPI[WorkerCommandList]>) => ReturnType<GitServiceAPI[WorkerCommandList]>
+        gitWorkerServiceAPI as Record<
+          GitWorkerServiceAPIKeys,
+          (
+            ...args: Parameters<GitWorkerServiceAPI[GitWorkerServiceAPIKeys]>
+          ) => ReturnType<GitWorkerServiceAPI[GitWorkerServiceAPIKeys]>
         >
       )[data.type](args);
 
@@ -31,15 +38,13 @@ process.parentPort.once('message', async message => {
         type: data.type,
         result,
       } as ResultMessage);
-
-      console.log('[debug] Git operation handled successfully');
     } catch (error) {
       port.postMessage({
         type: 'error',
         error: error instanceof Error ? error.message : 'Unknown error',
       } as ErrorMessage);
 
-      console.error('[debug] Error handling git operation:', error);
+      console.error('[debug] Error handling git operation:', data.type, error);
     }
   });
 

--- a/packages/insomnia/src/git-worker.ts
+++ b/packages/insomnia/src/git-worker.ts
@@ -1,0 +1,48 @@
+import { database } from './common/database';
+import { type GitServiceAPI, gitServiceAPI, type WorkerCommandList } from './main/git-service';
+import { type ErrorMessage, readyMessage, type ResultMessage } from './main/git-service-register';
+import * as models from './models';
+
+process.parentPort.once('message', async message => {
+  const [port] = message.ports;
+
+  port.on('message', async message => {
+    const data = message.data as {
+      type: WorkerCommandList;
+      payload: {
+        args: Parameters<GitServiceAPI[WorkerCommandList]>[0];
+      };
+    };
+
+    try {
+      const args = data.payload.args;
+      await database.init(models.types());
+      await gitServiceAPI.loadGitRepository(args);
+
+      // gitServiceAPI is a constant, so we can safely cast it to a Record type to avoid TypeScript errors
+      const result = await (
+        gitServiceAPI as Record<
+          WorkerCommandList,
+          (...args: Parameters<GitServiceAPI[WorkerCommandList]>) => ReturnType<GitServiceAPI[WorkerCommandList]>
+        >
+      )[data.type](args);
+
+      port.postMessage({
+        type: data.type,
+        result,
+      } as ResultMessage);
+
+      console.log('[debug] Git operation handled successfully');
+    } catch (error) {
+      port.postMessage({
+        type: 'error',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      } as ErrorMessage);
+
+      console.error('[debug] Error handling git operation:', error);
+    }
+  });
+
+  port.start();
+  port.postMessage(readyMessage);
+});

--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -13,7 +13,7 @@ import log, { initializeLogging } from './common/log';
 import { SegmentEvent, trackSegmentEvent } from './main/analytics';
 import { registerInsomniaProtocols } from './main/api.protocol';
 import { backupIfNewerVersionAvailable } from './main/backup';
-import { registerGitServiceAPI } from './main/git-service';
+import { registerGitServiceAPI } from './main/git-service-register';
 import { ipcMainOn, ipcMainOnce, registerElectronHandlers } from './main/ipc/electron';
 import { registergRPCHandlers } from './main/ipc/grpc';
 import { registerMainHandlers } from './main/ipc/main';

--- a/packages/insomnia/src/main/git-service-register.ts
+++ b/packages/insomnia/src/main/git-service-register.ts
@@ -1,15 +1,15 @@
 import path from 'node:path';
 
-import { app, MessageChannelMain, utilityProcess } from 'electron';
+import { app, ipcMain, MessageChannelMain, type UtilityProcess, utilityProcess } from 'electron';
 
 import { typedKeys } from '../utils';
+import { type GitServiceAPI, gitServiceAPI, updateHasUncommittedChanges } from './git-service';
 import {
-  type GitServiceAPI,
-  gitServiceAPI,
-  gitServiceAPIFallback,
-  type WorkerCommandList,
-  workerCommandList,
-} from './git-service';
+  type GitWorkerServiceAPI,
+  gitWorkerServiceAPI,
+  type GitWorkerServiceAPIKeys,
+  gitWorkerServiceFallbacks,
+} from './git-worker-service';
 import { ipcMainHandle } from './ipc/electron';
 
 export const readyMessage = {
@@ -22,8 +22,8 @@ export interface ErrorMessage {
   error: string;
 }
 export interface ResultMessage {
-  type: WorkerCommandList;
-  result: Awaited<ReturnType<GitServiceAPI[WorkerCommandList]>>;
+  type: GitWorkerServiceAPIKeys;
+  result: Awaited<ReturnType<GitWorkerServiceAPI[GitWorkerServiceAPIKeys]>>;
 }
 
 const isReadyMessage = (message: ReadyMessage | ResultMessage | ErrorMessage): message is ReadyMessage => {
@@ -33,8 +33,18 @@ const isErrorMessage = (message: ReadyMessage | ResultMessage | ErrorMessage): m
   return message?.type === 'error';
 };
 
-const runGitCommandInWorker = <C extends WorkerCommandList>(command: C, options: Parameters<GitServiceAPI[C]>[0]) => {
-  type R = ReturnType<GitServiceAPI[C]>;
+const runningGitProcesses = new Map<string, UtilityProcess>();
+
+const runGitCommandInWorker = <C extends GitWorkerServiceAPIKeys>(
+  command: C,
+  options: Parameters<GitWorkerServiceAPI[C]>[0] & {
+    pid: string;
+  },
+) => {
+  type R = ReturnType<GitWorkerServiceAPI[C]>;
+
+  console.warn(`[debug] Running git command "${command}"`, options);
+
   return new Promise<R>(resolve => {
     const { port1, port2 } = new MessageChannelMain();
     const gitProcess = utilityProcess.fork(path.join(__dirname, 'git-worker.js'), [], {
@@ -44,12 +54,16 @@ const runGitCommandInWorker = <C extends WorkerCommandList>(command: C, options:
       },
     });
 
+    runningGitProcesses.set(options.pid, gitProcess);
+
     gitProcess.on('exit', (code: number) => {
+      console.warn(`[debug] git worker process exited with code ${code} for command "${command}"`);
       if (code !== 0) {
         console.error(`Git worker process exited with code ${code}. This may indicate an error in the git operation.`);
-        // From the current state, git operations should not crash the app, return the fallback result instead
-        resolve(gitServiceAPIFallback[command]() as R);
+        // Git operations should not crash the app, return the fallback result instead
+        resolve(gitWorkerServiceFallbacks[command]() as R);
       }
+      runningGitProcesses.delete(options.pid);
     });
 
     // Send one end of the port to the git utility process
@@ -68,7 +82,7 @@ const runGitCommandInWorker = <C extends WorkerCommandList>(command: C, options:
       } else if (isErrorMessage(data)) {
         gitProcess.kill();
         console.error('gitProcess sent an error', data);
-        resolve(gitServiceAPIFallback[command]() as R);
+        resolve(gitWorkerServiceFallbacks[command]() as R);
       } else if (data.type === command) {
         gitProcess.kill();
         resolve(data.result as R);
@@ -81,18 +95,60 @@ const runGitCommandInWorker = <C extends WorkerCommandList>(command: C, options:
   });
 };
 
-// Whether a command should be run in the worker process
-const isWorkerCommand = (command: string): command is WorkerCommandList => {
-  return workerCommandList.includes(command as WorkerCommandList);
-};
-
 // Register the git service API commands with the main process, some commands will run in the worker process
 export const registerGitServiceAPI = () => {
   typedKeys(gitServiceAPI).forEach(command => {
-    if (isWorkerCommand(command)) {
-      ipcMainHandle(`git.${command}`, (_, options) => runGitCommandInWorker(command, options));
+    ipcMainHandle(`git.${command}`, (_, options) => gitServiceAPI[command](options));
+  });
+
+  // The git worker service API commands only support read-only operations to avoid data corruption.
+  ipcMainHandle('git.gitStatus', async (_, options) => {
+    const result = await runGitCommandInWorker('gitStatus', options);
+
+    await updateHasUncommittedChanges({
+      projectId: options.projectId,
+      workspaceId: options.workspaceId,
+      hasUncommittedChanges: result.status.localChanges > 0,
+    });
+
+    return result;
+  });
+
+  ipcMainHandle('git.gitChangesLoader', async (_, options) => {
+    const result = await runGitCommandInWorker('gitChangesLoader', options);
+
+    await updateHasUncommittedChanges({
+      projectId: options.projectId,
+      workspaceId: options.workspaceId,
+      hasUncommittedChanges: result.changes.staged.length > 0 || result.changes.unstaged.length > 0,
+    });
+
+    return result;
+  });
+
+  ipcMainHandle('git.abortGitWorkerOperation', (_, { pid }) => {
+    console.warn(`[debug] Request aborting git operation with pid ${pid}`);
+    const gitProcess = runningGitProcesses.get(pid);
+    if (gitProcess) {
+      gitProcess.kill();
+      runningGitProcesses.delete(pid);
+      console.warn(`[debug] Aborted git operation with pid ${pid}`);
     } else {
-      ipcMainHandle(`git.${command}`, (_, options) => gitServiceAPI[command](options));
+      console.warn(`[debug] No git operation found with pid ${pid}`);
     }
   });
+};
+
+// Git worker services could be aborted, so we need to pass the pid to the worker service API
+export type GitServiceMainAPI = GitServiceAPI & {
+  abortGitWorkerOperation: (options: { pid: string }) => void;
+  gitStatus: (
+    options: Parameters<GitWorkerServiceAPI['gitStatus']>[0] & { pid: string },
+  ) => Promise<ReturnType<GitWorkerServiceAPI['gitStatus']>>;
+  diffFileLoader: (
+    options: Parameters<GitWorkerServiceAPI['diffFileLoader']>[0] & { pid: string },
+  ) => Promise<ReturnType<GitWorkerServiceAPI['diffFileLoader']>>;
+  gitChangesLoader: (
+    options: Parameters<GitWorkerServiceAPI['gitChangesLoader']>[0] & { pid: string },
+  ) => Promise<ReturnType<GitWorkerServiceAPI['gitChangesLoader']>>;
 };

--- a/packages/insomnia/src/main/git-service-register.ts
+++ b/packages/insomnia/src/main/git-service-register.ts
@@ -1,0 +1,98 @@
+import path from 'node:path';
+
+import { app, MessageChannelMain, utilityProcess } from 'electron';
+
+import { typedKeys } from '../utils';
+import {
+  type GitServiceAPI,
+  gitServiceAPI,
+  gitServiceAPIFallback,
+  type WorkerCommandList,
+  workerCommandList,
+} from './git-service';
+import { ipcMainHandle } from './ipc/electron';
+
+export const readyMessage = {
+  type: 'ready',
+} as const;
+
+export type ReadyMessage = typeof readyMessage;
+export interface ErrorMessage {
+  type: 'error';
+  error: string;
+}
+export interface ResultMessage {
+  type: WorkerCommandList;
+  result: Awaited<ReturnType<GitServiceAPI[WorkerCommandList]>>;
+}
+
+const isReadyMessage = (message: ReadyMessage | ResultMessage | ErrorMessage): message is ReadyMessage => {
+  return message?.type === 'ready';
+};
+const isErrorMessage = (message: ReadyMessage | ResultMessage | ErrorMessage): message is ErrorMessage => {
+  return message?.type === 'error';
+};
+
+const runGitCommandInWorker = <C extends WorkerCommandList>(command: C, options: Parameters<GitServiceAPI[C]>[0]) => {
+  type R = ReturnType<GitServiceAPI[C]>;
+  return new Promise<R>(resolve => {
+    const { port1, port2 } = new MessageChannelMain();
+    const gitProcess = utilityProcess.fork(path.join(__dirname, 'git-worker.js'), [], {
+      env: {
+        ...process.env,
+        INSOMNIA_DATA_PATH: process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'),
+      },
+    });
+
+    gitProcess.on('exit', (code: number) => {
+      if (code !== 0) {
+        console.error(`Git worker process exited with code ${code}. This may indicate an error in the git operation.`);
+        // From the current state, git operations should not crash the app, return the fallback result instead
+        resolve(gitServiceAPIFallback[command]() as R);
+      }
+    });
+
+    // Send one end of the port to the git utility process
+    gitProcess.postMessage({}, [port2]);
+
+    port1.on('message', message => {
+      const data: ResultMessage | ErrorMessage | ReadyMessage = message.data;
+
+      if (isReadyMessage(data)) {
+        port1.postMessage({
+          type: command,
+          payload: {
+            args: options,
+          },
+        });
+      } else if (isErrorMessage(data)) {
+        gitProcess.kill();
+        console.error('gitProcess sent an error', data);
+        resolve(gitServiceAPIFallback[command]() as R);
+      } else if (data.type === command) {
+        gitProcess.kill();
+        resolve(data.result as R);
+      } else {
+        console.warn('gitProcess sent unexpected message:', data);
+      }
+    });
+
+    port1.start();
+  });
+};
+
+// Whether a command should be run in the worker process
+const isWorkerCommand = (command: string): command is WorkerCommandList => {
+  return workerCommandList.includes(command as WorkerCommandList);
+};
+
+// Register the git service API commands with the main process, some commands will run in the worker process
+export const registerGitServiceAPI = () => {
+  typedKeys(gitServiceAPI).forEach(command => {
+    if (isWorkerCommand(command)) {
+      ipcMainHandle(`git.${command}`, (_, options) => runGitCommandInWorker(command, options));
+    } else {
+      ipcMainHandle(`git.${command}`, (_, options) => gitServiceAPI[command](options));
+    }
+  });
+};

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -42,7 +42,6 @@ import { getOauth2FormatName } from '../sync/git/utils';
 import type { MergeConflict } from '../sync/types';
 import { invariant } from '../utils/invariant';
 import { SegmentEvent, trackSegmentEvent } from './analytics';
-import { ipcMainHandle } from './ipc/electron';
 
 type PushPull = 'push' | 'pull';
 type VCSAction =
@@ -342,14 +341,7 @@ export const gitChangesLoader = async ({
       changes,
     };
   } catch {
-    return {
-      branch: '',
-      changes: {
-        staged: [],
-        unstaged: [],
-      },
-      errors: ['Failed to get changes'],
-    };
+    return gitServiceAPIFallback.gitChangesLoader();
   }
 };
 
@@ -563,7 +555,7 @@ const recursivelyFindInsomniaFiles = async (
 };
 
 // Actions
-export const initGitRepoCloneAction = async ({
+export const initGitRepoClone = async ({
   uri,
   authorName,
   authorEmail,
@@ -669,7 +661,7 @@ export const initGitRepoCloneAction = async ({
   return { files };
 };
 
-export const cloneGitRepoAction = async ({
+export const cloneGitRepo = async ({
   organizationId,
   projectId,
   cloneIntoProjectId,
@@ -1054,7 +1046,7 @@ export const cloneGitRepoAction = async ({
   }
 };
 
-export const updateGitRepoAction = async ({
+export const updateGitRepo = async ({
   projectId,
   workspaceId,
   authorEmail,
@@ -1173,7 +1165,7 @@ export const updateGitRepoAction = async ({
   }
 };
 
-export const resetGitRepoAction = async ({ projectId, workspaceId }: { projectId: string; workspaceId?: string }) => {
+export const resetGitRepo = async ({ projectId, workspaceId }: { projectId: string; workspaceId?: string }) => {
   const repo = await getGitRepository({ projectId, workspaceId });
 
   invariant(repo, 'Git Repository not found');
@@ -1204,7 +1196,7 @@ export interface CommitToGitRepoResult {
   errors?: string[];
 }
 
-export const commitToGitRepoAction = async ({
+export const commitToGitRepo = async ({
   projectId,
   workspaceId,
   message,
@@ -1254,14 +1246,14 @@ export const migrateLegacyInsomniaFolderToFile = async ({ projectId }: { project
   if (result.changes) {
     await GitVCS.setAuthor();
     await GitVCS.stageChanges(result.changes);
-    await commitToGitRepoAction({
+    await commitToGitRepo({
       projectId,
       message: 'Migrated legacy .insomnia folder to file',
     });
   }
 };
 
-export const commitAndPushToGitRepoAction = async ({
+export const commitAndPushToGitRepo = async ({
   projectId,
   workspaceId,
   message,
@@ -1365,7 +1357,7 @@ export interface CreateNewGitBranchResult {
   errors?: string[];
 }
 
-export const createNewGitBranchAction = async ({
+export const createNewGitBranch = async ({
   projectId,
   workspaceId,
   branch,
@@ -1411,7 +1403,7 @@ export interface CheckoutGitBranchResult {
   errors?: string[];
 }
 
-export const checkoutGitBranchAction = async ({
+export const checkoutGitBranch = async ({
   projectId,
   workspaceId,
   branch,
@@ -1514,7 +1506,7 @@ export interface DeleteGitBranchResult {
   errors?: string[];
 }
 
-export const deleteGitBranchAction = async ({
+export const deleteGitBranch = async ({
   projectId,
   workspaceId,
   branch,
@@ -1543,7 +1535,7 @@ export interface PushToGitRemoteResult {
   gitRepository?: GitRepository;
 }
 
-export const pushToGitRemoteAction = async ({
+export const pushToGitRemote = async ({
   projectId,
   workspaceId,
   // @TODO - Force is never used
@@ -1714,7 +1706,7 @@ async function getGitChanges(vcs: typeof GitVCS) {
   };
 }
 
-export const discardChangesAction = async ({
+export const discardChanges = async ({
   projectId,
   workspaceId,
   paths,
@@ -1747,7 +1739,7 @@ export interface GitStatusResult {
   };
 }
 
-export const gitStatusAction = async ({
+export const gitStatus = async ({
   projectId,
   workspaceId,
 }: {
@@ -1770,15 +1762,11 @@ export const gitStatusAction = async ({
     };
   } catch (e) {
     console.error(e);
-    return {
-      status: {
-        localChanges: 0,
-      },
-    };
+    return gitServiceAPIFallback.gitStatus();
   }
 };
 
-export const stageChangesAction = async ({
+export const stageChanges = async ({
   projectId,
   workspaceId,
   paths,
@@ -1805,7 +1793,7 @@ export const stageChangesAction = async ({
   }
 };
 
-export const unstageChangesAction = async ({
+export const unstageChanges = async ({
   projectId,
   workspaceId,
   paths,
@@ -1901,9 +1889,7 @@ export const diffFileLoader = async ({
     };
   } catch (e) {
     const errorMessage = e instanceof Error ? e.message : 'Error while unstaging changes';
-    return {
-      errors: [errorMessage],
-    };
+    return gitServiceAPIFallback.diffFileLoader(errorMessage);
   }
 };
 
@@ -2349,125 +2335,78 @@ async function signOutOfGitLab() {
   }
 }
 
-export interface GitServiceAPI {
-  loadGitRepository: typeof loadGitRepository;
-  getGitBranches: typeof getGitBranches;
-  gitFetchAction: typeof gitFetchAction;
-  gitLogLoader: typeof gitLogLoader;
-  gitChangesLoader: typeof gitChangesLoader;
-  canPushLoader: typeof canPushLoader;
-  initGitRepoClone: typeof initGitRepoCloneAction;
-  cloneGitRepo: typeof cloneGitRepoAction;
-  updateGitRepo: typeof updateGitRepoAction;
-  resetGitRepo: typeof resetGitRepoAction;
-  commitToGitRepo: typeof commitToGitRepoAction;
-  commitAndPushToGitRepo: typeof commitAndPushToGitRepoAction;
-  createNewGitBranch: typeof createNewGitBranchAction;
-  checkoutGitBranch: typeof checkoutGitBranchAction;
-  mergeGitBranch: typeof mergeGitBranch;
-  deleteGitBranch: typeof deleteGitBranchAction;
-  pushToGitRemote: typeof pushToGitRemoteAction;
-  pullFromGitRemote: typeof pullFromGitRemote;
-  continueMerge: typeof continueMerge;
-  discardChanges: typeof discardChangesAction;
-  gitStatus: typeof gitStatusAction;
-  stageChanges: typeof stageChangesAction;
-  unstageChanges: typeof unstageChangesAction;
-  diffFileLoader: typeof diffFileLoader;
-  getRepositoryDirectoryTree: typeof getRepositoryDirectoryTree;
-  migrateLegacyInsomniaFolderToFile: typeof migrateLegacyInsomniaFolderToFile;
+export const gitServiceAPI = {
+  loadGitRepository,
+  getGitBranches,
+  gitFetchAction,
+  gitLogLoader,
+  gitChangesLoader,
+  canPushLoader,
+  initGitRepoClone,
+  cloneGitRepo,
+  updateGitRepo,
+  resetGitRepo,
+  commitToGitRepo,
+  commitAndPushToGitRepo,
+  createNewGitBranch,
+  checkoutGitBranch,
+  mergeGitBranch,
+  deleteGitBranch,
+  pushToGitRemote,
+  pullFromGitRemote,
+  continueMerge,
+  discardChanges,
+  gitStatus,
+  stageChanges,
+  unstageChanges,
+  diffFileLoader,
+  getRepositoryDirectoryTree,
+  migrateLegacyInsomniaFolderToFile,
+  initSignInToGitHub,
+  completeSignInToGitHub,
+  signOutOfGitHub,
+  getGitHubRepositories,
+  getGitHubRepository,
+  initSignInToGitLab,
+  completeSignInToGitLab,
+  signOutOfGitLab,
+};
 
-  initSignInToGitHub: typeof initSignInToGitHub;
-  completeSignInToGitHub: typeof completeSignInToGitHub;
-  signOutOfGitHub: typeof signOutOfGitHub;
-  getGitHubRepositories: typeof getGitHubRepositories;
-  getGitHubRepository: typeof getGitHubRepository;
+export type GitServiceAPI = typeof gitServiceAPI;
+export type GitServiceAPIKeys = keyof GitServiceAPI;
 
-  initSignInToGitLab: typeof initSignInToGitLab;
-  completeSignInToGitLab: typeof completeSignInToGitLab;
-  signOutOfGitLab: typeof signOutOfGitLab;
-}
+/**
+ * List of commands that should be run in a worker process.
+ *
+ * These commands are expected to be long-running or resource-intensive, so they should not block the main process.
+ *
+ * ! Note: Should only include read-only commands to avoid the risk of data corruption.
+ */
+export const workerCommandList = ['gitStatus', 'diffFileLoader', 'gitChangesLoader'] as const;
+export type WorkerCommandList = (typeof workerCommandList)[number];
 
-export const registerGitServiceAPI = () => {
-  ipcMainHandle('git.loadGitRepository', (_, options: Parameters<typeof loadGitRepository>[0]) =>
-    loadGitRepository(options),
-  );
-  ipcMainHandle('git.getGitBranches', (_, options: Parameters<typeof getGitBranches>[0]) => getGitBranches(options));
-  ipcMainHandle('git.gitFetchAction', (_, options: Parameters<typeof gitFetchAction>[0]) => gitFetchAction(options));
-  ipcMainHandle('git.gitLogLoader', (_, options: Parameters<typeof gitLogLoader>[0]) => gitLogLoader(options));
-  ipcMainHandle('git.gitChangesLoader', (_, options: Parameters<typeof gitChangesLoader>[0]) =>
-    gitChangesLoader(options),
-  );
-  ipcMainHandle('git.canPushLoader', (_, options: Parameters<typeof canPushLoader>[0]) => canPushLoader(options));
-  ipcMainHandle('git.cloneGitRepo', (_, options: Parameters<typeof cloneGitRepoAction>[0]) =>
-    cloneGitRepoAction(options),
-  );
-  ipcMainHandle('git.initGitRepoClone', (_, options: Parameters<typeof initGitRepoCloneAction>[0]) =>
-    initGitRepoCloneAction(options),
-  );
-  ipcMainHandle('git.updateGitRepo', (_, options: Parameters<typeof updateGitRepoAction>[0]) =>
-    updateGitRepoAction(options),
-  );
-  ipcMainHandle('git.resetGitRepo', (_, options: Parameters<typeof resetGitRepoAction>[0]) =>
-    resetGitRepoAction(options),
-  );
-  ipcMainHandle('git.commitToGitRepo', (_, options: Parameters<typeof commitToGitRepoAction>[0]) =>
-    commitToGitRepoAction(options),
-  );
-  ipcMainHandle('git.commitAndPushToGitRepo', (_, options: Parameters<typeof commitAndPushToGitRepoAction>[0]) =>
-    commitAndPushToGitRepoAction(options),
-  );
-  ipcMainHandle('git.createNewGitBranch', (_, options: Parameters<typeof createNewGitBranchAction>[0]) =>
-    createNewGitBranchAction(options),
-  );
-  ipcMainHandle('git.checkoutGitBranch', (_, options: Parameters<typeof checkoutGitBranchAction>[0]) =>
-    checkoutGitBranchAction(options),
-  );
-  ipcMainHandle('git.mergeGitBranch', (_, options: Parameters<typeof mergeGitBranch>[0]) => mergeGitBranch(options));
-  ipcMainHandle('git.deleteGitBranch', (_, options: Parameters<typeof deleteGitBranchAction>[0]) =>
-    deleteGitBranchAction(options),
-  );
-  ipcMainHandle('git.pushToGitRemote', (_, options: Parameters<typeof pushToGitRemoteAction>[0]) =>
-    pushToGitRemoteAction(options),
-  );
-  ipcMainHandle('git.pullFromGitRemote', (_, options: Parameters<typeof pullFromGitRemote>[0]) =>
-    pullFromGitRemote(options),
-  );
-  ipcMainHandle('git.continueMerge', (_, options: Parameters<typeof continueMerge>[0]) => continueMerge(options));
-  ipcMainHandle('git.discardChanges', (_, options: Parameters<typeof discardChangesAction>[0]) =>
-    discardChangesAction(options),
-  );
-  ipcMainHandle('git.gitStatus', (_, options: Parameters<typeof gitStatusAction>[0]) => gitStatusAction(options));
-  ipcMainHandle('git.stageChanges', (_, options: Parameters<typeof stageChangesAction>[0]) =>
-    stageChangesAction(options),
-  );
-  ipcMainHandle('git.unstageChanges', (_, options: Parameters<typeof unstageChangesAction>[0]) =>
-    unstageChangesAction(options),
-  );
-  ipcMainHandle('git.diffFileLoader', (_, options: Parameters<typeof diffFileLoader>[0]) => diffFileLoader(options));
-  ipcMainHandle('git.getRepositoryDirectoryTree', (_, options: Parameters<typeof getRepositoryDirectoryTree>[0]) =>
-    getRepositoryDirectoryTree(options),
-  );
-  ipcMainHandle(
-    'git.migrateLegacyInsomniaFolderToFile',
-    (_, options: Parameters<typeof migrateLegacyInsomniaFolderToFile>[0]) => migrateLegacyInsomniaFolderToFile(options),
-  );
-
-  ipcMainHandle('git.initSignInToGitHub', () => initSignInToGitHub());
-  ipcMainHandle('git.completeSignInToGitHub', (_, options: Parameters<typeof completeSignInToGitHub>[0]) =>
-    completeSignInToGitHub(options),
-  );
-  ipcMainHandle('git.signOutOfGitHub', () => signOutOfGitHub());
-  ipcMainHandle('git.getGitHubRepositories', (_, options: Parameters<typeof getGitHubRepositories>[0]) =>
-    getGitHubRepositories(options),
-  );
-  ipcMainHandle('git.getGitHubRepository', (_, options: Parameters<typeof getGitHubRepository>[0]) =>
-    getGitHubRepository(options),
-  );
-
-  ipcMainHandle('git.initSignInToGitLab', () => initSignInToGitLab());
-  ipcMainHandle('git.completeSignInToGitLab', (_, options: Parameters<typeof completeSignInToGitLab>[0]) =>
-    completeSignInToGitLab(options),
-  );
-  ipcMainHandle('git.signOutOfGitLab', () => signOutOfGitLab());
+// This is intended to be used as a fallback for the gitServiceAPI in case of errors or unavailability.
+export const gitServiceAPIFallback = {
+  gitStatus: () => {
+    return {
+      status: {
+        localChanges: 0,
+      },
+    };
+  },
+  diffFileLoader: (errorMessage = 'Failed to load diff') => {
+    return {
+      errors: [errorMessage],
+    };
+  },
+  gitChangesLoader: () => {
+    return {
+      branch: '',
+      changes: {
+        staged: [],
+        unstaged: [],
+      },
+      errors: ['Failed to get changes'],
+    };
+  },
 };

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -6,7 +6,7 @@ import { app, net } from 'electron/main';
 import { fromUrl } from 'hosted-git-info';
 import { Errors, type HeadStatus, type PromiseFsClient, type StageStatus, type WorkdirStatus } from 'isomorphic-git';
 import { v4 } from 'uuid';
-import YAML, { parse } from 'yaml';
+import YAML from 'yaml';
 
 import {
   getApiBaseURL,
@@ -87,31 +87,6 @@ function parseGitToHttpsURL(s: string) {
   return parsed;
 }
 
-async function getGitRepository({ projectId, workspaceId }: { projectId: string; workspaceId?: string }) {
-  if (workspaceId) {
-    const workspace = await models.workspace.getById(workspaceId);
-    invariant(workspace, 'Workspace not found');
-    const workspaceMeta = await models.workspaceMeta.getByParentId(workspaceId);
-    invariant(workspaceMeta, 'Workspace meta not found');
-    if (!workspaceMeta.gitRepositoryId) {
-      throw new Error('Workspace is not linked to a git repository');
-    }
-
-    const gitRepository = await models.gitRepository.getById(workspaceMeta.gitRepositoryId);
-    invariant(gitRepository, 'Git Repository not found');
-
-    return gitRepository;
-  }
-
-  invariant(projectId, 'Project ID is required');
-  const project = await models.project.getById(projectId);
-  invariant(project, 'Project not found');
-  invariant(project.gitRepositoryId, 'Project is not linked to a git repository');
-  const gitRepository = await models.gitRepository.getById(project.gitRepositoryId);
-  invariant(gitRepository, 'Git Repository not found');
-  return gitRepository;
-}
-
 async function getGitFSClient({
   projectId,
   workspaceId,
@@ -162,6 +137,31 @@ async function getGitFSClient({
   });
 
   return routableFS;
+}
+
+export async function getGitRepository({ projectId, workspaceId }: { projectId: string; workspaceId?: string }) {
+  if (workspaceId) {
+    const workspace = await models.workspace.getById(workspaceId);
+    invariant(workspace, 'Workspace not found');
+    const workspaceMeta = await models.workspaceMeta.getByParentId(workspaceId);
+    invariant(workspaceMeta, 'Workspace meta not found');
+    if (!workspaceMeta.gitRepositoryId) {
+      throw new Error('Workspace is not linked to a git repository');
+    }
+
+    const gitRepository = await models.gitRepository.getById(workspaceMeta.gitRepositoryId);
+    invariant(gitRepository, 'Git Repository not found');
+
+    return gitRepository;
+  }
+
+  invariant(projectId, 'Project ID is required');
+  const project = await models.project.getById(projectId);
+  invariant(project, 'Project not found');
+  invariant(project.gitRepositoryId, 'Project is not linked to a git repository');
+  const gitRepository = await models.gitRepository.getById(project.gitRepositoryId);
+  invariant(gitRepository, 'Git Repository not found');
+  return gitRepository;
 }
 
 export async function loadGitRepository({ projectId, workspaceId }: { projectId: string; workspaceId?: string }) {
@@ -301,47 +301,6 @@ export const gitLogLoader = async ({ projectId, workspaceId }: { projectId: stri
       log: [],
       errors: ['Failed to fetch log'],
     };
-  }
-};
-
-export interface GitChangesLoaderData {
-  changes: {
-    staged: {
-      name: string;
-      path: string;
-    }[];
-    unstaged: {
-      name: string;
-      path: string;
-    }[];
-  };
-  branch: string;
-  errors?: string[];
-}
-
-export const gitChangesLoader = async ({
-  projectId,
-  workspaceId,
-}: {
-  projectId: string;
-  workspaceId?: string;
-}): Promise<GitChangesLoaderData> => {
-  try {
-    const gitRepository = await getGitRepository({ projectId, workspaceId });
-    const branch = await GitVCS.getCurrentBranch();
-
-    const { changes, hasUncommittedChanges } = await getGitChanges(GitVCS);
-
-    await models.gitRepository.update(gitRepository, {
-      hasUncommittedChanges,
-    });
-
-    return {
-      branch,
-      changes,
-    };
-  } catch {
-    return gitServiceAPIFallback.gitChangesLoader();
   }
 };
 
@@ -1733,39 +1692,6 @@ export const discardChanges = async ({
   }
 };
 
-export interface GitStatusResult {
-  status: {
-    localChanges: number;
-  };
-}
-
-export const gitStatus = async ({
-  projectId,
-  workspaceId,
-}: {
-  projectId: string;
-  workspaceId?: string;
-}): Promise<GitStatusResult> => {
-  try {
-    const gitRepository = await getGitRepository({ workspaceId, projectId });
-    const { hasUncommittedChanges, changes } = await getGitChanges(GitVCS);
-    const localChanges = changes.staged.length + changes.unstaged.length;
-
-    await models.gitRepository.update(gitRepository, {
-      hasUncommittedChanges,
-    });
-
-    return {
-      status: {
-        localChanges,
-      },
-    };
-  } catch (e) {
-    console.error(e);
-    return gitServiceAPIFallback.gitStatus();
-  }
-};
-
 export const stageChanges = async ({
   projectId,
   workspaceId,
@@ -1817,79 +1743,6 @@ export const unstageChanges = async ({
     return {
       errors: [errorMessage],
     };
-  }
-};
-
-function getPreviewItemName(previewDiffItem: { before: string; after: string }) {
-  let prevName = '';
-  let nextName = '';
-
-  try {
-    const prev = parse(previewDiffItem.before);
-
-    if ((prev && 'fileName' in prev) || 'name' in prev) {
-      prevName = prev.fileName || prev.name;
-    }
-  } catch {
-    // Nothing to do
-  }
-
-  try {
-    const next = parse(previewDiffItem.after);
-    if ((next && 'fileName' in next) || 'name' in next) {
-      nextName = next.fileName || next.name;
-    }
-  } catch {
-    // Nothing to do
-  }
-
-  return nextName || prevName;
-}
-
-export type GitDiffResult =
-  | {
-      name: string;
-      diff?: {
-        before: string;
-        after: string;
-      };
-    }
-  | {
-      errors: string[];
-    };
-
-export const diffFileLoader = async ({
-  projectId,
-  workspaceId,
-  filepath,
-  staged,
-}: {
-  projectId: string;
-  workspaceId?: string;
-  filepath: string;
-  staged: boolean;
-}): Promise<GitDiffResult> => {
-  try {
-    await getGitRepository({ workspaceId, projectId });
-    const fileStatus = await GitVCS.fileStatus(filepath);
-
-    const diff = staged
-      ? {
-          before: fileStatus.head,
-          after: fileStatus.stage,
-        }
-      : {
-          before: fileStatus.stage || fileStatus.head,
-          after: fileStatus.workdir,
-        };
-
-    return {
-      name: getPreviewItemName(diff) || filepath,
-      diff,
-    };
-  } catch (e) {
-    const errorMessage = e instanceof Error ? e.message : 'Error while unstaging changes';
-    return gitServiceAPIFallback.diffFileLoader(errorMessage);
   }
 };
 
@@ -2340,7 +2193,6 @@ export const gitServiceAPI = {
   getGitBranches,
   gitFetchAction,
   gitLogLoader,
-  gitChangesLoader,
   canPushLoader,
   initGitRepoClone,
   cloneGitRepo,
@@ -2356,10 +2208,8 @@ export const gitServiceAPI = {
   pullFromGitRemote,
   continueMerge,
   discardChanges,
-  gitStatus,
   stageChanges,
   unstageChanges,
-  diffFileLoader,
   getRepositoryDirectoryTree,
   migrateLegacyInsomniaFolderToFile,
   initSignInToGitHub,
@@ -2375,38 +2225,22 @@ export const gitServiceAPI = {
 export type GitServiceAPI = typeof gitServiceAPI;
 export type GitServiceAPIKeys = keyof GitServiceAPI;
 
-/**
- * List of commands that should be run in a worker process.
- *
- * These commands are expected to be long-running or resource-intensive, so they should not block the main process.
- *
- * ! Note: Should only include read-only commands to avoid the risk of data corruption.
- */
-export const workerCommandList = ['gitStatus', 'diffFileLoader', 'gitChangesLoader'] as const;
-export type WorkerCommandList = (typeof workerCommandList)[number];
+export const updateHasUncommittedChanges = async ({
+  projectId,
+  workspaceId,
+  hasUncommittedChanges,
+}: {
+  projectId: string;
+  workspaceId?: string;
+  hasUncommittedChanges: boolean;
+}) => {
+  try {
+    const gitRepository = await getGitRepository({ projectId, workspaceId });
 
-// This is intended to be used as a fallback for the gitServiceAPI in case of errors or unavailability.
-export const gitServiceAPIFallback = {
-  gitStatus: () => {
-    return {
-      status: {
-        localChanges: 0,
-      },
-    };
-  },
-  diffFileLoader: (errorMessage = 'Failed to load diff') => {
-    return {
-      errors: [errorMessage],
-    };
-  },
-  gitChangesLoader: () => {
-    return {
-      branch: '',
-      changes: {
-        staged: [],
-        unstaged: [],
-      },
-      errors: ['Failed to get changes'],
-    };
-  },
+    await models.gitRepository.update(gitRepository, {
+      hasUncommittedChanges,
+    });
+  } catch (error) {
+    console.error('Error updating hasUncommittedChanges:', error);
+  }
 };

--- a/packages/insomnia/src/main/git-worker-service.ts
+++ b/packages/insomnia/src/main/git-worker-service.ts
@@ -1,0 +1,196 @@
+import { parse } from 'yaml';
+
+import GitVCS from '../sync/git/git-vcs';
+import { getGitRepository } from './git-service';
+
+interface GitChangesLoaderData {
+  changes: {
+    staged: {
+      name: string;
+      path: string;
+    }[];
+    unstaged: {
+      name: string;
+      path: string;
+    }[];
+  };
+  branch: string;
+  errors?: string[];
+}
+
+const gitChangesLoader = async ({
+  projectId,
+  workspaceId,
+}: {
+  projectId: string;
+  workspaceId?: string;
+}): Promise<GitChangesLoaderData> => {
+  try {
+    await getGitRepository({ projectId, workspaceId });
+    const branch = await GitVCS.getCurrentBranch();
+
+    const { changes } = await getGitChanges(GitVCS);
+
+    return {
+      branch,
+      changes,
+    };
+  } catch {
+    return gitWorkerServiceFallbacks.gitChangesLoader();
+  }
+};
+
+async function getGitChanges(vcs: typeof GitVCS) {
+  const changes = await vcs.status();
+
+  return {
+    changes,
+    hasUncommittedChanges: changes.staged.length > 0 || changes.unstaged.length > 0,
+  };
+}
+
+interface GitStatusResult {
+  status: {
+    localChanges: number;
+  };
+}
+
+const gitStatus = async ({
+  projectId,
+  workspaceId,
+}: {
+  projectId: string;
+  workspaceId?: string;
+}): Promise<GitStatusResult> => {
+  try {
+    await getGitRepository({ workspaceId, projectId });
+    const { changes } = await getGitChanges(GitVCS);
+    const localChanges = changes.staged.length + changes.unstaged.length;
+
+    return {
+      status: {
+        localChanges,
+      },
+    };
+  } catch (e) {
+    console.error(e);
+    return gitWorkerServiceFallbacks.gitStatus();
+  }
+};
+
+function getPreviewItemName(previewDiffItem: { before: string; after: string }) {
+  let prevName = '';
+  let nextName = '';
+
+  try {
+    const prev = parse(previewDiffItem.before);
+
+    if ((prev && 'fileName' in prev) || 'name' in prev) {
+      prevName = prev.fileName || prev.name;
+    }
+  } catch {
+    // Nothing to do
+  }
+
+  try {
+    const next = parse(previewDiffItem.after);
+    if ((next && 'fileName' in next) || 'name' in next) {
+      nextName = next.fileName || next.name;
+    }
+  } catch {
+    // Nothing to do
+  }
+
+  return nextName || prevName;
+}
+
+type GitDiffResult =
+  | {
+      name: string;
+      diff?: {
+        before: string;
+        after: string;
+      };
+    }
+  | {
+      errors: string[];
+    };
+
+const diffFileLoader = async ({
+  projectId,
+  workspaceId,
+  filepath,
+  staged,
+}: {
+  projectId: string;
+  workspaceId?: string;
+  filepath: string;
+  staged: boolean;
+}): Promise<GitDiffResult> => {
+  try {
+    await getGitRepository({ workspaceId, projectId });
+    const fileStatus = await GitVCS.fileStatus(filepath);
+
+    const diff = staged
+      ? {
+          before: fileStatus.head,
+          after: fileStatus.stage,
+        }
+      : {
+          before: fileStatus.stage || fileStatus.head,
+          after: fileStatus.workdir,
+        };
+
+    return {
+      name: getPreviewItemName(diff) || filepath,
+      diff,
+    };
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : 'Error while unstaging changes';
+    return gitWorkerServiceFallbacks.diffFileLoader(errorMessage);
+  }
+};
+
+/**
+ * List of commands that should be run in a worker process.
+ *
+ * These commands are expected to be long-running or resource-intensive, so they should not block the main process.
+ *
+ * ! Note: Should only include read-only commands to avoid the risk of data corruption.
+ */
+const workerProcessCommands = ['gitStatus', 'diffFileLoader', 'gitChangesLoader'] as const;
+export type WorkerProcessCommand = (typeof workerProcessCommands)[number];
+
+// This is intended to be used as a fallback for the gitServiceAPI in case of errors or unavailability.
+export const gitWorkerServiceFallbacks = {
+  gitStatus: () => {
+    return {
+      status: {
+        localChanges: 0,
+      },
+    };
+  },
+  diffFileLoader: (errorMessage = 'Failed to load diff') => {
+    return {
+      errors: [errorMessage],
+    };
+  },
+  gitChangesLoader: () => {
+    return {
+      branch: '',
+      changes: {
+        staged: [],
+        unstaged: [],
+      },
+      errors: ['Failed to get changes'],
+    };
+  },
+};
+
+export const gitWorkerServiceAPI = {
+  gitStatus,
+  diffFileLoader,
+  gitChangesLoader,
+};
+export type GitWorkerServiceAPI = typeof gitWorkerServiceAPI;
+export type GitWorkerServiceAPIKeys = keyof GitWorkerServiceAPI;

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -12,6 +12,7 @@ import { type NunjucksParsedTagArg, type NunjucksTagContextMenuAction } from '..
 import type { extractNunjucksTagFromCoords } from '../../templating/utils';
 import { localTemplateTags } from '../../ui/components/templating/local-template-tags';
 import { invariant } from '../../utils/invariant';
+import type { GitServiceAPIKeys } from '../git-service';
 
 export type HandleChannels =
   | 'authorizeUserInWindow'
@@ -42,40 +43,7 @@ export type HandleChannels =
   | 'secretStorage.deleteSecret'
   | 'secretStorage.encryptString'
   | 'secretStorage.decryptString'
-  | 'git.loadGitRepository'
-  | 'git.getGitBranches'
-  | 'git.gitFetchAction'
-  | 'git.gitLogLoader'
-  | 'git.gitChangesLoader'
-  | 'git.canPushLoader'
-  | 'git.cloneGitRepo'
-  | 'git.initGitRepoClone'
-  | 'git.updateGitRepo'
-  | 'git.resetGitRepo'
-  | 'git.commitToGitRepo'
-  | 'git.commitAndPushToGitRepo'
-  | 'git.createNewGitBranch'
-  | 'git.checkoutGitBranch'
-  | 'git.mergeGitBranch'
-  | 'git.deleteGitBranch'
-  | 'git.pushToGitRemote'
-  | 'git.pullFromGitRemote'
-  | 'git.continueMerge'
-  | 'git.discardChanges'
-  | 'git.gitStatus'
-  | 'git.stageChanges'
-  | 'git.unstageChanges'
-  | 'git.diffFileLoader'
-  | 'git.getRepositoryDirectoryTree'
-  | 'git.migrateLegacyInsomniaFolderToFile'
-  | 'git.initSignInToGitHub'
-  | 'git.completeSignInToGitHub'
-  | 'git.signOutOfGitHub'
-  | 'git.getGitHubRepositories'
-  | 'git.getGitHubRepository'
-  | 'git.initSignInToGitLab'
-  | 'git.completeSignInToGitLab'
-  | 'git.signOutOfGitLab';
+  | `git.${GitServiceAPIKeys}`;
 
 export const ipcMainHandle = (
   channel: HandleChannels,

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -13,6 +13,7 @@ import type { extractNunjucksTagFromCoords } from '../../templating/utils';
 import { localTemplateTags } from '../../ui/components/templating/local-template-tags';
 import { invariant } from '../../utils/invariant';
 import type { GitServiceAPIKeys } from '../git-service';
+import type { GitWorkerServiceAPIKeys } from '../git-worker-service';
 
 export type HandleChannels =
   | 'authorizeUserInWindow'
@@ -43,7 +44,9 @@ export type HandleChannels =
   | 'secretStorage.deleteSecret'
   | 'secretStorage.encryptString'
   | 'secretStorage.decryptString'
-  | `git.${GitServiceAPIKeys}`;
+  | `git.${GitServiceAPIKeys}`
+  | `git.${GitWorkerServiceAPIKeys}`
+  | 'git.abortGitWorkerOperation';
 
 export const ipcMainHandle = (
   channel: HandleChannels,

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -11,7 +11,7 @@ import type { SegmentEvent } from '../analytics';
 import { trackPageView, trackSegmentEvent } from '../analytics';
 import { authorizeUserInWindow } from '../authorizeUserInWindow';
 import { backup, restoreBackup } from '../backup';
-import type { GitServiceAPI } from '../git-service';
+import type { GitServiceMainAPI } from '../git-service-register';
 import installPlugin from '../install-plugin';
 import type { CurlBridgeAPI } from '../network/curl';
 import { cancelCurlRequest, curlRequest } from '../network/libcurl-promise';
@@ -48,7 +48,7 @@ export interface RendererToMainBridgeAPI {
   webSocket: WebSocketBridgeAPI;
   grpc: gRPCBridgeAPI;
   curl: CurlBridgeAPI;
-  git: GitServiceAPI;
+  git: GitServiceMainAPI;
   secretStorage: secretStorageBridgeAPI;
   trackSegmentEvent: (options: { event: string; properties?: Record<string, unknown> }) => void;
   trackPageView: (options: { name: string }) => void;

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -1,6 +1,6 @@
 import { contextBridge, ipcRenderer, webUtils as webUtilities } from 'electron';
 
-import type { GitServiceAPI } from './main/git-service';
+import type { GitServiceMainAPI } from './main/git-service-register';
 import type { gRPCBridgeAPI } from './main/ipc/grpc';
 import type { secretStorageBridgeAPI } from './main/ipc/secret-storage';
 import type { CurlBridgeAPI } from './main/network/curl';
@@ -51,7 +51,7 @@ const secretStorage: secretStorageBridgeAPI = {
   decryptString: cipherText => ipcRenderer.invoke('secretStorage.decryptString', cipherText),
 };
 
-const git: GitServiceAPI = {
+const git: GitServiceMainAPI = {
   loadGitRepository: options => ipcRenderer.invoke('git.loadGitRepository', options),
   getGitBranches: options => ipcRenderer.invoke('git.getGitBranches', options),
   gitFetchAction: options => ipcRenderer.invoke('git.gitFetchAction', options),
@@ -88,6 +88,8 @@ const git: GitServiceAPI = {
   initSignInToGitLab: () => ipcRenderer.invoke('git.initSignInToGitLab'),
   completeSignInToGitLab: options => ipcRenderer.invoke('git.completeSignInToGitLab', options),
   signOutOfGitLab: () => ipcRenderer.invoke('git.signOutOfGitLab'),
+
+  abortGitWorkerOperation: options => ipcRenderer.invoke('git.abortGitWorkerOperation', options),
 };
 
 const main: Window['main'] = {

--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -1,5 +1,5 @@
 import type { IconName, IconProp } from '@fortawesome/fontawesome-svg-core';
-import React, { type FC, useEffect, useState } from 'react';
+import React, { type FC, useEffect, useRef, useState } from 'react';
 import {
   Button,
   Collection,
@@ -57,7 +57,10 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository }) => {
   const gitCheckoutFetcher = useFetcher();
   const gitRepoDataFetcher = useFetcher<GitRepoLoaderData>();
   const gitFetchFetcher = useFetcher<GitFetchLoaderData>();
-  const gitStatusFetcher = useFetcher<GitStatusResult>();
+  // Use key to identify the fetcher, to leverage the AbortController for the fetcher
+  const gitStatusFetcher = useFetcher<GitStatusResult>({
+    key: `git-status-git-project-sync-dropdown`,
+  });
 
   const loadingPush = gitPushFetcher.state === 'loading';
   const loadingFetch = gitFetchFetcher.state === 'loading';
@@ -98,11 +101,17 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository }) => {
     }
   }, [gitRepoDataFetcher.data]);
 
+  const counterRef = useRef(0);
   useEffect(() => {
-    if (shouldFetchGitRepoStatus) {
+    // Should force
+    if (shouldFetchGitRepoStatus || counterRef.current === 0) {
+      counterRef.current = 1;
       // file://./../../routes/git-actions.tsx#gitStatusAction
+      const gitOperationPID = crypto.randomUUID();
       gitStatusFetcher.submit(
-        {},
+        {
+          pid: gitOperationPID,
+        },
         {
           action: `/organization/${organizationId}/project/${projectId}/git/status`,
           method: 'post',

--- a/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
@@ -84,13 +84,7 @@ export const GitSyncDropdown: FC<Props> = ({ gitRepository, isInsomniaSyncEnable
   useEffect(() => {
     if (shouldFetchGitRepoStatus) {
       // file://./../../routes/git-actions.tsx#gitStatusAction
-      gitStatusFetcher.submit(
-        {},
-        {
-          action: `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/git/status`,
-          method: 'post',
-        },
-      );
+      gitStatusFetcher.load(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/git/status`);
     }
   }, [gitStatusFetcher, organizationId, projectId, shouldFetchGitRepoStatus, workspaceId]);
 

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -914,7 +914,7 @@ async function renderApp() {
                                   {
                                     path: 'changes',
                                     loader: async (...args) =>
-                                      (await import('./routes/git-actions')).gitChangesLoader(...args),
+                                      (await import('./routes/git-actions')).gitChangesAction(...args),
                                   },
                                   {
                                     path: 'log',

--- a/packages/insomnia/src/ui/routes/git-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-actions.tsx
@@ -86,11 +86,12 @@ export interface GitChangesLoaderData {
   branch: string;
 }
 
-export const gitChangesLoader: LoaderFunction = async ({ params }): Promise<GitChangesLoaderData> => {
+export const gitChangesAction: ActionFunction = async ({ params }): Promise<GitChangesLoaderData> => {
   const { projectId, workspaceId } = params;
   invariant(typeof projectId === 'string', 'Project Id is required');
   invariant(typeof workspaceId === 'string', 'Workspace Id is required');
-  return window.main.git.gitChangesLoader({ projectId, workspaceId });
+  const gitOperationPID = crypto.randomUUID();
+  return window.main.git.gitChangesLoader({ projectId, workspaceId, pid: gitOperationPID });
 };
 
 export interface GitCanPushLoaderData {
@@ -399,16 +400,29 @@ export interface GitStatusResult {
   };
 }
 
-export const gitStatusAction: ActionFunction = async ({ params }): Promise<GitStatusResult> => {
+export const gitStatusAction: ActionFunction = async ({ params, request }): Promise<GitStatusResult> => {
   const { projectId, workspaceId } = params;
   invariant(typeof projectId === 'string', 'Project Id is required');
   invariant(typeof workspaceId === 'string', 'Workspace Id is required');
 
-  return window.main.git.gitStatus({ projectId, workspaceId });
+  const gitOperationPID = crypto.randomUUID();
+
+  console.warn(
+    `[debug] Starting git status operation for project ${projectId} in workspace ${workspaceId} with PID ${gitOperationPID}`,
+    request.signal,
+  );
+
+  request.signal.onabort = () => {
+    console.warn('[debug] Git status request aborted');
+    window.main.git.abortGitWorkerOperation({ pid: gitOperationPID });
+  };
+
+  return window.main.git.gitStatus({ projectId, workspaceId, pid: gitOperationPID });
 };
 
 export async function checkGitChanges({ projectId, workspaceId }: { projectId: string; workspaceId: string }) {
-  return window.main.git.gitChangesLoader({ projectId, workspaceId });
+  const gitOperationPID = crypto.randomUUID();
+  return window.main.git.gitChangesLoader({ projectId, workspaceId, pid: gitOperationPID });
 }
 
 export async function checkGitCanPush({ projectId, workspaceId }: { projectId: string; workspaceId: string }) {
@@ -465,8 +479,9 @@ export const diffFileLoader: LoaderFunction = async ({ request, params }): Promi
   invariant(filepath, 'Filepath is required');
 
   const staged = urlParams.get('staged') === 'true';
+  const gitOperationPID = crypto.randomUUID();
 
-  return window.main.git.diffFileLoader({ projectId, workspaceId, filepath, staged });
+  return window.main.git.diffFileLoader({ projectId, workspaceId, filepath, staged, pid: gitOperationPID });
 };
 
 export const loadGitHubCredentials: LoaderFunction = async () => {

--- a/packages/insomnia/src/ui/routes/git-project-actions.tsx
+++ b/packages/insomnia/src/ui/routes/git-project-actions.tsx
@@ -23,10 +23,12 @@ export type GitRepoLoaderData =
       errors: string[];
     };
 
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
 export const gitRepoLoader: ActionFunction = async ({ params }): Promise<GitRepoLoaderData> => {
   const { projectId } = params;
   invariant(typeof projectId === 'string', 'Project Id is required');
-
+  await sleep(10000);
   return window.main.git.loadGitRepository({ projectId });
 };
 
@@ -90,7 +92,8 @@ export const gitChangesLoader: LoaderFunction = async ({ params }): Promise<GitC
   const { projectId } = params;
   invariant(typeof projectId === 'string', 'Project Id is required');
 
-  return window.main.git.gitChangesLoader({ projectId });
+  const gitOperationPID = crypto.randomUUID();
+  return window.main.git.gitChangesLoader({ projectId, pid: gitOperationPID });
 };
 
 export interface GitCanPushLoaderData {
@@ -385,14 +388,29 @@ export interface GitStatusResult {
   };
 }
 
-export const gitStatusAction: ActionFunction = async ({ params }): Promise<GitStatusResult> => {
+export const gitStatusAction: ActionFunction = async ({ params, request }): Promise<GitStatusResult> => {
+  console.log('[debug]', request.body);
+
   const { projectId } = params;
   invariant(typeof projectId === 'string', 'Project Id is required');
-  return window.main.git.gitStatus({ projectId });
+
+  const gitOperationPID = crypto.randomUUID();
+  console.warn(
+    `[debug] Starting git status operation for project ${projectId} in with PID ${gitOperationPID}`,
+    request.signal,
+  );
+
+  request.signal.onabort = () => {
+    console.warn('[debug] Git status request aborted');
+    window.main.git.abortGitWorkerOperation({ pid: gitOperationPID });
+  };
+
+  return window.main.git.gitStatus({ projectId, pid: gitOperationPID });
 };
 
 export const checkGitChanges = async (projectId: string) => {
-  return window.main.git.gitChangesLoader({ projectId });
+  const gitOperationPID = crypto.randomUUID();
+  return window.main.git.gitChangesLoader({ projectId, pid: gitOperationPID });
 };
 
 export const checkGitCanPush = async (projectId: string) => {
@@ -447,7 +465,8 @@ export const diffFileLoader: LoaderFunction = async ({ request, params }): Promi
 
   const staged = urlParams.get('staged') === 'true';
 
-  return window.main.git.diffFileLoader({ projectId, filepath, staged });
+  const gitOperationPID = crypto.randomUUID();
+  return window.main.git.diffFileLoader({ projectId, filepath, staged, pid: gitOperationPID });
 };
 
 export type GetRepositoryDirectoryTreeResult = Awaited<ReturnType<typeof window.main.git.getRepositoryDirectoryTree>>;

--- a/packages/insomnia/vite.config.ts
+++ b/packages/insomnia/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig(({ mode }) => {
         '@stoplight/spectral-rulesets',
         'codemirror-graphql/utils/SchemaReference',
         'openapi-types',
+        'isomorphic-git',
       ],
       force: true,
     },


### PR DESCRIPTION
## Background

INS-5761

When there are more than 1000 requests in one collection, some git operations will significantly block the main process, and users can't do anything during that time. This has seriously affected the user experience.

## Changes

- Move `gitStatus`, `diffFileLoader`, and `gitChangesLoader` to a separate process to avoid them blocking the main process.

Still reuse the current git service and database, so currently only support read only operations in the git process.

## Comparison

### Current
https://github.com/user-attachments/assets/8306f9d9-56db-4360-a4e1-e1298589f464

### After
https://github.com/user-attachments/assets/7a3046b0-e1ce-4ecc-a77c-bae803d2a07b






