### PR TITLE
fix: squirrel windows can not start the new version after update - [INS-856]

### DIFF
--- a/packages/insomnia/src/cpp/insomnia.cpp
+++ b/packages/insomnia/src/cpp/insomnia.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <string>
 #include <windows.h>
+#include <filesystem>
 
 const wchar_t *INSOMNIA_VERSION = L"__VERSION__";
 
@@ -122,7 +123,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
     // Squirrel.Windows install
     std::wstring shortcut = QuotePathIfNeeded(insomniaExecutable);
-    std::wstring args = std::wstring(L"--createShortcut=") + shortcut;
+    std::wstring shortcutTarget = std::filesystem::path(shortcut).filename().wstring();
+    ::DebugLog((L"Shortcut target: " + shortcutTarget).c_str());
+    std::wstring args = std::wstring(L"--createShortcut=") + shortcutTarget;
     ::ShellExecuteW(0, L"open", updatePath.c_str(), args.c_str(), NULL, SW_HIDE);
 
     return 0;
@@ -134,7 +137,9 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
   } else if (cmdLine.find(SQUIRREL_UNINSTALL) != std::wstring::npos) {
     // Squirrel.Windows uninstall
     std::wstring shortcut = QuotePathIfNeeded(insomniaExecutable);
-    std::wstring args = std::wstring(L"--removeShortcut=") + shortcut;
+    std::wstring shortcutTarget = std::filesystem::path(shortcut).filename().wstring();
+    ::DebugLog((L"Shortcut target: " + shortcutTarget).c_str());
+    std::wstring args = std::wstring(L"--removeShortcut=") + shortcutTarget;
     ::ShellExecuteW(0, L"open", updatePath.c_str(), args.c_str(), NULL, SW_HIDE);
     ::DebugLog(L"Squirrel.Windows uninstall");
 

--- a/packages/insomnia/src/main/updates.ts
+++ b/packages/insomnia/src/main/updates.ts
@@ -1,8 +1,8 @@
+import { spawn } from 'node:child_process';
 import { promises as fsPromise } from 'node:fs';
 import path from 'node:path';
 
-import { autoUpdater, BrowserWindow, dialog, app } from 'electron';
-import { spawn } from 'node:child_process';
+import { app, autoUpdater, BrowserWindow, dialog } from 'electron';
 
 import { CHECK_FOR_UPDATES_INTERVAL, getAppId, getAppVersion, isDevelopment, UpdateURL } from '../common/constants';
 import { delay } from '../common/misc';
@@ -113,9 +113,9 @@ export const init = async () => {
         if (returnValue.response === 0) {
           const updateExe = path.resolve(path.dirname(process.execPath), '..', 'Update.exe');
           spawn(updateExe, ['--processStartAndWait', 'Insomnia.exe'], {
-                  detached: true,
-                  windowsHide: true
-                });
+            detached: true,
+            windowsHide: true,
+          });
           app.quit();
         }
       });

--- a/packages/insomnia/src/main/updates.ts
+++ b/packages/insomnia/src/main/updates.ts
@@ -1,7 +1,8 @@
 import { promises as fsPromise } from 'node:fs';
 import path from 'node:path';
 
-import { autoUpdater, BrowserWindow, dialog } from 'electron';
+import { autoUpdater, BrowserWindow, dialog, app } from 'electron';
+import { spawn } from 'node:child_process';
 
 import { CHECK_FOR_UPDATES_INTERVAL, getAppId, getAppVersion, isDevelopment, UpdateURL } from '../common/constants';
 import { delay } from '../common/misc';
@@ -110,7 +111,12 @@ export const init = async () => {
       })
       .then(returnValue => {
         if (returnValue.response === 0) {
-          autoUpdater.quitAndInstall();
+          const updateExe = path.resolve(path.dirname(process.execPath), '..', 'Update.exe');
+          spawn(updateExe, ['--processStartAndWait', 'Insomnia.exe'], {
+                  detached: true,
+                  windowsHide: true
+                });
+          app.quit();
         }
       });
   });


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
This should be introduced after #8451 
Issue list:

- The shortcut target is wrong; the correct one should be `/AppData/Local/insomnia/Insomnia.exe`
- When the user clicks restart in the update modal, it can not launch the new version

This is because we copy the Insomnia.exe to Insomnia-$version.exe and then execute in the wrapper, when Squirrel try to launch the new version, it will try to open the same exe file(`path.basename(process.execPath)`) in the new version folder, but there is no that file in the new version folder.
```
[02/07/25 18:49:59] info: Program: Starting Squirrel Updater: --processStartAndWait insomnia-11.2.0.exe
[02/07/25 18:50:00] info: Program: Want to launch 'C:\Users\curry.yangkonghq.com\AppData\Local\insomnia\app-11.3.0-beta0\insomnia-11.2.0.exe'
[02/07/25 18:50:00] error: Program: File C:\Users\curry.yangkonghq.com\AppData\Local\insomnia\app-11.3.0-beta0\insomnia-11.2.0.exe doesn't exist in current release
[02/07/25 18:50:00] fatal: Finished with unhandled exception: System.ArgumentException: Value does not fall within the expected range.
   at Squirrel.Update.Program.ProcessStart(String exeName, String arguments, Boolean shouldWait)
   at Squirrel.Update.Program.executeCommandLine(String[] args)
   at Squirrel.Update.Program.main(String[] args)
```

Changes:

- Fix the short cut creation process in cpp wrapper, should same with [electron-squirrel-startup](https://github.com/mongodb-js/electron-squirrel-startup/blob/master/index.js)
- Run `update.exe  --processStartAndWait Insomnia.exe` instead of calling `quitAndInstall` in electron.autoUpdater

reference the source code in electron:
https://github.com/electron/electron/blob/5ef6897bc73fa0301df583717be8bc53485dc239/lib/browser/api/auto-updater/auto-updater-win.ts#L11