### PR TITLE
fix(Git Sync): Importing a resource without a workspace prevents it from being shown in the git diff

### DIFF
--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -559,6 +559,10 @@ const importResourcesToNewWorkspace = async ({
     }
   }
 
+  // Make sure the new workspace has required resources like base environment, cookie jar and workspaceMeta
+  await models.environment.getOrCreateForParentId(newWorkspace._id);
+  await models.workspaceMeta.getOrCreateByParentId(newWorkspace._id);
+
   // we sync the new workspace to the cloud in workspaceLoader when user enters the workspace
   // since we won't navigate to the workspace automatically after import
   // here we push to the cloud programmatically

--- a/packages/insomnia/src/sync/git/project-ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/project-ne-db-client.ts
@@ -230,8 +230,15 @@ export class GitProjectNeDBClient {
   async getWorkspaceIdFromFilePath(filePath: string) {
     filePath = path.normalize(filePath);
 
+    const workspaces = await db.find<Workspace>(models.workspace.type, {
+      parentId: this._projectId,
+    });
+
     const workspaceMeta = await db.find<WorkspaceMeta>(models.workspaceMeta.type, {
       gitFilePath: filePath,
+      parentId: {
+        $in: workspaces.map(w => w._id),
+      },
     });
 
     if (workspaceMeta.length === 0) {

--- a/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
@@ -170,7 +170,7 @@ export const NewWorkspaceModal = ({
                   />
                   <FieldError className="text-xs text-red-500" />
                 </TextField>
-                {isGitProject(project) && gitRepoTreeFetcher.data && (
+                {isGitProject(project) && (
                   <>
                     <TextField
                       name="fileName"
@@ -205,19 +205,29 @@ export const NewWorkspaceModal = ({
                     <Label className="text-sm text-[--hl]">
                       Folder where the file will be saved in the repository:
                     </Label>
+
                     <Tree
                       className="grid max-h-52 gap-0 overflow-auto rounded-sm border border-solid border-[--hl-sm]"
-                      defaultSelectedKeys={[gitRepoTreeFetcher.data.repositoryTree.id]}
+                      defaultSelectedKeys={[gitRepoTreeFetcher.data?.repositoryTree.id || '']}
                       disallowEmptySelection
-                      defaultExpandedKeys={[gitRepoTreeFetcher.data.repositoryTree.id]}
+                      defaultExpandedKeys={[gitRepoTreeFetcher.data?.repositoryTree.id || '']}
                       onSelectionChange={selection => {
                         if (selection !== 'all') {
-                          setWorkspaceData({ ...workspaceData, folderPath: selection.values().next().value as string });
+                          setWorkspaceData({
+                            ...workspaceData,
+                            folderPath: selection.values().next().value as string,
+                          });
                         }
                       }}
                       aria-label="Files"
                       selectionMode="single"
-                      items={[gitRepoTreeFetcher.data.repositoryTree]}
+                      items={gitRepoTreeFetcher.data?.repositoryTree ? [gitRepoTreeFetcher.data?.repositoryTree] : []}
+                      renderEmptyState={() => (
+                        <div className="flex h-full items-center justify-center gap-2 p-2 text-sm text-[--hl]">
+                          <Icon icon="spinner" className="size-5 animate-spin" />
+                          Loading files...
+                        </div>
+                      )}
                     >
                       {function renderItem(item) {
                         return (
@@ -329,14 +339,14 @@ export const NewWorkspaceModal = ({
                 <div className="flex items-center gap-2">
                   <Button
                     onPress={close}
-                    isDisabled={createNewWorkspaceFetcher.state !== 'idle'}
+                    isDisabled={createNewWorkspaceFetcher.state !== 'idle' || gitRepoTreeFetcher.state !== 'idle'}
                     className="rounded-sm border border-solid border-[--hl-md] px-3 py-2 text-[--color-font] transition-colors hover:bg-opacity-90 hover:no-underline"
                   >
                     Cancel
                   </Button>
                   <Button
                     type="submit"
-                    isDisabled={createNewWorkspaceFetcher.state !== 'idle'}
+                    isDisabled={createNewWorkspaceFetcher.state !== 'idle' || gitRepoTreeFetcher.state !== 'idle'}
                     className="flex w-[10ch] items-center justify-center gap-2 rounded-sm border border-solid border-[--hl-md] bg-[--color-surprise] px-3 py-2 text-center text-[--color-font-surprise] transition-colors hover:bg-opacity-90 hover:no-underline"
                   >
                     {createNewWorkspaceFetcher.state !== 'idle' && <Icon icon="spinner" className="animate-spin" />}

--- a/packages/insomnia/src/ui/routes/actions.tsx
+++ b/packages/insomnia/src/ui/routes/actions.tsx
@@ -558,7 +558,7 @@ export const createNewWorkspaceAction: ActionFunction = async ({ params, request
   await database.flushChanges(flushId);
 
   const { id } = await models.userSession.getOrCreate();
-  if (id && !workspaceMeta.gitRepositoryId) {
+  if (id && !workspaceMeta.gitRepositoryId && !isGitProject(project)) {
     const vcs = VCSInstance();
     await initializeLocalBackendProjectAndMarkForSync({
       vcs,


### PR DESCRIPTION
Highlights:

- [x] Create required entities when importing resources to a new workspace
- [x] Improve the loading state handling on the new workspace modal inside git projects
- [x] Do not initialize VCS projects when inside a Git Project
- [x] Fix an issue where a workspace will appear empty if it's path matches another