### PR TITLE
OAuth authorize using system browser [INS-817]

### DIFF
--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -130,9 +130,8 @@ export enum UpdateURL {
   windows = 'https://updates.insomnia.rest/updates/win',
 }
 
-// TODO: change this to production version
 // Oauth redirect URL
-export const getOauthRedirectUrl = () => env.OAUTH_REDIRECT_URL || 'https://app.dev.insomnia.moe/oauth/redirect';
+export const getOauthRedirectUrl = () => env.OAUTH_REDIRECT_URL || 'https://app.insomnia.rest/oauth/redirect';
 
 // API
 export const getApiBaseURL = () => env.INSOMNIA_API_URL || 'https://api.insomnia.rest';

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -130,6 +130,10 @@ export enum UpdateURL {
   windows = 'https://updates.insomnia.rest/updates/win',
 }
 
+// TODO: change this to production version
+// Oauth redirect URL
+export const getOauthRedirectUrl = () => env.OAUTH_REDIRECT_URL || 'https://app.dev.insomnia.moe/oauth/redirect';
+
 // API
 export const getApiBaseURL = () => env.INSOMNIA_API_URL || 'https://api.insomnia.rest';
 export const getMockServiceURL = () => env.INSOMNIA_MOCK_API_URL || 'https://mock.insomnia.run';

--- a/packages/insomnia/src/common/import-v5-parser.ts
+++ b/packages/insomnia/src/common/import-v5-parser.ts
@@ -156,6 +156,7 @@ const OAuth2AuthenticationSchema = z.object({
   username: z.string().optional(),
   password: z.string().optional(),
   redirectUrl: z.string().optional(),
+  useDefaultBrowser: z.boolean().optional(),
   credentialsInBody: z.boolean().optional(),
   state: z.string().optional(),
   code: z.string().optional(),

--- a/packages/insomnia/src/main.development.ts
+++ b/packages/insomnia/src/main.development.ts
@@ -116,7 +116,21 @@ app.on('ready', async () => {
 // Set as default protocol
 const defaultProtocol = `insomnia${isDevelopment() ? 'dev' : ''}`;
 const fullDefaultProtocol = `${defaultProtocol}://`;
-const defaultProtocolSuccessful = app.setAsDefaultProtocolClient(defaultProtocol);
+let defaultProtocolSuccessful: boolean;
+if (isDevelopment()) {
+  // In development, we start the app by running `electron --inspect=5858 .`
+  // So here we register the default protocol client the same way
+
+  // replace `.` with the absolute path
+  const restArgv = process.argv.slice(1).map(arg => (arg === '.' ? path.resolve('.') : arg));
+  defaultProtocolSuccessful = app.setAsDefaultProtocolClient(
+    defaultProtocol,
+    process.execPath, // This is the path to the Electron executable
+    restArgv, // This is the rest of the arguments passed to the Electron app
+  );
+} else {
+  defaultProtocolSuccessful = app.setAsDefaultProtocolClient(defaultProtocol);
+}
 if (defaultProtocolSuccessful) {
   console.log(`[electron client protocol] successfully set default protocol '${fullDefaultProtocol}'`);
 } else {

--- a/packages/insomnia/src/main/authorizeUserInDefaultBrowser.ts
+++ b/packages/insomnia/src/main/authorizeUserInDefaultBrowser.ts
@@ -1,0 +1,35 @@
+const { shell } = require('electron');
+
+let pendingOAuthResolver: ((code: string) => void) | null = null;
+let pendingOAuthRejector: ((err: Error) => void) | null = null;
+
+function clearPendingResolverAndRejector() {
+  pendingOAuthResolver = null;
+  pendingOAuthRejector = null;
+}
+
+export async function authorizeUserInDefaultBrowser({ url }: { url: string }) {
+  if (pendingOAuthRejector) {
+    pendingOAuthRejector(new Error('Canceled by new OAuth request'));
+    clearPendingResolverAndRejector();
+  }
+
+  return new Promise<string>((resolve, reject) => {
+    pendingOAuthResolver = resolve;
+    pendingOAuthRejector = reject;
+
+    shell.openExternal(url).catch((err: Error) => {
+      reject(new Error(`Failed to open default browser: ${err?.message}`));
+      clearPendingResolverAndRejector();
+    });
+  });
+}
+
+export function onDefaultBrowserOAuthRedirect({ url }: { url: string }) {
+  try {
+    if (pendingOAuthResolver) {
+      pendingOAuthResolver(url);
+      clearPendingResolverAndRejector();
+    }
+  } catch (e) {}
+}

--- a/packages/insomnia/src/main/authorizeUserInDefaultBrowser.ts
+++ b/packages/insomnia/src/main/authorizeUserInDefaultBrowser.ts
@@ -33,3 +33,12 @@ export function onDefaultBrowserOAuthRedirect({ url }: { url: string }) {
     }
   } catch (e) {}
 }
+
+export function cancelAuthorizationInDefaultBrowser(reason = '') {
+  try {
+    if (pendingOAuthRejector) {
+      pendingOAuthRejector(new Error(reason));
+      clearPendingResolverAndRejector();
+    }
+  } catch (e) {}
+}

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -16,6 +16,7 @@ import { invariant } from '../../utils/invariant';
 export type HandleChannels =
   | 'authorizeUserInDefaultBrowser'
   | 'onDefaultBrowserOAuthRedirect'
+  | 'cancelAuthorizationInDefaultBrowser'
   | 'authorizeUserInWindow'
   | 'backup'
   | 'curl.event.findMany'

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -14,6 +14,8 @@ import type { extractNunjucksTagFromCoords } from '../../templating/utils';
 import { invariant } from '../../utils/invariant';
 
 export type HandleChannels =
+  | 'authorizeUserInDefaultBrowser'
+  | 'onDefaultBrowserOAuthRedirect'
   | 'authorizeUserInWindow'
   | 'backup'
   | 'curl.event.findMany'

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -19,6 +19,7 @@ import type { HiddenBrowserWindowBridgeAPI } from '../../hidden-window';
 import * as models from '../../models';
 import type { SegmentEvent } from '../analytics';
 import { trackPageView, trackSegmentEvent } from '../analytics';
+import { authorizeUserInDefaultBrowser, onDefaultBrowserOAuthRedirect } from '../authorizeUserInDefaultBrowser';
 import { authorizeUserInWindow } from '../authorizeUserInWindow';
 import { backup, restoreBackup } from '../backup';
 import type { GitServiceAPI } from '../git-service';
@@ -52,6 +53,8 @@ export interface RendererToMainBridgeAPI {
   backup: () => Promise<void>;
   restoreBackup: (version: string) => Promise<void>;
   authorizeUserInWindow: typeof authorizeUserInWindow;
+  authorizeUserInDefaultBrowser: typeof authorizeUserInDefaultBrowser;
+  onDefaultBrowserOAuthRedirect: typeof onDefaultBrowserOAuthRedirect;
   setMenuBarVisibility: (visible: boolean) => void;
   installPlugin: typeof installPlugin;
   writeFile: (options: { path: string; content: string }) => Promise<string>;
@@ -124,6 +127,13 @@ export function registerMainHandlers() {
   ipcMainHandle('authorizeUserInWindow', (_, options: Parameters<typeof authorizeUserInWindow>[0]) => {
     const { url, urlSuccessRegex, urlFailureRegex, sessionId } = options;
     return authorizeUserInWindow({ url, urlSuccessRegex, urlFailureRegex, sessionId });
+  });
+
+  ipcMainHandle('authorizeUserInDefaultBrowser', (_, options: Parameters<typeof authorizeUserInDefaultBrowser>[0]) => {
+    return authorizeUserInDefaultBrowser(options);
+  });
+  ipcMainHandle('onDefaultBrowserOAuthRedirect', (_, options: Parameters<typeof onDefaultBrowserOAuthRedirect>[0]) => {
+    return onDefaultBrowserOAuthRedirect(options);
   });
 
   ipcMainHandle('writeFile', async (_, options: { path: string; content: string }) => {

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -19,7 +19,11 @@ import type { HiddenBrowserWindowBridgeAPI } from '../../hidden-window';
 import * as models from '../../models';
 import type { SegmentEvent } from '../analytics';
 import { trackPageView, trackSegmentEvent } from '../analytics';
-import { authorizeUserInDefaultBrowser, onDefaultBrowserOAuthRedirect } from '../authorizeUserInDefaultBrowser';
+import {
+  authorizeUserInDefaultBrowser,
+  cancelAuthorizationInDefaultBrowser,
+  onDefaultBrowserOAuthRedirect,
+} from '../authorizeUserInDefaultBrowser';
 import { authorizeUserInWindow } from '../authorizeUserInWindow';
 import { backup, restoreBackup } from '../backup';
 import type { GitServiceAPI } from '../git-service';
@@ -55,6 +59,7 @@ export interface RendererToMainBridgeAPI {
   authorizeUserInWindow: typeof authorizeUserInWindow;
   authorizeUserInDefaultBrowser: typeof authorizeUserInDefaultBrowser;
   onDefaultBrowserOAuthRedirect: typeof onDefaultBrowserOAuthRedirect;
+  cancelAuthorizationInDefaultBrowser: typeof cancelAuthorizationInDefaultBrowser;
   setMenuBarVisibility: (visible: boolean) => void;
   installPlugin: typeof installPlugin;
   writeFile: (options: { path: string; content: string }) => Promise<string>;
@@ -135,6 +140,12 @@ export function registerMainHandlers() {
   ipcMainHandle('onDefaultBrowserOAuthRedirect', (_, options: Parameters<typeof onDefaultBrowserOAuthRedirect>[0]) => {
     return onDefaultBrowserOAuthRedirect(options);
   });
+  ipcMainHandle(
+    'cancelAuthorizationInDefaultBrowser',
+    (_, options: Parameters<typeof cancelAuthorizationInDefaultBrowser>[0]) => {
+      return cancelAuthorizationInDefaultBrowser(options);
+    },
+  );
 
   ipcMainHandle('writeFile', async (_, options: { path: string; content: string }) => {
     try {

--- a/packages/insomnia/src/models/request.ts
+++ b/packages/insomnia/src/models/request.ts
@@ -72,6 +72,7 @@ export interface AuthTypeOAuth2 {
   username?: string;
   password?: string;
   redirectUrl?: string;
+  useDefaultBrowser?: boolean;
   credentialsInBody?: boolean;
   state?: string;
   code?: string;

--- a/packages/insomnia/src/network/o-auth-2/constants.ts
+++ b/packages/insomnia/src/network/o-auth-2/constants.ts
@@ -32,3 +32,5 @@ export type AuthKeys =
   | 'xResponseId';
 export const PKCE_CHALLENGE_S256 = 'S256';
 export const PKCE_CHALLENGE_PLAIN = 'plain';
+
+export type OAuth2AuthorizationStatusType = 'none' | 'getting_code' | 'getting_token';

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -146,14 +146,16 @@ export const getOAuth2Token = async (
 
       let redirectedTo: string | null = null;
       if (authentication.useDefaultBrowser) {
+        const authCodeUrlStr = authCodeUrl.toString();
         uiEventBus.emit(OAUTH2_AUTHORIZATION_STATUS_CHANGE, {
           status: 'getting_code',
+          authCodeUrlStr,
         });
         // If the user has selected to use the default browser, we will open the
         // authorization URL in the default browser and wait for the user to
         // authorize the application.
         redirectedTo = await window.main.authorizeUserInDefaultBrowser({
-          url: authCodeUrl.toString(),
+          url: authCodeUrlStr,
         });
       } else {
         redirectedTo = await window.main.authorizeUserInWindow({

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -4,6 +4,7 @@ import querystring from 'node:querystring';
 import { v4 as uuidv4 } from 'uuid';
 
 import { version } from '../../../package.json';
+import { getOauthRedirectUrl } from '../../common/constants';
 import { database as db } from '../../common/database';
 import { escapeRegex } from '../../common/misc';
 import * as models from '../../models';
@@ -12,6 +13,7 @@ import type { AuthTypeOAuth2, OAuth2ResponseType, RequestHeader, RequestParamete
 import type { Request } from '../../models/request';
 import { isRequestGroup, isRequestGroupId, type RequestGroup } from '../../models/request-group';
 import type { Response } from '../../models/response';
+import uiEventBus, { OAUTH2_AUTHORIZATION_STATUS_CHANGE } from '../../ui/eventBus';
 import { invariant } from '../../utils/invariant';
 import { setDefaultProtocol } from '../../utils/url/protocol';
 import { getAuthObjectOrNull, isAuthEnabled } from '../authentication';
@@ -50,155 +52,194 @@ export const getOAuth2Token = async (
   authentication: AuthTypeOAuth2,
   forceRefresh = false,
 ): Promise<OAuth2Token | null> => {
-  const { oAuth2Token, closestAuthId } = await getExistingAccessTokenAndRefreshIfExpired(
-    requestId,
-    authentication,
-    forceRefresh,
-  );
-  if (oAuth2Token) {
-    return oAuth2Token;
-  }
-  const validGrantType = ['implicit', 'authorization_code', 'password', 'client_credentials'].includes(
-    authentication.grantType,
-  );
-  invariant(validGrantType, `Invalid grant type ${authentication.grantType}`);
-  if (authentication.grantType === 'implicit') {
-    invariant(authentication.authorizationUrl, 'Missing authorization URL');
-    const responseTypeOrFallback = authentication.responseType || 'token';
-    const hasNonce = responseTypeOrFallback === 'id_token token' || responseTypeOrFallback === 'id_token';
-    const implicitUrl = new URL(authentication.authorizationUrl);
-    [
-      { name: 'response_type', value: responseTypeOrFallback },
-      { name: 'client_id', value: authentication.clientId },
-      ...insertAuthKeyIf('redirect_uri', authentication.redirectUrl),
-      ...insertAuthKeyIf('scope', authentication.scope),
-      ...insertAuthKeyIf('state', authentication.state),
-      ...insertAuthKeyIf('audience', authentication.audience),
-      ...(hasNonce
-        ? [
-            {
-              name: 'nonce',
-              value: Math.floor(Math.random() * 9999999999999) + 1 + '',
-            },
-          ]
-        : []),
-    ].forEach(p => p.value && implicitUrl.searchParams.append(p.name, p.value));
-    const redirectedTo = await window.main.authorizeUserInWindow({
-      url: implicitUrl.toString(),
-      urlSuccessRegex: /(access_token=|id_token=)/,
-      urlFailureRegex: /(error=)/,
-      sessionId: getOAuthSession(),
-    });
-    console.log('[oauth2] Detected redirect ' + redirectedTo);
-
-    const responseUrl = new URL(redirectedTo);
-    if (responseUrl.searchParams.has('error')) {
-      const params = Object.fromEntries(responseUrl.searchParams);
-      const old = await models.oAuth2Token.getOrCreateByParentId(closestAuthId);
-      return models.oAuth2Token.update(old, transformNewAccessTokenToOauthModel(params));
+  try {
+    const { oAuth2Token, closestAuthId } = await getExistingAccessTokenAndRefreshIfExpired(
+      requestId,
+      authentication,
+      forceRefresh,
+    );
+    if (oAuth2Token) {
+      return oAuth2Token;
     }
-    const hash = responseUrl.hash.slice(1);
-    invariant(hash, 'No hash found in response URL from OAuth2 provider');
-    const data = Object.fromEntries(new URLSearchParams(hash));
+    const validGrantType = ['implicit', 'authorization_code', 'password', 'client_credentials'].includes(
+      authentication.grantType,
+    );
+    invariant(validGrantType, `Invalid grant type ${authentication.grantType}`);
+    if (authentication.grantType === 'implicit') {
+      invariant(authentication.authorizationUrl, 'Missing authorization URL');
+      const responseTypeOrFallback = authentication.responseType || 'token';
+      const hasNonce = responseTypeOrFallback === 'id_token token' || responseTypeOrFallback === 'id_token';
+      const implicitUrl = new URL(authentication.authorizationUrl);
+      [
+        { name: 'response_type', value: responseTypeOrFallback },
+        { name: 'client_id', value: authentication.clientId },
+        ...insertAuthKeyIf('redirect_uri', authentication.redirectUrl),
+        ...insertAuthKeyIf('scope', authentication.scope),
+        ...insertAuthKeyIf('state', authentication.state),
+        ...insertAuthKeyIf('audience', authentication.audience),
+        ...(hasNonce
+          ? [
+              {
+                name: 'nonce',
+                value: Math.floor(Math.random() * 9999999999999) + 1 + '',
+              },
+            ]
+          : []),
+      ].forEach(p => p.value && implicitUrl.searchParams.append(p.name, p.value));
+      const redirectedTo = await window.main.authorizeUserInWindow({
+        url: implicitUrl.toString(),
+        urlSuccessRegex: /(access_token=|id_token=)/,
+        urlFailureRegex: /(error=)/,
+        sessionId: getOAuthSession(),
+      });
+      console.log('[oauth2] Detected redirect ' + redirectedTo);
+
+      const responseUrl = new URL(redirectedTo);
+      if (responseUrl.searchParams.has('error')) {
+        const params = Object.fromEntries(responseUrl.searchParams);
+        const old = await models.oAuth2Token.getOrCreateByParentId(closestAuthId);
+        return models.oAuth2Token.update(old, transformNewAccessTokenToOauthModel(params));
+      }
+      const hash = responseUrl.hash.slice(1);
+      invariant(hash, 'No hash found in response URL from OAuth2 provider');
+      const data = Object.fromEntries(new URLSearchParams(hash));
+      const old = await models.oAuth2Token.getOrCreateByParentId(closestAuthId);
+      return models.oAuth2Token.update(
+        old,
+        transformNewAccessTokenToOauthModel({
+          ...data,
+          access_token: data.access_token || data.id_token,
+        }),
+      );
+    }
+    invariant(authentication.accessTokenUrl, 'Missing access token URL');
+    let params: RequestHeader[] = [];
+    if (authentication.grantType === 'authorization_code') {
+      invariant(authentication.authorizationUrl, 'Invalid authorization URL');
+
+      // default to S256 if usePkce is true and pkceMethod is not defined
+      const pkceMethod =
+        authentication.usePkce && !authentication.pkceMethod ? PKCE_CHALLENGE_S256 : authentication.pkceMethod;
+      const codeVerifier = authentication.usePkce ? encodePKCE(crypto.randomBytes(32)) : '';
+      const codeChallenge =
+        authentication.usePkce && pkceMethod === PKCE_CHALLENGE_S256
+          ? encodePKCE(crypto.createHash('sha256').update(codeVerifier).digest())
+          : codeVerifier;
+      const authCodeUrl = new URL(authentication.authorizationUrl);
+      const responseType: OAuth2ResponseType = 'code';
+      const redirectUrl = authentication.useDefaultBrowser ? getOauthRedirectUrl() : authentication.redirectUrl;
+      [
+        { name: 'response_type', value: responseType },
+        { name: 'client_id', value: authentication.clientId },
+        ...insertAuthKeyIf('redirect_uri', redirectUrl),
+        ...insertAuthKeyIf('scope', authentication.scope),
+        ...insertAuthKeyIf('state', authentication.state),
+        ...insertAuthKeyIf('audience', authentication.audience),
+        ...insertAuthKeyIf('resource', authentication.resource),
+        ...(codeChallenge
+          ? [
+              { name: 'code_challenge', value: codeChallenge },
+              { name: 'code_challenge_method', value: pkceMethod },
+            ]
+          : []),
+      ].forEach(p => p.value && authCodeUrl.searchParams.append(p.name, p.value));
+
+      let redirectedTo: string | null = null;
+      if (authentication.useDefaultBrowser) {
+        uiEventBus.emit(OAUTH2_AUTHORIZATION_STATUS_CHANGE, {
+          status: 'getting_code',
+        });
+        // If the user has selected to use the default browser, we will open the
+        // authorization URL in the default browser and wait for the user to
+        // authorize the application.
+        redirectedTo = await window.main.authorizeUserInDefaultBrowser({
+          url: authCodeUrl.toString(),
+        });
+      } else {
+        redirectedTo = await window.main.authorizeUserInWindow({
+          url: authCodeUrl.toString(),
+          urlSuccessRegex: authentication.redirectUrl
+            ? new RegExp(`${escapeRegex(authentication.redirectUrl)}.*([?&]code=)`, 'i')
+            : /([?&]code=)/i,
+          urlFailureRegex: authentication.redirectUrl
+            ? new RegExp(`${escapeRegex(authentication.redirectUrl)}.*([?&]error=)`, 'i')
+            : /([?&]error=)/i,
+          sessionId: getOAuthSession(),
+        });
+      }
+
+      console.log('[oauth2] Detected redirect ' + redirectedTo);
+      const redirectParams = Object.fromEntries(new URL(redirectedTo).searchParams);
+      if (redirectParams.error) {
+        const code = redirectParams.error;
+        const msg = redirectParams.error_description;
+        const uri = redirectParams.error_uri;
+        throw new Error(`OAuth 2.0 Error ${code}\n\n${msg}\n\n${uri}`);
+      }
+      console.log('[oauth2] Detected code ' + redirectParams.code);
+      params = [
+        { name: 'grant_type', value: GRANT_TYPE_AUTHORIZATION_CODE },
+        { name: 'code', value: redirectParams.code },
+        ...insertAuthKeyIf('redirect_uri', redirectUrl),
+        ...insertAuthKeyIf('state', authentication.state),
+        ...insertAuthKeyIf('audience', authentication.audience),
+        ...insertAuthKeyIf('resource', authentication.resource),
+        ...insertAuthKeyIf('code_verifier', codeVerifier),
+      ];
+    } else if (authentication.grantType === 'password') {
+      params = [
+        { name: 'grant_type', value: 'password' },
+        ...insertAuthKeyIf('username', authentication.username),
+        ...insertAuthKeyIf('password', authentication.password),
+        ...insertAuthKeyIf('scope', authentication.scope),
+        ...insertAuthKeyIf('audience', authentication.audience),
+      ];
+    } else if (authentication.grantType === 'client_credentials') {
+      params = [
+        { name: 'grant_type', value: 'client_credentials' },
+        ...insertAuthKeyIf('scope', authentication.scope),
+        ...insertAuthKeyIf('audience', authentication.audience),
+        ...insertAuthKeyIf('resource', authentication.resource),
+      ];
+    }
+    const headers = authentication.origin ? [{ name: 'Origin', value: authentication.origin }] : [];
+    if (authentication.credentialsInBody) {
+      params = [
+        ...params,
+        ...insertAuthKeyIf('client_id', authentication.clientId),
+        ...insertAuthKeyIf('client_secret', authentication.clientSecret),
+      ];
+    } else {
+      headers.push(getBasicAuthHeader(authentication.clientId, authentication.clientSecret));
+    }
+
+    if (authentication.useDefaultBrowser) {
+      uiEventBus.emit(OAUTH2_AUTHORIZATION_STATUS_CHANGE, {
+        status: 'getting_token',
+      });
+    }
+
+    const response = await sendAccessTokenRequest(requestId, authentication, params, headers);
     const old = await models.oAuth2Token.getOrCreateByParentId(closestAuthId);
+
+    if (authentication.useDefaultBrowser) {
+      uiEventBus.emit(OAUTH2_AUTHORIZATION_STATUS_CHANGE, {
+        status: 'none',
+      });
+    }
+
     return models.oAuth2Token.update(
       old,
-      transformNewAccessTokenToOauthModel({
-        ...data,
-        access_token: data.access_token || data.id_token,
-      }),
+      transformNewAccessTokenToOauthModel(await oauthResponseToAccessToken(authentication.accessTokenUrl, response)),
     );
-  }
-  invariant(authentication.accessTokenUrl, 'Missing access token URL');
-  let params: RequestHeader[] = [];
-  if (authentication.grantType === 'authorization_code') {
-    invariant(authentication.authorizationUrl, 'Invalid authorization URL');
-
-    // default to S256 if usePkce is true and pkceMethod is not defined
-    const pkceMethod =
-      authentication.usePkce && !authentication.pkceMethod ? PKCE_CHALLENGE_S256 : authentication.pkceMethod;
-    const codeVerifier = authentication.usePkce ? encodePKCE(crypto.randomBytes(32)) : '';
-    const codeChallenge =
-      authentication.usePkce && pkceMethod === PKCE_CHALLENGE_S256
-        ? encodePKCE(crypto.createHash('sha256').update(codeVerifier).digest())
-        : codeVerifier;
-    const authCodeUrl = new URL(authentication.authorizationUrl);
-    const responseType: OAuth2ResponseType = 'code';
-    [
-      { name: 'response_type', value: responseType },
-      { name: 'client_id', value: authentication.clientId },
-      ...insertAuthKeyIf('redirect_uri', authentication.redirectUrl),
-      ...insertAuthKeyIf('scope', authentication.scope),
-      ...insertAuthKeyIf('state', authentication.state),
-      ...insertAuthKeyIf('audience', authentication.audience),
-      ...insertAuthKeyIf('resource', authentication.resource),
-      ...(codeChallenge
-        ? [
-            { name: 'code_challenge', value: codeChallenge },
-            { name: 'code_challenge_method', value: pkceMethod },
-          ]
-        : []),
-    ].forEach(p => p.value && authCodeUrl.searchParams.append(p.name, p.value));
-    const redirectedTo = await window.main.authorizeUserInWindow({
-      url: authCodeUrl.toString(),
-      urlSuccessRegex: authentication.redirectUrl
-        ? new RegExp(`${escapeRegex(authentication.redirectUrl)}.*([?&]code=)`, 'i')
-        : /([?&]code=)/i,
-      urlFailureRegex: authentication.redirectUrl
-        ? new RegExp(`${escapeRegex(authentication.redirectUrl)}.*([?&]error=)`, 'i')
-        : /([?&]error=)/i,
-      sessionId: getOAuthSession(),
-    });
-    console.log('[oauth2] Detected redirect ' + redirectedTo);
-    const redirectParams = Object.fromEntries(new URL(redirectedTo).searchParams);
-    if (redirectParams.error) {
-      const code = redirectParams.error;
-      const msg = redirectParams.error_description;
-      const uri = redirectParams.error_uri;
-      throw new Error(`OAuth 2.0 Error ${code}\n\n${msg}\n\n${uri}`);
+  } catch (err) {
+    if (authentication.useDefaultBrowser) {
+      uiEventBus.emit(OAUTH2_AUTHORIZATION_STATUS_CHANGE, {
+        status: 'none',
+      });
     }
-    params = [
-      { name: 'grant_type', value: GRANT_TYPE_AUTHORIZATION_CODE },
-      { name: 'code', value: redirectParams.code },
-      ...insertAuthKeyIf('redirect_uri', authentication.redirectUrl),
-      ...insertAuthKeyIf('state', authentication.state),
-      ...insertAuthKeyIf('audience', authentication.audience),
-      ...insertAuthKeyIf('resource', authentication.resource),
-      ...insertAuthKeyIf('code_verifier', codeVerifier),
-    ];
-  } else if (authentication.grantType === 'password') {
-    params = [
-      { name: 'grant_type', value: 'password' },
-      ...insertAuthKeyIf('username', authentication.username),
-      ...insertAuthKeyIf('password', authentication.password),
-      ...insertAuthKeyIf('scope', authentication.scope),
-      ...insertAuthKeyIf('audience', authentication.audience),
-    ];
-  } else if (authentication.grantType === 'client_credentials') {
-    params = [
-      { name: 'grant_type', value: 'client_credentials' },
-      ...insertAuthKeyIf('scope', authentication.scope),
-      ...insertAuthKeyIf('audience', authentication.audience),
-      ...insertAuthKeyIf('resource', authentication.resource),
-    ];
+    throw err;
   }
-  const headers = authentication.origin ? [{ name: 'Origin', value: authentication.origin }] : [];
-  if (authentication.credentialsInBody) {
-    params = [
-      ...params,
-      ...insertAuthKeyIf('client_id', authentication.clientId),
-      ...insertAuthKeyIf('client_secret', authentication.clientSecret),
-    ];
-  } else {
-    headers.push(getBasicAuthHeader(authentication.clientId, authentication.clientSecret));
-  }
-
-  const response = await sendAccessTokenRequest(requestId, authentication, params, headers);
-  const old = await models.oAuth2Token.getOrCreateByParentId(closestAuthId);
-  return models.oAuth2Token.update(
-    old,
-    transformNewAccessTokenToOauthModel(await oauthResponseToAccessToken(authentication.accessTokenUrl, response)),
-  );
 };
 // 1. get token from db and return if valid
 // 2. if expired, and no refresh token return null
@@ -228,6 +269,9 @@ async function getExistingAccessTokenAndRefreshIfExpired(
   if (!isExpired && !forceRefresh) {
     return { oAuth2Token: token, closestAuthId };
   }
+
+  // token is expired
+
   if (!token.refreshToken) {
     return { oAuth2Token: null, closestAuthId };
   }
@@ -247,6 +291,7 @@ async function getExistingAccessTokenAndRefreshIfExpired(
   } else {
     headers.push(getBasicAuthHeader(authentication.clientId, authentication.clientSecret));
   }
+  // Why not send headers here?
   const response = await sendAccessTokenRequest(requestId, authentication, params, []);
 
   const statusCode = response.statusCode || 0;

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -124,6 +124,7 @@ const main: Window['main'] = {
   authorizeUserInWindow: options => ipcRenderer.invoke('authorizeUserInWindow', options),
   authorizeUserInDefaultBrowser: options => ipcRenderer.invoke('authorizeUserInDefaultBrowser', options),
   onDefaultBrowserOAuthRedirect: options => ipcRenderer.invoke('onDefaultBrowserOAuthRedirect', options),
+  cancelAuthorizationInDefaultBrowser: options => ipcRenderer.invoke('cancelAuthorizationInDefaultBrowser', options),
   setMenuBarVisibility: options => ipcRenderer.send('setMenuBarVisibility', options),
   installPlugin: (lookupName: string, allowScopedPackageNames = false) =>
     ipcRenderer.invoke('installPlugin', lookupName, allowScopedPackageNames),

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -122,6 +122,8 @@ const main: Window['main'] = {
   backup: () => ipcRenderer.invoke('backup'),
   restoreBackup: options => ipcRenderer.invoke('restoreBackup', options),
   authorizeUserInWindow: options => ipcRenderer.invoke('authorizeUserInWindow', options),
+  authorizeUserInDefaultBrowser: options => ipcRenderer.invoke('authorizeUserInDefaultBrowser', options),
+  onDefaultBrowserOAuthRedirect: options => ipcRenderer.invoke('onDefaultBrowserOAuthRedirect', options),
   setMenuBarVisibility: options => ipcRenderer.send('setMenuBarVisibility', options),
   installPlugin: (lookupName: string, allowScopedPackageNames = false) =>
     ipcRenderer.invoke('installPlugin', lookupName, allowScopedPackageNames),

--- a/packages/insomnia/src/ui/components/editors/auth/components/auth-input-row.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/components/auth-input-row.tsx
@@ -1,4 +1,4 @@
-import React, { type ComponentProps, type FC, type ReactNode, useCallback } from 'react';
+import React, { type ComponentProps, type FC, type ReactNode, useCallback, useEffect, useRef } from 'react';
 import { useRouteLoaderData } from 'react-router';
 import { useToggle } from 'react-use';
 
@@ -7,7 +7,7 @@ import { useRequestGroupPatcher, useRequestPatcher } from '../../../../hooks/use
 import type { RequestLoaderData } from '../../../../routes/$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId';
 import type { RequestGroupLoaderData } from '../../../../routes/$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.$requestGroupId';
 import { useRootLoaderData } from '../../../../routes/root';
-import { OneLineEditor } from '../../../codemirror/one-line-editor';
+import { OneLineEditor, type OneLineEditorHandle } from '../../../codemirror/one-line-editor';
 import { AuthRow } from './auth-row';
 
 interface Props extends Pick<ComponentProps<typeof OneLineEditor>, 'getAutocompleteConstants'> {
@@ -16,6 +16,8 @@ interface Props extends Pick<ComponentProps<typeof OneLineEditor>, 'getAutocompl
   help?: ReactNode;
   mask?: boolean;
   disabled?: boolean;
+  overrideValueWhenDisabled?: string;
+  copyBtn?: boolean; // Whether to show the copy button
 }
 
 export const AuthInputRow: FC<Props> = ({
@@ -25,6 +27,8 @@ export const AuthInputRow: FC<Props> = ({
   mask,
   help,
   disabled = false,
+  overrideValueWhenDisabled,
+  copyBtn = false,
 }) => {
   const { settings } = useRootLoaderData();
   const { showPasswords } = settings;
@@ -38,16 +42,62 @@ export const AuthInputRow: FC<Props> = ({
   const canBeMasked = !showPasswords && mask;
   const isMasked = canBeMasked && masked;
 
+  // @ts-expect-error -- garbage abstraction
+  const propVal = authentication[property] || '';
+
+  // Use a ref to keep track of the original value, so we can restore it when the editor is enabled
+  const propValRef = useRef(propVal);
+  useEffect(() => {
+    propValRef.current = propVal;
+  }, [propVal]);
+
   const onChange = useCallback(
-    (value: string) => patcher(_id, { authentication: { ...authentication, [property]: value } }),
-    [patcher, _id, authentication, property],
+    (value: string) => {
+      if (disabled) {
+        // If the editor is disabled, we don't want to patch the value
+        return;
+      }
+      patcher(_id, { authentication: { ...authentication, [property]: value } });
+    },
+    [patcher, _id, authentication, property, disabled],
   );
 
   const id = toKebabCase(label);
 
+  const editorRef = useRef<OneLineEditorHandle>(null);
+
+  useEffect(() => {
+    if (overrideValueWhenDisabled) {
+      if (disabled) {
+        // If the editor is disabled, we want to set the value to the override value
+        editorRef.current?.setValue(overrideValueWhenDisabled);
+      } else {
+        // If the editor is enabled, we want to restore the original value
+        editorRef.current?.setValue(propValRef.current);
+      }
+    }
+  }, [disabled, overrideValueWhenDisabled]);
+
+  const onCopy = useCallback(
+    async (event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      let content = propVal;
+      if (overrideValueWhenDisabled && disabled) {
+        content = overrideValueWhenDisabled;
+      }
+
+      if (content) {
+        window.clipboard.writeText(content);
+      }
+    },
+    [overrideValueWhenDisabled, disabled, propVal],
+  );
+
   return (
     <AuthRow labelFor={id} label={label} help={help} disabled={disabled}>
       <OneLineEditor
+        ref={editorRef}
         id={id}
         type={isMasked ? 'password' : 'text'}
         onChange={onChange}
@@ -65,6 +115,11 @@ export const AuthInputRow: FC<Props> = ({
           )}
         </button>
       ) : null}
+      {copyBtn && (
+        <button className="btn btn--super-super-compact pointer btn--forever-enabled" onClick={onCopy}>
+          <i className="fa fa-copy" data-testid="reveal-password-icon" />
+        </button>
+      )}
     </AuthRow>
   );
 };

--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -1,7 +1,7 @@
 import React, { type ChangeEvent, type FC, type ReactNode, useEffect, useMemo, useState } from 'react';
 import { useRouteLoaderData } from 'react-router';
 
-import type { AUTH_OAUTH_2 } from '../../../../common/constants';
+import { type AUTH_OAUTH_2, getOauthRedirectUrl } from '../../../../common/constants';
 import { toKebabCase } from '../../../../common/misc';
 import accessTokenUrls from '../../../../datasets/access-token-urls';
 import authorizationUrls from '../../../../datasets/authorization-urls';
@@ -126,7 +126,24 @@ const getFields = (authentication: Extract<RequestAuthentication, { type: typeof
       label="Redirect URL"
       property="redirectUrl"
       key="redirectUrl"
-      help="This can be whatever you want or need it to be. Insomnia will automatically detect a redirect in the client browser window and extract the code from the redirected URL."
+      help={
+        authentication.useDefaultBrowser
+          ? 'The callback URL is provided by Insomnia and cannot be modified when authorizing via the default browser.'
+          : 'This can be whatever you want or need it to be. Insomnia will automatically detect a redirect in the client browser window and extract the code from the redirected URL.'
+      }
+      disabled={authentication.useDefaultBrowser}
+      overrideValueWhenDisabled={getOauthRedirectUrl()}
+      copyBtn={authentication.useDefaultBrowser}
+    />
+  );
+  const useDefaultBrowser = (
+    <AuthToggleRow
+      label="Using default browser"
+      property="useDefaultBrowser"
+      key="useDefaultBrowser"
+      help="You must use the redirect URL provided by Insomnia when using the default browser. You also need to set the redirect URL in your OAuth 2 provider to match the one provided by Insomnia."
+      onTitle="Click to use built-in browser"
+      offTitle="Click to use default browser"
     />
   );
   const state = <AuthInputRow label="State" property="state" key="state" />;
@@ -182,6 +199,7 @@ const getFields = (authentication: Extract<RequestAuthentication, { type: typeof
     authorizationUrl,
     accessTokenUrl,
     redirectUri,
+    useDefaultBrowser,
     state,
     scope,
     username,
@@ -204,6 +222,7 @@ const getFieldsForGrantType = (authentication: Extract<RequestAuthentication, { 
     authorizationUrl,
     accessTokenUrl,
     redirectUri,
+    useDefaultBrowser,
     state,
     scope,
     username,
@@ -222,7 +241,16 @@ const getFieldsForGrantType = (authentication: Extract<RequestAuthentication, { 
   let advanced: ReactNode[] = [];
 
   if (grantType === GRANT_TYPE_AUTHORIZATION_CODE) {
-    basic = [authorizationUrl, accessTokenUrl, clientId, clientSecret, usePkce, pkceMethod, redirectUri];
+    basic = [
+      authorizationUrl,
+      accessTokenUrl,
+      clientId,
+      clientSecret,
+      usePkce,
+      pkceMethod,
+      redirectUri,
+      useDefaultBrowser,
+    ];
 
     advanced = [scope, state, credentialsInBody, tokenPrefix, audience, resource, origin];
   } else if (grantType === GRANT_TYPE_CLIENT_CREDENTIALS) {

--- a/packages/insomnia/src/ui/components/modals/oauth-authorization-status-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/oauth-authorization-status-modal.tsx
@@ -1,23 +1,28 @@
 import React, { type FC, useEffect, useRef, useState } from 'react';
 
 import type { OAuth2AuthorizationStatusType } from '../../../network/o-auth-2/constants';
+import { invariant } from '../../../utils/invariant';
 import uiEventBus, { OAUTH2_AUTHORIZATION_STATUS_CHANGE } from '../../eventBus';
 import { Modal, type ModalHandle } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
-
-const statusTextMap: Record<OAuth2AuthorizationStatusType, string> = {
-  none: 'Not in Authorization',
-  getting_code: 'See your browser to finish authorization ...',
-  getting_token: 'Getting access token ...',
-};
+import { Icon } from '../icon';
 
 export const OAuthAuthorizationStatusModal: FC = () => {
   const [status, setStatus] = useState<OAuth2AuthorizationStatusType>('none');
+  const [authCodeUrlStr, setAuthCodeUrlStr] = useState<string | undefined>();
+  const [submitting, setSubmitting] = useState<boolean>(false);
 
   useEffect(() => {
-    const handleStatusChange = ({ status: newStatus }: { status: OAuth2AuthorizationStatusType }) => {
+    const handleStatusChange = ({
+      status: newStatus,
+      authCodeUrlStr,
+    }: {
+      status: OAuth2AuthorizationStatusType;
+      authCodeUrlStr?: string;
+    }) => {
       setStatus(newStatus);
+      setAuthCodeUrlStr(authCodeUrlStr);
     };
     uiEventBus.on(OAUTH2_AUTHORIZATION_STATUS_CHANGE, handleStatusChange);
     return () => {
@@ -35,13 +40,82 @@ export const OAuthAuthorizationStatusModal: FC = () => {
       modalRef.current?.hide();
     } else if (status === 'getting_code') {
       modalRef.current?.show();
+      setSubmitting(false);
     }
   }, [status]);
 
   return (
-    <Modal centered ref={modalRef}>
+    <Modal centered ref={modalRef} onHide={() => {
+      window.main.cancelAuthorizationInDefaultBrowser('Canceled by user.');
+    }}>
       <ModalHeader>OAuth 2.0 Authorization</ModalHeader>
-      <ModalBody>{statusTextMap[status]}</ModalBody>
+      <ModalBody>
+        {status === 'none' && 'Not in Authorization'}
+        {status === 'getting_code' && (
+          <>
+            <p className="text-[rgba(var(--color-font-rgb),0.8))] text-start">
+              See your browser to finish authorization, if the browser didn’t open automatically, copy and paste this
+              URL into your browser to authorize.
+            </p>
+            <div className="form-control form-control--outlined no-pad-top flex">
+              <input type="text" value={authCodeUrlStr} style={{ marginRight: 'var(--padding-sm)' }} readOnly />
+              <button
+                className="btn btn--super-compact btn--outlined"
+                onClick={() => {
+                  window.clipboard.writeText(authCodeUrlStr as string);
+                }}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 'var(--padding-xs)',
+                }}
+              >
+                <i className="fa fa-clipboard" aria-hidden="true" />
+                Copy
+              </button>
+            </div>
+            <p className="text-[rgba(var(--color-font-rgb),0.8))] text-start">
+              If the Insomnia app doesn’t open automatically after you complete the authorization in your browser,
+              please copy the full redirect URL from your browser’s address bar and paste it below.
+            </p>
+            <form
+              onSubmit={e => {
+                e.preventDefault();
+                const form = e.currentTarget;
+                const data = new FormData(form);
+
+                const url = data.get('url');
+                invariant(typeof url === 'string', 'Expected code to be a string');
+                if (url.length === 0) {
+                  return;
+                }
+                setSubmitting(true);
+                window.main.onDefaultBrowserOAuthRedirect({
+                  url,
+                });
+              }}
+            >
+              <div className="form-control form-control--outlined no-pad-top" style={{ display: 'flex' }}>
+                <input type="text" name="url" style={{ marginRight: 'var(--padding-sm)' }} />
+                <button
+                  className="btn btn--super-compact btn--outlined"
+                  type="submit"
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 'var(--padding-xs)',
+                  }}
+                  disabled={submitting}
+                >
+                  <Icon icon={submitting ? 'spinner' : 'sign-in'} className={submitting ? 'animate-spin' : ''} />
+                  Proceed
+                </button>
+              </div>
+            </form>
+          </>
+        )}
+        {status === 'getting_token' && 'Getting access token ...'}
+      </ModalBody>
     </Modal>
   );
 };

--- a/packages/insomnia/src/ui/components/modals/oauth-authorization-status-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/oauth-authorization-status-modal.tsx
@@ -45,9 +45,13 @@ export const OAuthAuthorizationStatusModal: FC = () => {
   }, [status]);
 
   return (
-    <Modal centered ref={modalRef} onHide={() => {
-      window.main.cancelAuthorizationInDefaultBrowser('Canceled by user.');
-    }}>
+    <Modal
+      centered
+      ref={modalRef}
+      onHide={() => {
+        window.main.cancelAuthorizationInDefaultBrowser('Canceled by user.');
+      }}
+    >
       <ModalHeader>OAuth 2.0 Authorization</ModalHeader>
       <ModalBody>
         {status === 'none' && 'Not in Authorization'}
@@ -76,7 +80,7 @@ export const OAuthAuthorizationStatusModal: FC = () => {
             </div>
             <p className="text-[rgba(var(--color-font-rgb),0.8))] text-start">
               If the Insomnia app doesn’t open automatically after you complete the authorization in your browser,
-              please copy the full redirect URL from your browser’s address bar and paste it below.
+              please copy the full redirect URL showed in the redirect page and paste it below.
             </p>
             <form
               onSubmit={e => {

--- a/packages/insomnia/src/ui/components/modals/oauth-authorization-status-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/oauth-authorization-status-modal.tsx
@@ -1,0 +1,47 @@
+import React, { type FC, useEffect, useRef, useState } from 'react';
+
+import type { OAuth2AuthorizationStatusType } from '../../../network/o-auth-2/constants';
+import uiEventBus, { OAUTH2_AUTHORIZATION_STATUS_CHANGE } from '../../eventBus';
+import { Modal, type ModalHandle } from '../base/modal';
+import { ModalBody } from '../base/modal-body';
+import { ModalHeader } from '../base/modal-header';
+
+const statusTextMap: Record<OAuth2AuthorizationStatusType, string> = {
+  none: 'Not in Authorization',
+  getting_code: 'See your browser to finish authorization ...',
+  getting_token: 'Getting access token ...',
+};
+
+export const OAuthAuthorizationStatusModal: FC = () => {
+  const [status, setStatus] = useState<OAuth2AuthorizationStatusType>('none');
+
+  useEffect(() => {
+    const handleStatusChange = ({ status: newStatus }: { status: OAuth2AuthorizationStatusType }) => {
+      setStatus(newStatus);
+    };
+    uiEventBus.on(OAUTH2_AUTHORIZATION_STATUS_CHANGE, handleStatusChange);
+    return () => {
+      uiEventBus.off(OAUTH2_AUTHORIZATION_STATUS_CHANGE, handleStatusChange);
+    };
+  }, []);
+
+  const modalRef = useRef<ModalHandle>(null);
+  useEffect(() => {
+    modalRef.current?.show();
+  }, []);
+
+  useEffect(() => {
+    if (status === 'none') {
+      modalRef.current?.hide();
+    } else if (status === 'getting_code') {
+      modalRef.current?.show();
+    }
+  }, [status]);
+
+  return (
+    <Modal centered ref={modalRef}>
+      <ModalHeader>OAuth 2.0 Authorization</ModalHeader>
+      <ModalBody>{statusTextMap[status]}</ModalBody>
+    </Modal>
+  );
+};

--- a/packages/insomnia/src/ui/css/main.css
+++ b/packages/insomnia/src/ui/css/main.css
@@ -930,7 +930,7 @@ strong {
 .form-control.form-control--inactive textarea,
 .form-control.form-control--inactive .input,
 .form-control.form-control--inactive input,
-.form-control.form-control--inactive .btn,
+.form-control.form-control--inactive .btn:not(.btn--forever-enabled),
 .form-control.form-control--inactive select {
   border-style: dashed;
   opacity: var(--opacity-subtle);

--- a/packages/insomnia/src/ui/eventBus.ts
+++ b/packages/insomnia/src/ui/eventBus.ts
@@ -1,10 +1,13 @@
 type EventHandler = (...args: any[]) => void;
 
-type UIEventType = 'CLOSE_TAB' | 'CHANGE_ACTIVE_ENV';
+export const OAUTH2_AUTHORIZATION_STATUS_CHANGE = 'OAUTH2_AUTHORIZATION_STATUS_CHANGE';
+
+type UIEventType = 'CLOSE_TAB' | 'CHANGE_ACTIVE_ENV' | typeof OAUTH2_AUTHORIZATION_STATUS_CHANGE;
 class EventBus {
   private events: Record<UIEventType, EventHandler[]> = {
     CLOSE_TAB: [],
     CHANGE_ACTIVE_ENV: [],
+    [OAUTH2_AUTHORIZATION_STATUS_CHANGE]: [],
   };
 
   // Subscribe to event

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -1612,6 +1612,11 @@ async function renderApp() {
                 path: 'clear-vault-key',
                 action: async args => (await import('./routes/auth.clear-vault-key')).action(args),
               },
+              {
+                path: 'defaultBrowserOauthRedirect',
+                action: async (...args) =>
+                  (await import('./routes/auth.systemBrowserOAuth')).defaultBrowserOAuthRedirect(...args),
+              },
             ],
           },
         ],

--- a/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -91,6 +91,7 @@ import { CookiesModal } from '../components/modals/cookies-modal';
 import { ErrorModal } from '../components/modals/error-modal';
 import { GenerateCodeModal } from '../components/modals/generate-code-modal';
 import { ImportModal } from '../components/modals/import-modal/import-modal';
+import { OAuthAuthorizationStatusModal } from '../components/modals/oauth-authorization-status-modal';
 import { PasteCurlModal } from '../components/modals/paste-curl-modal';
 import { PromptModal } from '../components/modals/prompt-modal';
 import { RequestSettingsModal } from '../components/modals/request-settings-modal';
@@ -1255,6 +1256,7 @@ export const Debug: FC = () => {
                       </Panel>
                     </>
                   ) : null}
+                  <OAuthAuthorizationStatusModal />
                 </>
               }
             />

--- a/packages/insomnia/src/ui/routes/auth.systemBrowserOAuth.ts
+++ b/packages/insomnia/src/ui/routes/auth.systemBrowserOAuth.ts
@@ -1,0 +1,10 @@
+import { type ActionFunction } from 'react-router';
+
+export const defaultBrowserOAuthRedirect: ActionFunction = async ({ request }) => {
+  const { redirectUrl } = (await request.json()) as { redirectUrl: string };
+  await window.main.onDefaultBrowserOAuthRedirect({
+    url: redirectUrl,
+  });
+
+  return null;
+};

--- a/packages/insomnia/src/ui/routes/root.tsx
+++ b/packages/insomnia/src/ui/routes/root.tsx
@@ -215,6 +215,19 @@ const Root = () => {
         }
         return navigate(`/organization/${params.organizationId}`);
       }
+      if (urlWithoutParams === 'insomnia://system-browser-oauth/redirect') {
+        const { url: redirectUrl } = params;
+        return actionFetcher.submit(
+          {
+            redirectUrl,
+          },
+          {
+            action: '/auth/defaultBrowserOauthRedirect',
+            method: 'POST',
+            encType: 'application/json',
+          },
+        );
+      }
       console.log(`Unknown deep link: ${url}`);
     });
   }, [actionFetcher, navigate]);


### PR DESCRIPTION
Use the default browser for the OAuth flow instead of an in-client browser
Close [INS-817](https://konghq.atlassian.net/browse/INS-817)

[INS-817]: https://konghq.atlassian.net/browse/INS-817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Refer to [this doc](https://konghq.atlassian.net/wiki/spaces/ST/pages/4788387901/Use+the+default+browser+for+OAuth2+authorization) for detailed design and implementation.

Closes https://github.com/Kong/insomnia/issues/8303
Closes https://github.com/Kong/insomnia/discussions/5838