### PR TITLE
fix(LintProcess): Ensure subsequent lint commands work

### DIFF
--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -12,6 +12,7 @@ import {
   shell,
   utilityProcess,
 } from 'electron';
+import type { UtilityProcess } from 'electron/main';
 import iconv from 'iconv-lite';
 
 import type { HiddenBrowserWindowBridgeAPI } from '../../hidden-window';
@@ -73,7 +74,7 @@ export interface RendererToMainBridgeAPI {
   lintSpec: (options: {
     documentContent: string;
     rulesetPath: string;
-  }) => Promise<{ diagnostics?: ISpectralDiagnostic[]; error?: string }>;
+  }) => Promise<{ diagnostics?: ISpectralDiagnostic[]; error?: string; cancelled?: boolean }>;
   database: {
     caCertificate: {
       create: (options: { parentId: string; path: string }) => Promise<string>;
@@ -130,6 +131,7 @@ export function registerMainHandlers() {
       throw new Error(err);
     }
   });
+
   ipcMainHandle('lintSpec', async (_, options: { documentContent: string; rulesetPath: string }) => {
     const { documentContent, rulesetPath } = options;
     return new Promise((resolve, reject) => {
@@ -139,24 +141,28 @@ export function registerMainHandlers() {
       if (lintProcess) {
         lintProcess.kill();
       }
+
       lintProcess = utilityProcess.fork(path.join(__dirname, 'main/lint-process.mjs'));
 
-      lintProcess.on('exit', code => {
+      let process: UtilityProcess | null = lintProcess!;
+
+      process.on('exit', code => {
         console.log('[lint-process] exited with code:', code);
-        resolve({ diagnostics: [] });
-      });
-      lintProcess.on('message', msg => {
-        resolve(msg);
-        lintProcess?.kill();
-        lintProcess = null;
+        resolve({ cancelled: true });
       });
 
-      lintProcess.on('error', err => {
+      process.on('message', msg => {
+        resolve(msg);
+        process?.kill();
+        process = null;
+      });
+
+      process.on('error', err => {
         console.error('[lint-process] error:', err);
         reject({ error: err.toString() });
       });
 
-      lintProcess.postMessage({ documentContent, rulesetPath });
+      process.postMessage({ documentContent, rulesetPath });
     });
   });
 

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -141,6 +141,10 @@ export function registerMainHandlers() {
       }
       lintProcess = utilityProcess.fork(path.join(__dirname, 'main/lint-process.mjs'));
 
+      lintProcess.on('exit', code => {
+        console.log('[lint-process] exited with code:', code);
+        resolve({ diagnostics: [] });
+      });
       lintProcess.on('message', msg => {
         resolve(msg);
         lintProcess?.kill();

--- a/packages/insomnia/src/ui/routes/design.tsx
+++ b/packages/insomnia/src/ui/routes/design.tsx
@@ -192,7 +192,13 @@ const Design: FC = () => {
   const registerCodeMirrorLint = (rulesetPath: string) => {
     CodeMirror.registerHelper('lint', 'openapi', async (contents: string) => {
       try {
-        const { diagnostics, error } = await window.main.lintSpec({ documentContent: contents, rulesetPath });
+        const { diagnostics, error, cancelled } = await window.main.lintSpec({
+          documentContent: contents,
+          rulesetPath,
+        });
+        if (cancelled) {
+          return;
+        }
         if (error) {
           console.log('Handled error detected while linting:', error);
           showError({


### PR DESCRIPTION
# Overview:

When running subsequent lint commands we kill the previous processes which leads to the previous lint commands not replying and hanging indefinitely.

This PR makes sure we resolve when the process is killed to avoid this issue.

