### PR TITLE
fix: apply GraphQL body parsing to requests of plugins and tags

### DIFF
--- a/packages/insomnia/src/common/har.ts
+++ b/packages/insomnia/src/common/har.ts
@@ -14,7 +14,7 @@ import * as plugins from '../plugins';
 import * as pluginContexts from '../plugins/context/index';
 import { RenderError } from '../templating/render-error';
 import type { RenderedRequest } from '../templating/types';
-import { parseGraphQLReqeustBody } from '../utils/graph-ql';
+import { parseGraphQLRequestBody } from '../utils/graph-ql';
 import { smartEncodeUrl } from '../utils/url/querystring';
 import { getAppVersion } from './constants';
 import { jarFromCookies } from './cookies';
@@ -167,7 +167,10 @@ export async function exportHarWithRequest(request: Request, environmentId?: str
   try {
     const renderResult = await getRenderedRequestAndContext({ request, environment: environmentId });
     const renderedRequest = await _applyRequestPluginHooks(renderResult.request, renderResult.context);
-    parseGraphQLReqeustBody(renderedRequest);
+
+    // TODO: remove this temporary hack to support GraphQL variables in the request body properly
+    parseGraphQLRequestBody(renderedRequest);
+    
     return exportHarWithRenderedRequest(renderedRequest, addContentLength);
   } catch (err) {
     if (err instanceof RenderError) {

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -26,7 +26,7 @@ import { getBearerAuthHeader } from '../../network/bearer-auth/get-header';
 import { filterClientCertificates } from '../../network/certificate';
 import { addSetCookiesToToughCookieJar } from '../../network/set-cookie-util';
 import type { RenderedRequest } from '../../templating/types';
-import { parseGraphQLReqeustBody } from '../../utils/graph-ql';
+import { parseGraphQLRequestBody } from '../../utils/graph-ql';
 import { invariant } from '../../utils/invariant';
 import { setDefaultProtocol } from '../../utils/url/protocol';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from '../../utils/url/querystring';
@@ -452,7 +452,9 @@ const handleGraphQLWsMessage = (data: MessageEvent['data'], request: Request) =>
   const requestId = request._id;
   // send subscribe operation to graphql websocket server when ack is received
   if (graphqlServerDataType === MessageType.ConnectionAck) {
-    parseGraphQLReqeustBody(request as RenderedRequest);
+    // TODO: remove this temporary hack to support GraphQL variables in the request body properly
+    parseGraphQLRequestBody(request as RenderedRequest);
+    
     let subscriptionPayload = {};
     try {
       // @ts-expect-error graphql request has body attribute

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -4,6 +4,7 @@ import type { Request as DBRequest } from '../models/request';
 import type { RequestGroup } from '../models/request-group';
 import type { Workspace } from '../models/workspace';
 import { fetchRequestData, sendCurlAndWriteTimeline, tryToInterpolateRequest } from '../network/network';
+import { parseGraphQLRequestBody } from '../utils/graph-ql';
 
 export const resolveDbByKey = async (request: Request) => {
   const url = new URL(request.url);
@@ -64,6 +65,10 @@ export const resolveDbByKey = async (request: Request) => {
       purpose: 'send',
       extraInfo: body.extraInfo,
     });
+
+    // TODO: remove this temporary hack to support GraphQL variables in the request body properly
+    parseGraphQLRequestBody(renderResult.request);
+
     const response = await sendCurlAndWriteTimeline(
       renderResult.request,
       clientCertificates,

--- a/packages/insomnia/src/network/unit-test-feature.ts
+++ b/packages/insomnia/src/network/unit-test-feature.ts
@@ -1,6 +1,6 @@
 import { stats } from '../models';
 import { getBodyBuffer } from '../models/response';
-import { parseGraphQLReqeustBody } from '../utils/graph-ql';
+import { parseGraphQLRequestBody } from '../utils/graph-ql';
 import {
   fetchRequestData,
   responseTransform,
@@ -27,7 +27,7 @@ export function getSendRequestCallback() {
     const renderedRequest = await tryToTransformRequestWithPlugins(renderResult);
 
     // TODO: remove this temporary hack to support GraphQL variables in the request body properly
-    parseGraphQLReqeustBody(renderedRequest);
+    parseGraphQLRequestBody(renderedRequest);
 
     const response = await sendCurlAndWriteTimeline(
       renderedRequest,

--- a/packages/insomnia/src/plugins/context/network.ts
+++ b/packages/insomnia/src/plugins/context/network.ts
@@ -7,6 +7,7 @@ import {
   tryToTransformRequestWithPlugins,
 } from '../../network/network';
 import type { PluginTemplateTagContext } from '../../templating/types';
+import { parseGraphQLRequestBody } from '../../utils/graph-ql';
 
 export function init(): {
   network: PluginTemplateTagContext['network'];
@@ -32,6 +33,10 @@ export function init(): {
           extraInfo,
         });
         const renderedRequest = await tryToTransformRequestWithPlugins(renderResult);
+
+        // TODO: remove this temporary hack to support GraphQL variables in the request body properly
+        parseGraphQLRequestBody(renderedRequest);
+
         const response = await sendCurlAndWriteTimeline(
           renderedRequest,
           clientCertificates,

--- a/packages/insomnia/src/ui/routes/request.tsx
+++ b/packages/insomnia/src/ui/routes/request.tsx
@@ -58,7 +58,7 @@ import {
   tryToTransformRequestWithPlugins,
 } from '../../network/network';
 import { type RenderedRequest } from '../../templating/types';
-import { parseGraphQLReqeustBody } from '../../utils/graph-ql';
+import { parseGraphQLRequestBody } from '../../utils/graph-ql';
 import { invariant } from '../../utils/invariant';
 import { SegmentEvent } from '../analytics';
 import { updateMimeType } from '../components/dropdowns/content-type-dropdown';
@@ -649,7 +649,7 @@ export const sendActionImplementation = async (options: {
   window.main.completeExecutionStep({ requestId });
 
   // TODO: remove this temporary hack to support GraphQL variables in the request body properly
-  parseGraphQLReqeustBody(renderedRequest);
+  parseGraphQLRequestBody(renderedRequest);
 
   invariant(requestMeta, 'RequestMeta not found');
 

--- a/packages/insomnia/src/utils/graph-ql.ts
+++ b/packages/insomnia/src/utils/graph-ql.ts
@@ -5,7 +5,7 @@ import type { Request } from '../models/request';
 import type { RenderedRequest } from '../templating/types';
 
 // parse graphql request body since we save entire query variables as string rather then stringified json string. - INS-4281
-export function parseGraphQLReqeustBody(renderedRequest: RenderedRequest) {
+export function parseGraphQLRequestBody(renderedRequest: RenderedRequest) {
   if (renderedRequest && renderedRequest.body?.text && renderedRequest.body?.mimeType === CONTENT_TYPE_GRAPHQL) {
     try {
       const parsedBody = JSON.parse(renderedRequest.body.text);


### PR DESCRIPTION
This PR addresses https://github.com/Kong/insomnia/issues/8307. There are many places in the code where the "temporary hack" called `parseGraphQLRequestBody()` is applied, yet is still missing for **built-in Templating Tags** and **Plugins** sending requests without elevated access.

### Background

A GraphQL request has the following format:

```json
{
  "query": "...",
  "operationName": "...",
  "variables": { "myVariable": "someValue", ...},
  ...
}
```
As you can see, the `"variables"` property is expected to be an object, not a recursively encoded JSON. Some GraphQL servers surprisingly accept a string, but many don't, some crash, as it's out-of-spec.
Unfortunately in the GraphQL editor at `packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx@91` it is persisted as a raw string instead of being attempted to be parsed.

```js
-  // Code that should probably have been used
-  if (isString(variables) && variables.length > 0) {
-    try {
-      content.variables = JSON.parse(variables);
-    } catch(e) {
-      content.variables = variables;
-    }
-  }

+  // Code that is currently in use
+  if (isString(variables)) {
+    content.variables = variables.length ? variables : undefined;
+  }
```
Instead the `parseGraphQLRequestBody()` function does exactly that, attempting to parse the variables and keep them as an encoded string, if it fails. But this hack must be manually applied everywhere a request is sent and is easily forgotten...

### The Solution

Simplest approach: Keep using the "temporary hack" and apply it where missed. This is implemented here.

Proper approach: The code snippet above makes `parseGraphQLRequestBody()` unnecessary, fixes the bug, but could maybe introduce some compatibility issues with plugins and before/after scripts. All tests still pass, but I have not looked further into this alternative solution.

### Testing

1. Create a GraphQL request
   - An example: `https://spacex-production.up.railway.app/` with `{}` as the variables
   - When sending this, the errors show no issues with the `variables` property
2. Create an arbitrary request 
   - Add a _Response Tag_ referencing the secondary request
   - An example: `google.de/search?q={% response 'body', 'req_YOUR_REQUEST', 'b64::JC5lcnJvcnNbMF0ubWVzc2FnZQ==::46b', 'when-expired', 1 %}`
3. When executing, we get a error from the SpaceX API, that the `variables` property is wrongly encoded. This error is different from the error returned, if the GraphQL request is sent directly.
4. Switch to this branch, **restart Insomnia** (this is **very important**, as otherwise the worker code is not actually updated!) and execute the request again
   - The issue seems fixed ✅