### PR TITLE
address joiner and tags in set-cookies

### DIFF
--- a/packages/insomnia/src/common/misc.ts
+++ b/packages/insomnia/src/common/misc.ts
@@ -47,8 +47,14 @@ export function hasAcceptEncodingHeader<T extends Header>(headers: T[]) {
   return filterHeaders(headers, 'accept-encoding').length > 0;
 }
 
-export function getSetCookieHeaders<T extends Header>(headers: T[]): T[] {
-  return filterHeaders(headers, 'set-cookie');
+export function getSetCookieHeaders(headers: Header[]): Header[] {
+  return filterHeaders(headers, 'set-cookie').map(h => {
+    // remove Nunjucks interpolation symbols
+    return {
+      name: h.name,
+      value: h.value.replaceAll('{{', '').replaceAll('}}', '').replaceAll('{%', '').replaceAll('%}', ''),
+    };
+  });
 }
 
 export function getLocationHeader<T extends Header>(headers: T[]): T | null {

--- a/packages/insomnia/src/network/__tests__/network.test.ts
+++ b/packages/insomnia/src/network/__tests__/network.test.ts
@@ -1042,6 +1042,16 @@ describe('getSetCookiesFromResponseHeaders', () => {
     ];
     expect(getSetCookiesFromResponseHeaders(headers)).toEqual(['monster', 'mash']);
   });
+  it('sanitize special characters, remove interpolation symbols', () => {
+    const headers = [
+      { name: 'Set-Cookie', value: 'sessionid=+_)(*&^%$#@!; HttpOnly; Path=/' },
+      { name: 'set-cookie', value: '{% magic %}={{_.env}}; HttpOnly; Path=/' },
+    ];
+    expect(getSetCookiesFromResponseHeaders(headers)).toEqual([
+      'sessionid=+_)(*&^%$#@!; HttpOnly; Path=/',
+      ' magic =_.env; HttpOnly; Path=/',
+    ]);
+  });
 });
 describe('getCurrentUrl for tough-cookie', () => {
   it('defaults to finalUrl', () => {

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -983,13 +983,7 @@ const extractCookies = async (
   return { cookies: [], rejectedCookies: [], totalSetCookies: 0 };
 };
 
-export const getSetCookiesFromResponseHeaders = (headers: any[]) =>
-  getSetCookieHeaders(headers).map(h => {
-    const name = h.value.split('=')[0];
-    // encodeURIComponent is used to ensure that the cookie value is properly encoded
-    const value = h.value.split('=')[1];
-    return `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
-  });
+export const getSetCookiesFromResponseHeaders = (headers: any[]) => getSetCookieHeaders(headers).map(h => h.value);
 
 export const getCurrentUrl = ({ headerResults, finalUrl }: { headerResults: any; finalUrl: string }): string => {
   if (!headerResults || !headerResults.length) {

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -983,7 +983,13 @@ const extractCookies = async (
   return { cookies: [], rejectedCookies: [], totalSetCookies: 0 };
 };
 
-export const getSetCookiesFromResponseHeaders = (headers: any[]) => getSetCookieHeaders(headers).map(h => h.value);
+export const getSetCookiesFromResponseHeaders = (headers: any[]) =>
+  getSetCookieHeaders(headers).map(h => {
+    const name = h.value.split('=')[0];
+    // encodeURIComponent is used to ensure that the cookie value is properly encoded
+    const value = h.value.split('=')[1];
+    return `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
+  });
 
 export const getCurrentUrl = ({ headerResults, finalUrl }: { headerResults: any; finalUrl: string }): string => {
   if (!headerResults || !headerResults.length) {

--- a/packages/insomnia/src/templating/index.ts
+++ b/packages/insomnia/src/templating/index.ts
@@ -172,6 +172,7 @@ async function getNunjucks(renderMode: string, ignoreUndefinedEnvVariable?: bool
   const nunjucksEnvironment = nunjucks.configure(config) as NunjucksEnvironment;
   nunjucksEnvironment.addGlobal('range', undefined);
   nunjucksEnvironment.addGlobal('cycler', undefined);
+  nunjucksEnvironment.addGlobal('joiner', undefined);
   const pluginTemplateTags = await (await import('../plugins')).getTemplateTags();
 
   const allExtensions = [

--- a/packages/insomnia/src/templating/worker.ts
+++ b/packages/insomnia/src/templating/worker.ts
@@ -172,6 +172,7 @@ async function getNunjucks(renderMode: string, ignoreUndefinedEnvVariable?: bool
   const nunjucksEnvironment = nunjucks.configure(config) as NunjucksEnvironment;
   nunjucksEnvironment.addGlobal('range', undefined);
   nunjucksEnvironment.addGlobal('cycler', undefined);
+  nunjucksEnvironment.addGlobal('joiner', undefined);
   const allExtensions = [...localTemplateTags];
 
   for (const extension of allExtensions) {


### PR DESCRIPTION
- makes safe set cookie values by removing interpolation symbols
- removes joiner from nunjucks globals list

I chose to remove symbols as a light touch, in the more heavy approach of parsing the cookie and encoding and decoding which could lead to undesirable side effects.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
