### PR TITLE
fix: prioritize oauth token association with request [INS-918]

### DIFF
--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -210,10 +210,12 @@ async function getExistingAccessTokenAndRefreshIfExpired(
   const requestGroups = (
     await db.withAncestors<Request | RequestGroup>(activeRequest, [models.requestGroup.type])
   ).filter(isRequestGroup) as RequestGroup[];
-  const closestAuth = requestGroups.find(
+  const closestFolderAuth = requestGroups.find(
     ({ authentication }) => getAuthObjectOrNull(authentication) && isAuthEnabled(authentication),
   );
-  const closestAuthId = closestAuth?._id || requestId;
+  const isRequestAuthEnabled =
+    getAuthObjectOrNull(activeRequest?.authentication) && isAuthEnabled(activeRequest?.authentication);
+  const closestAuthId = isRequestAuthEnabled ? requestId : closestFolderAuth?._id || requestId;
   const token: OAuth2Token | null = await models.oAuth2Token.getByParentId(closestAuthId);
   if (!token) {
     return { oAuth2Token: null, closestAuthId };


### PR DESCRIPTION
When both a folder and a child request have auth enabled, the token should be associated with the request, but is currently associating with the folder.

This change prioritizes the request over the folder, and continues to fall back to the request if no folder has auth enabled.