### PR TITLE
fix(Git Sync): Display up to date content in code editors when data change through git sync

### DIFF
--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -177,6 +177,10 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
         legacyInsomniaWorkspace = await containsLegacyInsomniaDir({ fsClient });
       }
 
+      await models.gitRepository.update(gitRepository, {
+        statusIdentifier: await GitVCS.statusIdentifier(),
+      });
+
       return {
         branch: await GitVCS.getCurrentBranch(),
         branches: await GitVCS.listBranches(),
@@ -220,6 +224,10 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
     if (!workspaceId) {
       legacyInsomniaWorkspace = await containsLegacyInsomniaDir({ fsClient });
     }
+
+    await models.gitRepository.update(gitRepository, {
+      statusIdentifier: await GitVCS.statusIdentifier(),
+    });
 
     return {
       branch: await GitVCS.getCurrentBranch(),
@@ -335,6 +343,7 @@ export const gitChangesLoader = async ({
 
     await models.gitRepository.update(gitRepository, {
       hasUncommittedChanges,
+      statusIdentifier: await GitVCS.statusIdentifier(),
     });
 
     return {
@@ -1228,6 +1237,7 @@ export const commitToGitRepoAction = async ({
     // update workspace meta with git sync data, use for show unpushed changes on collection card
     await models.gitRepository.update(gitRepository, {
       hasUnpushedChanges,
+      statusIdentifier: await GitVCS.statusIdentifier(),
     });
   } catch (e) {
     const message = e instanceof Error ? e.message : 'Error while committing changes';
@@ -1319,6 +1329,7 @@ export const commitAndPushToGitRepoAction = async ({
 
     await models.gitRepository.update(repo, {
       hasUnpushedChanges,
+      statusIdentifier: await GitVCS.statusIdentifier(),
     });
   } catch (err: unknown) {
     if (err instanceof Errors.PushRejectedError && err.data.reason === 'not-fast-forward') {
@@ -1391,6 +1402,7 @@ export const createNewGitBranchAction = async ({
     await models.gitRepository.update(gitRepository, {
       hasUncommittedChanges,
       hasUnpushedChanges,
+      statusIdentifier: await GitVCS.statusIdentifier(),
     });
   } catch (err) {
     if (err instanceof Errors.HttpError) {
@@ -1437,23 +1449,13 @@ export const checkoutGitBranchAction = async ({
     };
   }
 
-  const log = (await GitVCS.log({ depth: 1 })) || [];
-
-  const author = log[0] ? log[0].commit.author : null;
-  const cachedGitLastCommitTime = author ? author.timestamp * 1000 : null;
-
-  await models.gitRepository.update(gitRepository, {
-    cachedGitLastCommitTime,
-    cachedGitRepositoryBranch: branch,
-    cachedGitLastAuthor: author?.name || null,
-  });
-
   const { hasUncommittedChanges } = await getGitChanges(GitVCS);
   const hasUnpushedChanges = await GitVCS.canPush(gitRepository.credentials);
 
   await models.gitRepository.update(gitRepository, {
     hasUncommittedChanges,
     hasUnpushedChanges,
+    statusIdentifier: await GitVCS.statusIdentifier(),
   });
 
   await database.flushChanges(bufferId);
@@ -1490,6 +1492,11 @@ export const mergeGitBranch = async ({
       ...vcsSegmentEventProperties('git', 'merge_branch'),
       providerName,
     });
+
+    await models.gitRepository.update(gitRepository, {
+      statusIdentifier: await GitVCS.statusIdentifier(),
+    });
+
     await database.flushChanges(bufferId, true);
     return {};
   } catch (err) {
@@ -1638,6 +1645,11 @@ export async function pullFromGitRemote({ projectId, workspaceId }: { projectId:
     const providerName = getOauth2FormatName(gitRepository.credentials);
     const bufferId = await database.bufferChanges();
     await GitVCS.pull(gitRepository.credentials);
+
+    await models.gitRepository.update(gitRepository, {
+      statusIdentifier: await GitVCS.statusIdentifier(),
+    });
+
     trackSegmentEvent(SegmentEvent.vcsAction, {
       ...vcsSegmentEventProperties('git', 'pull'),
       providerName,
@@ -1677,7 +1689,7 @@ export const continueMerge = async ({
   commitParent: string[];
 }) => {
   try {
-    await getGitRepository({ workspaceId, projectId });
+    const gitRepository = await getGitRepository({ workspaceId, projectId });
     const bufferId = await database.bufferChanges();
 
     await GitVCS.continueMerge({
@@ -1686,6 +1698,9 @@ export const continueMerge = async ({
       commitParent,
     });
 
+    await models.gitRepository.update(gitRepository, {
+      statusIdentifier: await GitVCS.statusIdentifier(),
+    });
     await database.flushChanges(bufferId);
 
     return {};
@@ -1726,12 +1741,15 @@ export const discardChangesAction = async ({
   errors?: string[];
 }> => {
   try {
-    await getGitRepository({ workspaceId, projectId });
+    const gitRepository = await getGitRepository({ workspaceId, projectId });
     const { changes } = await getGitChanges(GitVCS);
 
     const files = changes.unstaged.filter(change => paths.includes(change.path));
 
     await GitVCS.discardChanges(files);
+    await models.gitRepository.update(gitRepository, {
+      statusIdentifier: await GitVCS.statusIdentifier(),
+    });
     return {};
   } catch (e) {
     const errorMessage = e instanceof Error ? e.message : 'Error while rolling back changes';

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -176,9 +176,12 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
       if (!workspaceId) {
         legacyInsomniaWorkspace = await containsLegacyInsomniaDir({ fsClient });
       }
-
+      const { identifier, totalChangesCount } = await GitVCS.statusIdentifier();
       await models.gitRepository.update(gitRepository, {
-        statusIdentifier: await GitVCS.statusIdentifier(),
+        status: {
+          id: identifier,
+          pending: totalChangesCount,
+        },
       });
 
       return {
@@ -225,8 +228,13 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
       legacyInsomniaWorkspace = await containsLegacyInsomniaDir({ fsClient });
     }
 
+    const { identifier, totalChangesCount } = await GitVCS.statusIdentifier();
+
     await models.gitRepository.update(gitRepository, {
-      statusIdentifier: await GitVCS.statusIdentifier(),
+      status: {
+        id: identifier,
+        pending: totalChangesCount,
+      },
     });
 
     return {
@@ -339,11 +347,13 @@ export const gitChangesLoader = async ({
     const gitRepository = await getGitRepository({ projectId, workspaceId });
     const branch = await GitVCS.getCurrentBranch();
 
-    const { changes, hasUncommittedChanges } = await getGitChanges(GitVCS);
+    const changes = await GitVCS.status();
 
     await models.gitRepository.update(gitRepository, {
-      hasUncommittedChanges,
-      statusIdentifier: await GitVCS.statusIdentifier(),
+      status: {
+        id: changes.identifier,
+        pending: changes.totalChangesCount,
+      },
     });
 
     return {
@@ -1166,11 +1176,9 @@ export const updateGitRepoAction = async ({
     await GitVCS.setAuthor();
     await GitVCS.addRemote(uri);
 
-    const { hasUncommittedChanges } = await getGitChanges(GitVCS);
     const hasUnpushedChanges = await GitVCS.canPush(gitRepository.credentials);
 
     await models.gitRepository.update(gitRepository, {
-      hasUncommittedChanges,
       hasUnpushedChanges,
     });
 
@@ -1237,7 +1245,6 @@ export const commitToGitRepoAction = async ({
     // update workspace meta with git sync data, use for show unpushed changes on collection card
     await models.gitRepository.update(gitRepository, {
       hasUnpushedChanges,
-      statusIdentifier: await GitVCS.statusIdentifier(),
     });
   } catch (e) {
     const message = e instanceof Error ? e.message : 'Error while committing changes';
@@ -1329,7 +1336,6 @@ export const commitAndPushToGitRepoAction = async ({
 
     await models.gitRepository.update(repo, {
       hasUnpushedChanges,
-      statusIdentifier: await GitVCS.statusIdentifier(),
     });
   } catch (err: unknown) {
     if (err instanceof Errors.PushRejectedError && err.data.reason === 'not-fast-forward') {
@@ -1396,13 +1402,12 @@ export const createNewGitBranchAction = async ({
       providerName,
     });
 
-    const { hasUncommittedChanges } = await getGitChanges(GitVCS);
+    // const { hasUncommittedChanges } = await getGitChanges(GitVCS);
     const hasUnpushedChanges = await GitVCS.canPush(gitRepository.credentials);
 
     await models.gitRepository.update(gitRepository, {
-      hasUncommittedChanges,
+      // hasUncommittedChanges,
       hasUnpushedChanges,
-      statusIdentifier: await GitVCS.statusIdentifier(),
     });
   } catch (err) {
     if (err instanceof Errors.HttpError) {
@@ -1449,13 +1454,10 @@ export const checkoutGitBranchAction = async ({
     };
   }
 
-  const { hasUncommittedChanges } = await getGitChanges(GitVCS);
   const hasUnpushedChanges = await GitVCS.canPush(gitRepository.credentials);
 
   await models.gitRepository.update(gitRepository, {
-    hasUncommittedChanges,
     hasUnpushedChanges,
-    statusIdentifier: await GitVCS.statusIdentifier(),
   });
 
   await database.flushChanges(bufferId);
@@ -1493,9 +1495,9 @@ export const mergeGitBranch = async ({
       providerName,
     });
 
-    await models.gitRepository.update(gitRepository, {
-      statusIdentifier: await GitVCS.statusIdentifier(),
-    });
+    // await models.gitRepository.update(gitRepository, {
+    //   statusIdentifier: await GitVCS.statusIdentifier(),
+    // });
 
     await database.flushChanges(bufferId, true);
     return {};
@@ -1646,9 +1648,9 @@ export async function pullFromGitRemote({ projectId, workspaceId }: { projectId:
     const bufferId = await database.bufferChanges();
     await GitVCS.pull(gitRepository.credentials);
 
-    await models.gitRepository.update(gitRepository, {
-      statusIdentifier: await GitVCS.statusIdentifier(),
-    });
+    // await models.gitRepository.update(gitRepository, {
+    //   statusIdentifier: await GitVCS.statusIdentifier(),
+    // });
 
     trackSegmentEvent(SegmentEvent.vcsAction, {
       ...vcsSegmentEventProperties('git', 'pull'),
@@ -1689,7 +1691,7 @@ export const continueMerge = async ({
   commitParent: string[];
 }) => {
   try {
-    const gitRepository = await getGitRepository({ workspaceId, projectId });
+    await getGitRepository({ workspaceId, projectId });
     const bufferId = await database.bufferChanges();
 
     await GitVCS.continueMerge({
@@ -1698,9 +1700,9 @@ export const continueMerge = async ({
       commitParent,
     });
 
-    await models.gitRepository.update(gitRepository, {
-      statusIdentifier: await GitVCS.statusIdentifier(),
-    });
+    // await models.gitRepository.update(gitRepository, {
+    //   statusIdentifier: await GitVCS.statusIdentifier(),
+    // });
     await database.flushChanges(bufferId);
 
     return {};
@@ -1720,15 +1722,6 @@ export interface GitChange {
   editable: boolean;
 }
 
-async function getGitChanges(vcs: typeof GitVCS) {
-  const changes = await vcs.status();
-
-  return {
-    changes,
-    hasUncommittedChanges: changes.staged.length > 0 || changes.unstaged.length > 0,
-  };
-}
-
 export const discardChangesAction = async ({
   projectId,
   workspaceId,
@@ -1742,13 +1735,18 @@ export const discardChangesAction = async ({
 }> => {
   try {
     const gitRepository = await getGitRepository({ workspaceId, projectId });
-    const { changes } = await getGitChanges(GitVCS);
+    const changes = await GitVCS.status();
 
     const files = changes.unstaged.filter(change => paths.includes(change.path));
 
     await GitVCS.discardChanges(files);
+
+    const updatedChanges = await GitVCS.status();
     await models.gitRepository.update(gitRepository, {
-      statusIdentifier: await GitVCS.statusIdentifier(),
+      status: {
+        id: updatedChanges.identifier,
+        pending: updatedChanges.totalChangesCount,
+      },
     });
     return {};
   } catch (e) {
@@ -1774,16 +1772,18 @@ export const gitStatusAction = async ({
 }): Promise<GitStatusResult> => {
   try {
     const gitRepository = await getGitRepository({ workspaceId, projectId });
-    const { hasUncommittedChanges, changes } = await getGitChanges(GitVCS);
-    const localChanges = changes.staged.length + changes.unstaged.length;
+    const changes = await GitVCS.status();
 
     await models.gitRepository.update(gitRepository, {
-      hasUncommittedChanges,
+      status: {
+        id: changes.identifier,
+        pending: changes.totalChangesCount,
+      },
     });
 
     return {
       status: {
-        localChanges,
+        localChanges: changes.totalChangesCount,
       },
     };
   } catch (e) {
@@ -1809,7 +1809,7 @@ export const stageChangesAction = async ({
 }> => {
   try {
     await getGitRepository({ workspaceId, projectId });
-    const { changes } = await getGitChanges(GitVCS);
+    const changes = await GitVCS.status();
 
     const files = changes.unstaged.filter(change => paths.includes(change.path));
 
@@ -1836,7 +1836,7 @@ export const unstageChangesAction = async ({
 }> => {
   try {
     await getGitRepository({ workspaceId, projectId });
-    const { changes } = await getGitChanges(GitVCS);
+    const changes = await GitVCS.status();
 
     const files = changes.staged.filter(change => paths.includes(change.path));
 

--- a/packages/insomnia/src/models/git-repository.ts
+++ b/packages/insomnia/src/models/git-repository.ts
@@ -25,11 +25,13 @@ export function init(): BaseGitRepository {
       name: '',
       email: '',
     },
-    statusIdentifier: '',
+    status: {
+      id: '',
+      pending: 0,
+    },
     cachedGitLastCommitTime: null,
     cachedGitRepositoryBranch: null,
     cachedGitLastAuthor: null,
-    hasUncommittedChanges: false,
     hasUnpushedChanges: false,
     uriNeedsMigration: true,
   };
@@ -43,8 +45,10 @@ export interface BaseGitRepository {
     name: string;
     email: string;
   };
-  hasUncommittedChanges: boolean;
-  statusIdentifier: string;
+  status: {
+    id: string;
+    pending: number;
+  };
   cachedGitLastCommitTime: number | null;
   cachedGitRepositoryBranch: string | null;
   cachedGitLastAuthor: string | null;

--- a/packages/insomnia/src/models/git-repository.ts
+++ b/packages/insomnia/src/models/git-repository.ts
@@ -25,6 +25,7 @@ export function init(): BaseGitRepository {
       name: '',
       email: '',
     },
+    statusIdentifier: '',
     cachedGitLastCommitTime: null,
     cachedGitRepositoryBranch: null,
     cachedGitLastAuthor: null,
@@ -43,6 +44,7 @@ export interface BaseGitRepository {
     email: string;
   };
   hasUncommittedChanges: boolean;
+  statusIdentifier: string;
   cachedGitLastCommitTime: number | null;
   cachedGitRepositoryBranch: string | null;
   cachedGitLastAuthor: string | null;

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -388,6 +388,8 @@ export class GitVCS {
   async statusWithContent() {
     const baseOpts = this._baseOpts;
 
+    const gitTreeIds: string[] = [];
+
     // Adopted from statusMatrix of isomorphic-git https://github.com/isomorphic-git/isomorphic-git/blob/main/src/api/statusMatrix.js#L157
     const status: {
       filepath: string;
@@ -465,6 +467,8 @@ export class GitVCS {
           workdirOid = await workdir?.oid();
         }
 
+        gitTreeIds.push(`${filepath}:${headOid}:${workdirOid}:${stageOid}`);
+
         // Adopted from isomorphic-git statusMatrix.
         // This is needed to return the same status code numbers as isomorphic-git
         // In isomorphic-git it can be found in these types: git.HeadStatus, git.WorkdirStatus, and git.StageStatus
@@ -518,19 +522,26 @@ export class GitVCS {
       },
     });
 
-    return status;
+    return {
+      status,
+      identifier: hash('sha1', gitTreeIds.join('')),
+    };
   }
 
   async status(): Promise<{
+    identifier: string;
+    totalChangesCount: number;
     staged: { path: string; status: [git.HeadStatus, git.WorkdirStatus, git.StageStatus]; name: string }[];
     unstaged: { path: string; status: [git.HeadStatus, git.WorkdirStatus, git.StageStatus]; name: string }[];
   }> {
-    const status = await this.statusWithContent();
+    const { status, identifier } = await this.statusWithContent();
 
     const unstagedChanges = status.filter(({ workdir, stage }) => stage.status !== workdir.status);
     const stagedChanges = status.filter(({ head, stage }) => stage.status !== head.status);
 
     return {
+      identifier,
+      totalChangesCount: unstagedChanges.length + stagedChanges.length,
       staged: stagedChanges.map(({ filepath, head, workdir, stage }) => ({
         path: filepath,
         status: [head.status, workdir.status, stage.status],
@@ -558,10 +569,19 @@ export class GitVCS {
       .map(([filepath, headOid, workdirOid, stageOid]) => {
         return `${filepath}:${headOid}:${workdirOid}:${stageOid}`;
       })
-      .join(',');
+      .join('');
+
+    const totalChangesCount = status.filter(([, headOid, workdirOid, stageOid]) => {
+      // If the headOid is not equal to the workdirOid or stageOid, it means there are pending changes
+      return headOid !== workdirOid || headOid !== stageOid;
+    }).length;
 
     // Hash the status identifier to get a unique identifier for the current status
-    return hash('sha1', Buffer.from(statusIdentifier + lastCommit));
+    const hashedStatus = hash('sha1', Buffer.from(statusIdentifier + lastCommit));
+    return {
+      identifier: hashedStatus,
+      totalChangesCount,
+    };
   }
 
   async addRemote(url: string) {

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -1,3 +1,4 @@
+import { hash } from 'node:crypto';
 import path from 'node:path';
 
 import * as git from 'isomorphic-git';
@@ -541,6 +542,26 @@ export class GitVCS {
         name: workdir.name || stage.name || head.name || '',
       })),
     };
+  }
+
+  async statusIdentifier() {
+    const status = await git.statusMatrix({
+      ...this._baseOpts,
+    });
+
+    const lastCommit = await git.resolveRef({
+      ...this._baseOpts,
+      ref: 'HEAD',
+    });
+
+    const statusIdentifier = status
+      .map(([filepath, headOid, workdirOid, stageOid]) => {
+        return `${filepath}:${headOid}:${workdirOid}:${stageOid}`;
+      })
+      .join(',');
+
+    // Hash the status identifier to get a unique identifier for the current status
+    return hash('sha1', Buffer.from(statusIdentifier + lastCommit));
   }
 
   async addRemote(url: string) {

--- a/packages/insomnia/src/ui/hooks/use-vcs-version.ts
+++ b/packages/insomnia/src/ui/hooks/use-vcs-version.ts
@@ -40,7 +40,7 @@ export function useActiveApiSpecSyncVCSVersion() {
 export function useGitVCSVersion() {
   const workspaceData = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
   const projectData = useRouteLoaderData('/project') as ProjectLoaderData;
-  const gitRepository = workspaceData.gitRepository || projectData.activeProjectGitRepository;
-  console.log('[git] useGitVCSVersion', gitRepository?.statusIdentifier);
+  const gitRepository = workspaceData?.gitRepository || projectData?.activeProjectGitRepository;
+
   return gitRepository?.statusIdentifier || '';
 }

--- a/packages/insomnia/src/ui/hooks/use-vcs-version.ts
+++ b/packages/insomnia/src/ui/hooks/use-vcs-version.ts
@@ -4,6 +4,7 @@ import { useParams } from 'react-router';
 
 import { type ChangeBufferEvent, database } from '../../common/database';
 import type { BaseModel } from '../../models';
+import type { ProjectLoaderData } from '../routes/project';
 import type { WorkspaceLoaderData } from '../routes/workspace';
 // We use this hook to determine if the active request has been updated from the system (not the user typing)
 // For example, by pulling a new version from the remote, switching branches, etc.
@@ -37,6 +38,9 @@ export function useActiveApiSpecSyncVCSVersion() {
 // We use this hook to determine if the active workspace has been updated from the Git VCS
 // For example, by pulling a new version from the remote, switching branches, etc.
 export function useGitVCSVersion() {
-  const { gitRepository } = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
-  return gitRepository?.cachedGitLastCommitTime + '' + gitRepository?.cachedGitRepositoryBranch + '';
+  const workspaceData = useRouteLoaderData(':workspaceId') as WorkspaceLoaderData;
+  const projectData = useRouteLoaderData('/project') as ProjectLoaderData;
+  const gitRepository = workspaceData.gitRepository || projectData.activeProjectGitRepository;
+  console.log('[git] useGitVCSVersion', gitRepository?.statusIdentifier);
+  return gitRepository?.statusIdentifier || '';
 }

--- a/packages/insomnia/src/ui/hooks/use-vcs-version.ts
+++ b/packages/insomnia/src/ui/hooks/use-vcs-version.ts
@@ -42,5 +42,5 @@ export function useGitVCSVersion() {
   const projectData = useRouteLoaderData('/project') as ProjectLoaderData;
   const gitRepository = workspaceData?.gitRepository || projectData?.activeProjectGitRepository;
 
-  return gitRepository?.statusIdentifier || '';
+  return gitRepository?.status.id || '';
 }

--- a/packages/insomnia/src/ui/routes/project.tsx
+++ b/packages/insomnia/src/ui/routes/project.tsx
@@ -651,6 +651,7 @@ const ProjectRoute: FC = () => {
     organizationId: string;
     projectId: string;
   };
+
   const [learningFeature] = useLoaderDeferData<LearningFeature>(learningFeaturePromise);
   const [remoteFiles] = useLoaderDeferData<InsomniaFile[]>(remoteFilesPromise, projectId);
   const [checkAllProjectSyncStatus] = useLoaderDeferData<Record<string, boolean>>(projectsSyncStatusPromise);
@@ -785,7 +786,7 @@ const ProjectRoute: FC = () => {
         presence: projectPresence,
         hasUncommittedOrUnpushedChanges:
           checkAllProjectSyncStatus?.[project._id] ||
-          project.gitRepository?.hasUncommittedChanges ||
+          (project.gitRepository?.status.pending ?? 0) > 0 ||
           project.gitRepository?.hasUnpushedChanges,
       };
     });


### PR DESCRIPTION
# Overview

Currently when content changes because of changes coming through git, the code editor doesn't reflect them immediately but requires another update to happen.

## Highlights:
- [x] Introduces a new property in the gitRepository model `statusIdentifier` that holds a hash of the latest commit alongside any changes that are not commited yet in git
- [x] The identifier gets updated when any operations related to git happen in git service.
- [x] We use this identifier in the code-editor key that updates it's state if it changes and therefore displays up to date content in these scenarios

Closes INS-5227, INS-5626