### PR TITLE
detect unknown tags poc

### DIFF
--- a/packages/insomnia/src/common/__tests__/render.test.ts
+++ b/packages/insomnia/src/common/__tests__/render.test.ts
@@ -6,6 +6,29 @@ import { environmentModelSchema, requestGroupModelSchema } from '../../models/__
 import type { Environment } from '../../models/environment';
 import type { Workspace } from '../../models/workspace';
 import * as renderUtils from '../render';
+import { getUnknownTags } from '../render';
+
+describe('getUnknownTags()', () => {
+  it('returns empty array for no tags', () => {
+    expect(getUnknownTags('Hello World')).toEqual([]);
+  });
+
+  it('returns empty array for known tags', () => {
+    expect(getUnknownTags('Hello {% uuid %}')).toEqual([]);
+  });
+
+  it('returns unknown tags', () => {
+    expect(getUnknownTags('Hello {% unknownTag %}')).toEqual(['unknownTag']);
+  });
+
+  it('returns multiple unknown tags', () => {
+    expect(getUnknownTags('Hello {% unknownTag1 %} and {% unknownTag2 %}')).toEqual(['unknownTag1', 'unknownTag2']);
+  });
+
+  it('ignores known tags with parameters', () => {
+    expect(getUnknownTags("Hello {% hash 'md5', 'hex', value %}")).toEqual([]);
+  });
+});
 
 const envBuilder = createBuilder(environmentModelSchema);
 const reqGroupBuilder = createBuilder(requestGroupModelSchema);

--- a/packages/insomnia/src/common/__tests__/render.test.ts
+++ b/packages/insomnia/src/common/__tests__/render.test.ts
@@ -28,6 +28,12 @@ describe('getUnknownTags()', () => {
   it('ignores known tags with parameters', () => {
     expect(getUnknownTags("Hello {% hash 'md5', 'hex', value %}")).toEqual([]);
   });
+  it('returns unknown tags with parameters', () => {
+    expect(
+      getUnknownTags(`{{ self.constructor.constructor('return global.process.mainModule.require("fs").readFileSync("/etc/passwd", "utf8")')() }}
+`),
+    ).toEqual(['unknownTag']);
+  });
 });
 
 const envBuilder = createBuilder(environmentModelSchema);

--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -226,10 +226,14 @@ export async function buildRenderContext({
 }
 export const getUnknownTags = (input: string) => {
   const knownTags: string[] = localTemplateTags.map(plugin => plugin.templateTag.name);
+  const knownVariableTags: string[] = ['env1'];
+  const unknownVariableTags = (input.match(/{{[\s\S]*?}}/g) || [])
+    .map(tag => (tag.match(/{{\s*(\w+)/) || [])[1])
+    .filter(tag => tag && !knownVariableTags.includes(tag));
   const unknownTags = (input.match(/{%[\s\S]*?%}/g) || [])
     .map(tag => (tag.match(/{%\s*(\w+)/) || [])[1])
     .filter(tag => tag && !knownTags.includes(tag));
-  return unknownTags;
+  return [...unknownVariableTags, ...unknownTags];
 };
 const renderInThisProcess = async (input: {
   input: string;

--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -26,6 +26,7 @@ import type {
 } from '../templating/types';
 import * as templatingUtils from '../templating/utils';
 import { maskOrDecryptVaultDataIfNecessary } from '../templating/utils';
+import { localTemplateTags } from '../ui/components/templating/local-template-tags';
 import { setDefaultProtocol } from '../utils/url/protocol';
 import { CONTENT_TYPE_GRAPHQL, JSON_ORDER_SEPARATOR } from './constants';
 import { database as db } from './database';
@@ -223,6 +224,13 @@ export async function buildRenderContext({
 
   return finalRenderContext;
 }
+export const getUnknownTags = (input: string) => {
+  const knownTags: string[] = localTemplateTags.map(plugin => plugin.templateTag.name);
+  const unknownTags = (input.match(/{%[\s\S]*?%}/g) || [])
+    .map(tag => (tag.match(/{%\s*(\w+)/) || [])[1])
+    .filter(tag => tag && !knownTags.includes(tag));
+  return unknownTags;
+};
 const renderInThisProcess = async (input: {
   input: string;
   context: BaseRenderContext;
@@ -295,7 +303,11 @@ export async function render<T>(
         // which case it's okay to render locally.
 
         const settings = await models.settings.get();
-        const pluginsAreRestrictedToRunInWorker = settings?.pluginsAllowElevatedAccess === false;
+
+        const hasUnknownTags = getUnknownTags(input).length > 0;
+
+        const pluginsAreRestrictedToRunInWorker = settings?.pluginsAllowElevatedAccess === false || hasUnknownTags;
+
         const currentProcessIsRendererAndPluginsAreRestricted =
           process.type === 'renderer' && pluginsAreRestrictedToRunInWorker;
         const renderFork = currentProcessIsRendererAndPluginsAreRestricted

--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -306,7 +306,7 @@ export async function render<T>(
 
         const hasUnknownTags = getUnknownTags(input).length > 0;
 
-        const pluginsAreRestrictedToRunInWorker = settings?.pluginsAllowElevatedAccess === false || hasUnknownTags;
+        const pluginsAreRestrictedToRunInWorker = settings?.pluginsAllowElevatedAccess === false && hasUnknownTags;
 
         const currentProcessIsRendererAndPluginsAreRestricted =
           process.type === 'renderer' && pluginsAreRestrictedToRunInWorker;

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -212,7 +212,7 @@ export function createWindow(): ElectronBrowserWindow {
       preload: path.join(__dirname, 'preload.js'),
       zoomFactor: getZoomFactor(),
       nodeIntegration: true,
-      nodeIntegrationInWorker: true,
+      nodeIntegrationInWorker: false,
       webviewTag: true,
       // TODO: enable context isolation
       contextIsolation: false,


### PR DESCRIPTION
depends on having a firm understanding on nunjucks templating conventions
the idea based on a limited understanding of whats possible in nunjucks, is that if we allow list all the plugins and the env variables as valid tags then everything else as invalid. Then we can run untrusted stuff in a sandbox without require access.

The problems faced here are the varied known and unknown ways to define a tag. For example
{{ myvar }} {{ _.myvar }} {{ _['myvar'] }}
{% myfunction %}
{# my comment #}

And also the need to know all the variable keys upfront in order to build the list of valid keys, and since we support rendering inside of keys that becomes impossible.

The only way this is viable is if we ban rendering inside of env var keys.

todo
- [ ] prove tag detection is a viable way forward
- [ ] try to find a workaround in tests
- [ ] decide if all plugin error should mean allowing elevated access
- [x] disable nodeIntegration in worker
- [ ] rewire spectral lint to tolerate absent nodeintegration
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
