### PR TITLE
JSON environment is not saved when json format becomes valid for the first time[INS-5894]

### DIFF
--- a/packages/insomnia/src/ui/components/editors/environment-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/environment-editor.tsx
@@ -24,6 +24,7 @@ export interface EnvironmentEditorHandle {
 export const EnvironmentEditor = forwardRef<EnvironmentEditorHandle, Props>(
   ({ environmentInfo, onBlur, onChange }, ref) => {
     const editorRef = useRef<CodeEditorHandle>(null);
+    const editorErrorRef = useRef('');
     const [error, setError] = useState('');
     const getValue = useCallback(() => {
       // @ts-expect-error -- current can be null
@@ -41,11 +42,16 @@ export const EnvironmentEditor = forwardRef<EnvironmentEditorHandle, Props>(
     useImperativeHandle(
       ref,
       () => ({
-        isValid: () => !error,
+        isValid: () => !editorErrorRef.current,
         getValue,
       }),
-      [error, getValue],
+      [getValue],
     );
+
+    const updateEditorError = (message: string) => {
+      editorErrorRef.current = message;
+      setError(message);
+    };
 
     const defaultValue = orderedJSON.stringify(
       environmentInfo.object,
@@ -60,7 +66,7 @@ export const EnvironmentEditor = forwardRef<EnvironmentEditorHandle, Props>(
           autoPrettify
           enableNunjucks
           onChange={() => {
-            setError('');
+            updateEditorError('');
             try {
               const value = getValue();
               // Check for invalid key names
@@ -68,13 +74,13 @@ export const EnvironmentEditor = forwardRef<EnvironmentEditorHandle, Props>(
                 // Check root and nested properties
                 const err = checkNestedKeys(value.object);
                 if (err) {
-                  setError(err);
+                  updateEditorError(err);
                 } else {
                   onChange?.(value);
                 }
               }
             } catch (err) {
-              setError(err.message);
+              updateEditorError(err.message);
             }
           }}
           defaultValue={defaultValue}


### PR DESCRIPTION
**Reproduce Step**:
1. Existing JSON environment:
```
{"foo": "bar"}
```
2.Insert a new row(Invalid JSON since comma is missing for the first line)
```
{
"foo": "bar"
"foo1": "bar"
}
```
3.Add the missing comma and close the editor
```
{
"foo": "bar",
"foo1": "bar"
}
```
4.The environment has not been saved

The root cause is that when json becomes valid for the first time, the **isValid()** ref still returns the false since error state is not updated yet. 
Add a new ref to save the error message and  **isValid()** ref will use the ref to detect if the json content is valid or not.
