### PR TITLE
feat(Git Sync): Introduce the option to select a branch when cloning a repository

### DIFF
--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -1105,6 +1105,7 @@ export const updateGitRepoAction = async ({
   oauth2format,
   username,
   token,
+  ref,
 }: {
   projectId: string;
   workspaceId?: string;
@@ -1114,6 +1115,7 @@ export const updateGitRepoAction = async ({
   oauth2format?: string;
   username: string;
   token: string;
+  ref?: string;
 }) => {
   try {
     let gitRepositoryId: string | null | undefined = null;
@@ -1194,6 +1196,7 @@ export const updateGitRepoAction = async ({
       gitDirectory: GIT_INTERNAL_DIR,
       gitCredentials: gitRepository.credentials,
       legacyDiff: Boolean(workspaceId),
+      ref,
     });
 
     await GitVCS.setAuthor();

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -191,6 +191,7 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
   try {
     const gitRepository = await getGitRepository({ workspaceId, projectId });
 
+    const bufferId = await database.bufferChanges();
     const fsClient = await getGitFSClient({ gitRepositoryId: gitRepository._id, projectId, workspaceId });
 
     if (GitVCS.isInitializedForRepo(gitRepository._id) && !gitRepository.needsFullClone) {
@@ -242,6 +243,8 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
     if (!workspaceId) {
       legacyInsomniaWorkspace = await containsLegacyInsomniaDir({ fsClient });
     }
+
+    await database.flushChanges(bufferId);
 
     return {
       branch: await GitVCS.getCurrentBranch(),
@@ -830,6 +833,7 @@ export const cloneGitRepoAction = async ({
           directory: GIT_CLONE_DIR,
           fs: fsClient,
           gitDirectory: GIT_INTERNAL_DIR,
+          ref,
         });
 
         await models.gitRepository.update(gitRepository, {
@@ -854,7 +858,10 @@ export const cloneGitRepoAction = async ({
         await migrateLegacyInsomniaFolderToFile({ projectId: project._id });
       }
 
-      await models.gitRepository.update(gitRepository, {
+      const updateRepository = await models.gitRepository.getById(gitRepository._id);
+      invariant(updateRepository, 'Git Repository not found');
+
+      await models.gitRepository.update(updateRepository, {
         cachedGitLastCommitTime: Date.now(),
         cachedGitRepositoryBranch: await GitVCS.getCurrentBranch(),
       });

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -26,10 +26,12 @@ import type { GitRepository } from '../models/git-repository';
 import { isWorkspace, type WorkspaceScope, WorkspaceScopeKeys } from '../models/workspace';
 import { fsClient } from '../sync/git/fs-client';
 import GitVCS, {
+  fetchRemoteBranches,
   GIT_CLONE_DIR,
   GIT_INSOMNIA_DIR,
   GIT_INSOMNIA_DIR_NAME,
   GIT_INTERNAL_DIR,
+  type GitCredentials,
   MergeConflictError,
 } from '../sync/git/git-vcs';
 import { MemClient } from '../sync/git/mem-client';
@@ -591,6 +593,7 @@ export const initGitRepoCloneAction = async ({
   token,
   username,
   oauth2format,
+  ref,
 }: {
   organizationId: string;
   uri: string;
@@ -599,6 +602,7 @@ export const initGitRepoCloneAction = async ({
   token: string;
   username: string;
   oauth2format?: string;
+  ref?: string;
 }): Promise<
   | {
       files: {
@@ -647,6 +651,7 @@ export const initGitRepoCloneAction = async ({
 
   try {
     await shallowClone({
+      ref,
       fsClient: inMemoryFsClient,
       gitRepository: repoSettingsPatch as GitRepository,
     });
@@ -701,6 +706,7 @@ export const cloneGitRepoAction = async ({
   token,
   username,
   oauth2format,
+  ref,
 }: {
   organizationId: string;
   projectId?: string;
@@ -712,6 +718,7 @@ export const cloneGitRepoAction = async ({
   token: string;
   username: string;
   oauth2format?: string;
+  ref?: string;
 }) => {
   try {
     if (!projectId) {
@@ -750,6 +757,7 @@ export const cloneGitRepoAction = async ({
 
       try {
         await shallowClone({
+          ref,
           fsClient: inMemoryFsClient,
           gitRepository: repoSettingsPatch as GitRepository,
         });
@@ -900,6 +908,7 @@ export const cloneGitRepoAction = async ({
     const providerName = getOauth2FormatName(repoSettingsPatch.credentials);
     try {
       await shallowClone({
+        ref,
         fsClient: inMemoryFsClient,
         gitRepository: repoSettingsPatch as GitRepository,
       });
@@ -1704,6 +1713,26 @@ export const pushToGitRemoteAction = async ({
   };
 };
 
+export async function fetchGitRemoteBranches({
+  uri,
+  credentials,
+}: {
+  uri: string;
+  credentials?: GitCredentials;
+}): Promise<{ branches: string[]; errors?: string[] }> {
+  try {
+    const branches = await fetchRemoteBranches({
+      uri: parseGitToHttpsURL(uri),
+      credentials,
+    });
+
+    return { branches };
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : 'Error while fetching remote branches';
+    return { branches: [], errors: [errorMessage] };
+  }
+}
+
 export async function pullFromGitRemote({ projectId, workspaceId }: { projectId: string; workspaceId?: string }) {
   try {
     const gitRepository = await getGitRepository({ projectId, workspaceId });
@@ -2472,7 +2501,7 @@ export interface GitServiceAPI {
   diffFileLoader: typeof diffFileLoader;
   getRepositoryDirectoryTree: typeof getRepositoryDirectoryTree;
   migrateLegacyInsomniaFolderToFile: typeof migrateLegacyInsomniaFolderToFile;
-
+  fetchGitRemoteBranches: typeof fetchGitRemoteBranches;
   initSignInToGitHub: typeof initSignInToGitHub;
   completeSignInToGitHub: typeof completeSignInToGitHub;
   signOutOfGitHub: typeof signOutOfGitHub;
@@ -2489,6 +2518,9 @@ export const registerGitServiceAPI = () => {
     loadGitRepository(options),
   );
   ipcMainHandle('git.getGitBranches', (_, options: Parameters<typeof getGitBranches>[0]) => getGitBranches(options));
+  ipcMainHandle('git.fetchGitRemoteBranches', (_, options: Parameters<typeof fetchGitRemoteBranches>[0]) =>
+    fetchGitRemoteBranches(options),
+  );
   ipcMainHandle('git.gitFetchAction', (_, options: Parameters<typeof gitFetchAction>[0]) => gitFetchAction(options));
   ipcMainHandle('git.gitLogLoader', (_, options: Parameters<typeof gitLogLoader>[0]) => gitLogLoader(options));
   ipcMainHandle('git.gitChangesLoader', (_, options: Parameters<typeof gitChangesLoader>[0]) =>

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -49,6 +49,7 @@ export type HandleChannels =
   | 'secretStorage.decryptString'
   | 'git.loadGitRepository'
   | 'git.getGitBranches'
+  | 'git.fetchGitRemoteBranches'
   | 'git.gitFetchAction'
   | 'git.gitLogLoader'
   | 'git.gitChangesLoader'

--- a/packages/insomnia/src/preload.ts
+++ b/packages/insomnia/src/preload.ts
@@ -70,6 +70,7 @@ const secretStorage: secretStorageBridgeAPI = {
 const git: GitServiceAPI = {
   loadGitRepository: options => ipcRenderer.invoke('git.loadGitRepository', options),
   getGitBranches: options => ipcRenderer.invoke('git.getGitBranches', options),
+  fetchGitRemoteBranches: options => ipcRenderer.invoke('git.fetchGitRemoteBranches', options),
   gitFetchAction: options => ipcRenderer.invoke('git.gitFetchAction', options),
   gitLogLoader: options => ipcRenderer.invoke('git.gitLogLoader', options),
   gitChangesLoader: options => ipcRenderer.invoke('git.gitChangesLoader', options),

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -68,6 +68,7 @@ interface InitOptions {
   gitCredentials?: GitCredentials | null;
   uri?: string;
   repoId: string;
+  ref?: string;
   // If enabled git-vcs will only diff files inside a .insomnia directory
   legacyDiff?: boolean;
 }
@@ -121,13 +122,14 @@ interface BaseOpts {
   uri: string;
   repoId: string;
   legacyDiff?: boolean;
+  ref?: string;
 }
 
 export class GitVCS {
   // @ts-expect-error -- TSCONVERSION not initialized with required properties
   _baseOpts: BaseOpts = gitCallbacks();
 
-  async init({ directory, fs, gitDirectory, gitCredentials, uri = '', repoId, legacyDiff = false }: InitOptions) {
+  async init({ directory, fs, gitDirectory, gitCredentials, uri = '', repoId, legacyDiff = false, ref }: InitOptions) {
     this._baseOpts = {
       ...this._baseOpts,
       dir: directory,
@@ -138,6 +140,7 @@ export class GitVCS {
       uri,
       repoId,
       legacyDiff,
+      ref,
     };
 
     if (await this.repoExists()) {
@@ -191,11 +194,14 @@ export class GitVCS {
       http: httpClient,
       repoId,
     };
+
+    const initRef = ref || this._baseOpts.ref;
+
     try {
       await git.clone({
         ...this._baseOpts,
         url,
-        ...(ref ? { ref } : {}),
+        ...(initRef ? { ref: initRef } : {}),
       });
     } catch (err) {
       // If we there is a checkout conflict we only want to clone the repo
@@ -203,7 +209,7 @@ export class GitVCS {
         await git.clone({
           ...this._baseOpts,
           url,
-          ...(ref ? { ref } : {}),
+          ...(initRef ? { ref: initRef } : {}),
           noCheckout: true,
         });
       }

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -3,11 +3,9 @@ import path from 'node:path';
 import * as git from 'isomorphic-git';
 import { parse, stringify } from 'yaml';
 
-import type { GitRepository } from '../../models/git-repository';
 import type { MergeConflict } from '../types';
 import { httpClient } from './http-client';
 import { convertToPosixSep } from './path-sep';
-import { shallowClone } from './shallow-clone';
 import { getAuthorFromGitRepository, gitCallbacks } from './utils';
 
 export interface GitAuthor {
@@ -80,6 +78,7 @@ interface InitFromCloneOptions {
   directory: string;
   fs: git.FsClient;
   gitDirectory: string;
+  ref?: string;
   repoId: string;
 }
 
@@ -104,7 +103,7 @@ function getInsomniaFileName(blob: void | Uint8Array | undefined): string {
   try {
     const parsed = parse(Buffer.from(blob).toString('utf-8'));
     return parsed?.fileName || parsed?.name || '';
-  } catch (e) {
+  } catch {
     // If the document couldn't be parsed as yaml return an empty string
     return '';
   }
@@ -160,7 +159,7 @@ export class GitVCS {
         });
 
         defaultBranch = mainRef?.target?.replace('refs/heads/', '') || 'main';
-      } catch (err) {
+      } catch {
         // Ignore error
       }
 
@@ -176,13 +175,13 @@ export class GitVCS {
       });
 
       return remoteOriginURI;
-    } catch (err) {
+    } catch {
       // Ignore error
       return this._baseOpts.uri || '';
     }
   }
 
-  async initFromClone({ repoId, url, gitCredentials, directory, fs, gitDirectory }: InitFromCloneOptions) {
+  async initFromClone({ repoId, url, gitCredentials, directory, fs, gitDirectory, ref }: InitFromCloneOptions) {
     this._baseOpts = {
       ...this._baseOpts,
       ...gitCallbacks(gitCredentials),
@@ -196,7 +195,7 @@ export class GitVCS {
       await git.clone({
         ...this._baseOpts,
         url,
-        singleBranch: true,
+        ...(ref ? { ref } : {}),
       });
     } catch (err) {
       // If we there is a checkout conflict we only want to clone the repo
@@ -204,11 +203,12 @@ export class GitVCS {
         await git.clone({
           ...this._baseOpts,
           url,
-          singleBranch: true,
+          ...(ref ? { ref } : {}),
           noCheckout: true,
         });
       }
     }
+
     console.log(`[git] Cloned repo to ${gitDirectory} from ${url}`);
   }
 
@@ -368,7 +368,7 @@ export class GitVCS {
 
           try {
             return Buffer.from(blob).toString('utf-8');
-          } catch (e) {
+          } catch {
             return null;
           }
         });
@@ -976,6 +976,7 @@ export class GitVCS {
       await git.checkout({
         ...this._baseOpts,
         ref: branch,
+
         remote: 'origin',
       });
       const branches = await this.listBranches();
@@ -988,7 +989,7 @@ export class GitVCS {
   async repoExists() {
     try {
       await git.getConfig({ ...this._baseOpts, path: '' });
-    } catch (err) {
+    } catch {
       return false;
     }
 

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -3,9 +3,11 @@ import path from 'node:path';
 import * as git from 'isomorphic-git';
 import { parse, stringify } from 'yaml';
 
+import type { GitRepository } from '../../models/git-repository';
 import type { MergeConflict } from '../types';
 import { httpClient } from './http-client';
 import { convertToPosixSep } from './path-sep';
+import { shallowClone } from './shallow-clone';
 import { getAuthorFromGitRepository, gitCallbacks } from './utils';
 
 export interface GitAuthor {
@@ -1065,6 +1067,37 @@ function assertIsPromiseFsClient(fs: git.FsClient): asserts fs is git.PromiseFsC
   if (!('promises' in fs)) {
     throw new Error('Expected fs to be of PromiseFsClient');
   }
+}
+
+export async function fetchRemoteBranches({ uri, credentials }: { uri: string; credentials?: GitCredentials | null }) {
+  const [mainRef] = await git.listServerRefs({
+    ...gitCallbacks(credentials),
+    http: httpClient,
+    url: uri,
+    prefix: 'HEAD',
+    symrefs: true,
+  });
+
+  const remoteRefs = await git.listServerRefs({
+    ...gitCallbacks(credentials),
+    http: httpClient,
+    url: uri,
+    prefix: 'refs/heads/',
+    symrefs: true,
+  });
+
+  const defaultBranch = mainRef?.target?.replace('refs/heads/', '') || 'main';
+
+  const remoteBranches = remoteRefs
+    .filter(b => b.ref !== 'HEAD')
+    .map(b => b.ref.replace('refs/heads/', ''))
+    .sort((a, b) => {
+      if (a === defaultBranch) return -1;
+      if (b === defaultBranch) return 1;
+      return a.localeCompare(b);
+    });
+
+  return remoteBranches;
 }
 
 export default new GitVCS();

--- a/packages/insomnia/src/sync/git/shallow-clone.ts
+++ b/packages/insomnia/src/sync/git/shallow-clone.ts
@@ -8,14 +8,16 @@ import { gitCallbacks } from './utils';
 interface Options {
   fsClient: git.FsClient;
   gitRepository: Pick<GitRepository, 'credentials' | 'uri'>;
+  ref?: string;
 }
 
 /**
  * Create a shallow clone into the provided FS plugin.
  * */
-export const shallowClone = async ({ fsClient, gitRepository }: Options) => {
+export const shallowClone = async ({ fsClient, gitRepository, ref = undefined }: Options) => {
   await git.clone({
     ...gitCallbacks(gitRepository.credentials),
+    ...(ref ? { ref } : {}),
     fs: fsClient,
     http: httpClient,
     dir: GIT_CLONE_DIR,

--- a/packages/insomnia/src/ui/components/git-credentials/custom-repository-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/custom-repository-settings-form.tsx
@@ -16,13 +16,19 @@ export const CustomRepositorySettingsFormGroup: FunctionComponent<Props> = ({ gi
   const linkIcon = <i className="fa fa-external-link-square" />;
   const defaultValues = gitRepository || {
     uri: '',
-    credentials: { username: '', token: '' },
+    credentials: { username: '', password: '' },
     author: { name: '', email: '' },
   };
 
-  const uri = defaultValues.uri;
+  const [credentials, setCredentials] = React.useState({
+    username: defaultValues.credentials?.username || '',
+    password:
+      defaultValues.credentials && 'password' in defaultValues.credentials ? defaultValues.credentials.password : '',
+  });
+
+  const [uri, setUri] = React.useState(defaultValues.uri || '');
+
   const author = defaultValues.author;
-  const credentials = defaultValues?.credentials || { username: '', token: '' };
 
   return (
     <form
@@ -50,6 +56,7 @@ export const CustomRepositorySettingsFormGroup: FunctionComponent<Props> = ({ gi
           type="url"
           autoFocus
           defaultValue={uri}
+          onChange={e => setUri(e.currentTarget.value)}
           disabled={Boolean(uri)}
           placeholder="https://github.com/org/repo.git"
           className="w-full rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] py-1 pl-2 pr-7 text-[--color-font] transition-colors placeholder:text-sm placeholder:italic focus:outline-none focus:ring-1 focus:ring-[--hl-md]"
@@ -82,6 +89,7 @@ export const CustomRepositorySettingsFormGroup: FunctionComponent<Props> = ({ gi
             placeholder="MyUser"
             disabled={Boolean(uri)}
             defaultValue={credentials?.username}
+            onChange={e => setCredentials({ ...credentials, username: e.currentTarget.value })}
             className="w-full rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] py-1 pl-2 pr-7 text-[--color-font] transition-colors placeholder:text-sm placeholder:italic focus:outline-none focus:ring-1 focus:ring-[--hl-md]"
           />
         </TextField>
@@ -105,13 +113,21 @@ export const CustomRepositorySettingsFormGroup: FunctionComponent<Props> = ({ gi
           <Input
             type="password"
             disabled={Boolean(uri)}
-            defaultValue={'token' in credentials ? credentials?.token : ''}
+            onChange={e => setCredentials({ ...credentials, password: e.currentTarget.value })}
+            defaultValue={'password' in credentials ? credentials?.password : ''}
             placeholder="88e7ee63b254e4b0bf047559eafe86ba9dd49507"
             className="w-full rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] py-1 pl-2 pr-7 text-[--color-font] transition-colors placeholder:text-sm placeholder:italic focus:outline-none focus:ring-1 focus:ring-[--hl-md]"
           />
         </TextField>
       </div>
-      <GitRemoteBranchSelect url={uri || ''} isDisabled={Boolean(uri)} />
+      <GitRemoteBranchSelect
+        credentials={{
+          password: credentials.password,
+          username: credentials.username,
+        }}
+        url={uri || ''}
+        isDisabled={Boolean(uri)}
+      />
     </form>
   );
 };

--- a/packages/insomnia/src/ui/components/git-credentials/custom-repository-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/custom-repository-settings-form.tsx
@@ -5,6 +5,7 @@ import { docsGitAccessToken } from '../../../common/documentation';
 import type { GitRepository } from '../../../models/git-repository';
 import { Link } from '../base/link';
 import { HelpTooltip } from '../help-tooltip';
+import { GitRemoteBranchSelect } from './git-remote-branch-select';
 
 export interface Props {
   gitRepository?: Partial<GitRepository> | null;
@@ -110,6 +111,7 @@ export const CustomRepositorySettingsFormGroup: FunctionComponent<Props> = ({ gi
           />
         </TextField>
       </div>
+      <GitRemoteBranchSelect url={uri || ''} isDisabled={Boolean(uri)} />
     </form>
   );
 };

--- a/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
@@ -3,8 +3,17 @@ import { Button, ComboBox, Input, Label, ListBox, ListBoxItem, Popover } from 'r
 import { useFetcher, useParams } from 'react-router';
 
 import { Icon } from '../icon';
+import type { GitCredentials } from '../../../sync/git/git-vcs';
 
-export const GitRemoteBranchSelect = ({ url, isDisabled }: { url: string; isDisabled: boolean }) => {
+export const GitRemoteBranchSelect = ({
+  url,
+  isDisabled,
+  credentials,
+}: {
+  url: string;
+  isDisabled: boolean;
+  credentials: GitCredentials;
+}) => {
   const remoteBranchesFetcher = useFetcher<{ branches: string[] }>({ key: url || 'branch-select' });
   const { organizationId } = useParams<{ organizationId: string }>();
 
@@ -14,9 +23,10 @@ export const GitRemoteBranchSelect = ({ url, isDisabled }: { url: string; isDisa
   useEffect(() => {
     if (uri && remoteBranchesFetcher.state === 'idle' && !remoteBranchesFetcher.data) {
       remoteBranchesFetcher.submit(
+        // @ts-expect-error credentials is not defined in the type, but it is used here
         {
           uri,
-          provider: 'github',
+          credentials,
         },
         {
           method: 'POST',
@@ -84,14 +94,15 @@ export const GitRemoteBranchSelect = ({ url, isDisabled }: { url: string; isDisa
         <Button
           type="button"
           isDisabled={isComboboxDisabled}
-          className="m-2 flex aspect-square size-[--line-height-xs] items-center justify-center gap-2 truncate rounded-sm border border-solid border-[--hl-sm] p-2 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+          className="m-2 flex aspect-square size-[--line-height-xs] items-center justify-center gap-2 truncate rounded-sm border border-solid border-[--hl-sm] p-2 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] disabled:opacity-30 aria-pressed:bg-[--hl-sm]"
           aria-label="Refresh repositories"
           onPress={() => {
-            if (uri && remoteBranchesFetcher.state === 'idle' && !remoteBranchesFetcher.data) {
+            if (uri && remoteBranchesFetcher.state === 'idle') {
               remoteBranchesFetcher.submit(
+                // @ts-expect-error credentials is not defined in the type, but it is used here
                 {
                   uri,
-                  provider: 'github',
+                  credentials,
                 },
                 {
                   method: 'POST',

--- a/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
@@ -2,8 +2,8 @@ import React, { useDeferredValue, useEffect } from 'react';
 import { Button, ComboBox, Input, Label, ListBox, ListBoxItem, Popover } from 'react-aria-components';
 import { useFetcher, useParams } from 'react-router';
 
-import { Icon } from '../icon';
 import type { GitCredentials } from '../../../sync/git/git-vcs';
+import { Icon } from '../icon';
 
 export const GitRemoteBranchSelect = ({
   url,
@@ -35,7 +35,7 @@ export const GitRemoteBranchSelect = ({
         },
       );
     }
-  }, [organizationId, remoteBranchesFetcher, uri]);
+  }, [organizationId, remoteBranchesFetcher, uri, credentials]);
 
   const remoteBranches = remoteBranchesFetcher.data?.branches || [];
 

--- a/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
@@ -32,7 +32,7 @@ export const GitRemoteBranchSelect = ({ url, isDisabled }: { url: string; isDisa
   const isComboboxDisabled = remoteBranches.length === 0 || isLoadingRemoteBranches || !url || isDisabled;
 
   return (
-    <Label className="flex flex-col gap-1">
+    <Label className="flex flex-col">
       <span className="text-sm font-semibold">Branch</span>
       <div className="flex items-center gap-2">
         <ComboBox

--- a/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
@@ -1,0 +1,110 @@
+import React, { useDeferredValue, useEffect } from 'react';
+import { Button, ComboBox, Input, Label, ListBox, ListBoxItem, Popover } from 'react-aria-components';
+import { useFetcher, useParams } from 'react-router';
+
+import { Icon } from '../icon';
+
+export const GitRemoteBranchSelect = ({ url, isDisabled }: { url: string; isDisabled: boolean }) => {
+  const remoteBranchesFetcher = useFetcher<{ branches: string[] }>({ key: url || 'branch-select' });
+  const { organizationId } = useParams<{ organizationId: string }>();
+
+  const isLoadingRemoteBranches = remoteBranchesFetcher.state !== 'idle';
+  const uri = useDeferredValue(url);
+
+  useEffect(() => {
+    if (uri && remoteBranchesFetcher.state === 'idle' && !remoteBranchesFetcher.data) {
+      remoteBranchesFetcher.submit(
+        {
+          uri,
+          provider: 'github',
+        },
+        {
+          method: 'POST',
+          encType: 'application/json',
+          action: `/organization/${organizationId}/git/remote-branches`,
+        },
+      );
+    }
+  }, [organizationId, remoteBranchesFetcher, uri]);
+
+  const remoteBranches = remoteBranchesFetcher.data?.branches || [];
+
+  const isComboboxDisabled = remoteBranches.length === 0 || isLoadingRemoteBranches || !url || isDisabled;
+
+  return (
+    <Label className="flex flex-col gap-1">
+      <span className="text-sm font-semibold">Branch</span>
+      <div className="flex items-center gap-2">
+        <ComboBox
+          key={`${url}:${remoteBranches[0]}:branch-select`}
+          aria-label="Branch to clone"
+          allowsCustomValue={false}
+          className="w-full"
+          defaultSelectedKey={remoteBranches[0]}
+          isDisabled={isComboboxDisabled}
+          items={remoteBranches.map(branch => ({
+            id: branch,
+            name: branch,
+          }))}
+        >
+          <div className="group flex items-center gap-2 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] text-[--color-font] transition-colors focus:outline-none focus:ring-1 focus:ring-[--hl-md]">
+            <Input
+              name="branch"
+              aria-label="Search branches"
+              placeholder={isLoadingRemoteBranches ? 'Fetching remote branches...' : 'Default branch'}
+              className="w-full py-1 pl-2 pr-7 placeholder:italic"
+            />
+            <Button
+              type="button"
+              className="m-2 flex aspect-square items-center justify-center gap-2 truncate rounded-sm !border-none text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+            >
+              <Icon icon="caret-down" className="w-5 flex-shrink-0" />
+            </Button>
+          </div>
+          <Popover
+            className="grid w-[--trigger-width] min-w-max select-none grid-flow-col divide-x divide-solid divide-[--hl-md] overflow-y-auto rounded-md border border-solid border-[--hl-sm] bg-[--color-bg] text-sm shadow-lg focus:outline-none"
+            placement="bottom start"
+            offset={8}
+          >
+            <ListBox<{
+              id: string;
+              name: string;
+            }> className="flex min-w-max select-none flex-col p-2 text-sm focus:outline-none">
+              {item => (
+                <ListBoxItem
+                  textValue={item.name}
+                  className="text-md flex h-[--line-height-xs] w-full items-center gap-2 whitespace-nowrap rounded bg-transparent px-[--padding-md] text-[--color-font] transition-colors hover:bg-[--hl-sm] focus:bg-[--hl-xs] focus:outline-none disabled:cursor-not-allowed aria-disabled:cursor-not-allowed aria-disabled:opacity-30 aria-selected:bg-[--hl-sm] aria-selected:font-bold data-[focused]:bg-[--hl-xs]"
+                >
+                  <span className="truncate">{item.name}</span>
+                </ListBoxItem>
+              )}
+            </ListBox>
+          </Popover>
+        </ComboBox>
+        <Button
+          type="button"
+          isDisabled={isComboboxDisabled}
+          className="m-2 flex aspect-square size-[--line-height-xs] items-center justify-center gap-2 truncate rounded-sm border border-solid border-[--hl-sm] p-2 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+          aria-label="Refresh repositories"
+          onPress={() => {
+            if (uri && remoteBranchesFetcher.state === 'idle' && !remoteBranchesFetcher.data) {
+              remoteBranchesFetcher.submit(
+                {
+                  uri,
+                  provider: 'github',
+                },
+                {
+                  method: 'POST',
+                  encType: 'application/json',
+                  action: `/organization/${organizationId}/git/remote-branches`,
+                },
+              );
+            }
+          }}
+        >
+          <Icon icon="refresh" className={isLoadingRemoteBranches ? 'animate-spin' : ''} />
+        </Button>
+      </div>
+    </Label>
+  );
+};

--- a/packages/insomnia/src/ui/components/git-credentials/github-repository-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/github-repository-select.tsx
@@ -20,6 +20,8 @@ export const GitHubRepositorySelect = ({ uri, token }: { uri?: string; token: st
   const { organizationId } = params;
   const remoteBranchesFetcher = useFetcher<{ branches: string[] }>({ key: selectedRepository?.clone_url || '' });
 
+  const isLoadingRemoteBranches = remoteBranchesFetcher.state !== 'idle';
+
   useEffect(() => {
     if (selectedRepository && remoteBranchesFetcher.state === 'idle' && !remoteBranchesFetcher.data) {
       remoteBranchesFetcher.submit(
@@ -160,15 +162,52 @@ export const GitHubRepositorySelect = ({ uri, token }: { uri?: string; token: st
           )}
         </>
       )}
-      {selectedRepository && remoteBranches.length > 0 && (
-        <select>
-          {remoteBranches.map(branch => (
-            <option key={branch} value={branch}>
-              {branch}
-            </option>
-          ))}
-        </select>
-      )}
+      <ComboBox
+        key={selectedRepository?.clone_url || 'branch-select'}
+        aria-label="Branch to clone"
+        allowsCustomValue={false}
+        className="w-full"
+        defaultSelectedKey={remoteBranches[0] || 'main'}
+        isDisabled={remoteBranches.length === 0 || loading || isLoadingRemoteBranches}
+        items={remoteBranches.map(branch => ({
+          id: branch,
+          name: branch,
+        }))}
+      >
+        <div className="group flex items-center gap-2 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] text-[--color-font] transition-colors focus:outline-none focus:ring-1 focus:ring-[--hl-md]">
+          <Input
+            name="branch"
+            aria-label="Search branches"
+            placeholder={isLoadingRemoteBranches ? 'Fetching remote branches...' : 'Select a branch...'}
+            className="w-full py-1 pl-2 pr-7 placeholder:italic"
+          />
+          <ComboButton
+            type="button"
+            className="m-2 flex aspect-square items-center justify-center gap-2 truncate rounded-sm !border-none text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+          >
+            <Icon icon="caret-down" className="w-5 flex-shrink-0" />
+          </ComboButton>
+        </div>
+        <Popover
+          className="grid w-[--trigger-width] min-w-max select-none grid-flow-col divide-x divide-solid divide-[--hl-md] overflow-y-auto rounded-md border border-solid border-[--hl-sm] bg-[--color-bg] text-sm shadow-lg focus:outline-none"
+          placement="bottom start"
+          offset={8}
+        >
+          <ListBox<{
+            id: string;
+            name: string;
+          }> className="flex min-w-max select-none flex-col p-2 text-sm focus:outline-none">
+            {item => (
+              <ListBoxItem
+                textValue={item.name}
+                className="text-md flex h-[--line-height-xs] w-full items-center gap-2 whitespace-nowrap rounded bg-transparent px-[--padding-md] text-[--color-font] transition-colors hover:bg-[--hl-sm] focus:bg-[--hl-xs] focus:outline-none disabled:cursor-not-allowed aria-disabled:cursor-not-allowed aria-disabled:opacity-30 aria-selected:bg-[--hl-sm] aria-selected:font-bold data-[focused]:bg-[--hl-xs]"
+              >
+                <span className="truncate">{item.name}</span>
+              </ListBoxItem>
+            )}
+          </ListBox>
+        </Popover>
+      </ComboBox>
       {cannotFindRepository && (
         <div className="text-sm text-red-500">
           <Icon icon="warning" /> Repository information could not be retrieved. Please <code>Reset</code> and select a

--- a/packages/insomnia/src/ui/components/git-credentials/github-repository-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/github-repository-select.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Button as ComboButton, ComboBox, Input, ListBox, ListBoxItem, Popover } from 'react-aria-components';
+import { useFetcher, useParams } from 'react-router';
 
 import { getAppWebsiteBaseURL } from '../../../common/constants';
 import { isGitHubAppUserToken } from '../github-app-config-link';
@@ -14,6 +15,30 @@ export const GitHubRepositorySelect = ({ uri, token }: { uri?: string; token: st
   const [selectedRepository, setSelectedRepository] = useState<GitHubRepository | null>(null);
   const [cannotFindRepository, setCannotFindRepository] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
+
+  const params = useParams<{ organizationId: string }>();
+  const { organizationId } = params;
+  const remoteBranchesFetcher = useFetcher<{ branches: string[] }>({ key: selectedRepository?.clone_url || '' });
+
+  useEffect(() => {
+    if (selectedRepository && remoteBranchesFetcher.state === 'idle' && !remoteBranchesFetcher.data) {
+      remoteBranchesFetcher.submit(
+        {
+          uri: selectedRepository.clone_url,
+          provider: 'github',
+        },
+        {
+          method: 'POST',
+          encType: 'application/json',
+          action: `/organization/${organizationId}/git/remote-branches`,
+        },
+      );
+    }
+  }, [organizationId, remoteBranchesFetcher, selectedRepository]);
+
+  console.log('remoteBranchesFetcher', remoteBranchesFetcher);
+
+  const remoteBranches = remoteBranchesFetcher.data?.branches || [];
 
   const getRepositories = async () => {
     setLoading(true);
@@ -134,6 +159,15 @@ export const GitHubRepositorySelect = ({ uri, token }: { uri?: string; token: st
             </div>
           )}
         </>
+      )}
+      {selectedRepository && remoteBranches.length > 0 && (
+        <select>
+          {remoteBranches.map(branch => (
+            <option key={branch} value={branch}>
+              {branch}
+            </option>
+          ))}
+        </select>
       )}
       {cannotFindRepository && (
         <div className="text-sm text-red-500">

--- a/packages/insomnia/src/ui/components/git-credentials/github-repository-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/github-repository-select.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { Button as ComboButton, ComboBox, Input, ListBox, ListBoxItem, Popover } from 'react-aria-components';
-import { useFetcher, useParams } from 'react-router';
+import { Button, ComboBox, Input, ListBox, ListBoxItem, Popover } from 'react-aria-components';
 
 import { getAppWebsiteBaseURL } from '../../../common/constants';
 import { isGitHubAppUserToken } from '../github-app-config-link';
 import { Icon } from '../icon';
-import { Button } from '../themed-button';
+import { GitRemoteBranchSelect } from './git-remote-branch-select';
 
 type GitHubRepository = Awaited<ReturnType<typeof window.main.git.getGitHubRepositories>>['repos'][number];
 
@@ -15,32 +14,6 @@ export const GitHubRepositorySelect = ({ uri, token }: { uri?: string; token: st
   const [selectedRepository, setSelectedRepository] = useState<GitHubRepository | null>(null);
   const [cannotFindRepository, setCannotFindRepository] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
-
-  const params = useParams<{ organizationId: string }>();
-  const { organizationId } = params;
-  const remoteBranchesFetcher = useFetcher<{ branches: string[] }>({ key: selectedRepository?.clone_url || '' });
-
-  const isLoadingRemoteBranches = remoteBranchesFetcher.state !== 'idle';
-
-  useEffect(() => {
-    if (selectedRepository && remoteBranchesFetcher.state === 'idle' && !remoteBranchesFetcher.data) {
-      remoteBranchesFetcher.submit(
-        {
-          uri: selectedRepository.clone_url,
-          provider: 'github',
-        },
-        {
-          method: 'POST',
-          encType: 'application/json',
-          action: `/organization/${organizationId}/git/remote-branches`,
-        },
-      );
-    }
-  }, [organizationId, remoteBranchesFetcher, selectedRepository]);
-
-  console.log('remoteBranchesFetcher', remoteBranchesFetcher);
-
-  const remoteBranches = remoteBranchesFetcher.data?.branches || [];
 
   const getRepositories = async () => {
     setLoading(true);
@@ -100,13 +73,13 @@ export const GitHubRepositorySelect = ({ uri, token }: { uri?: string; token: st
                   placeholder={loading ? 'Fetching...' : 'Find a repository...'}
                   className="w-full py-1 pl-2 pr-7 placeholder:italic"
                 />
-                <ComboButton
+                <Button
                   id="github_repo_select_dropdown_button"
                   type="button"
                   className="m-2 flex aspect-square items-center justify-center gap-2 truncate rounded-sm !border-none text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
                 >
                   <Icon icon="caret-down" className="w-5 flex-shrink-0" />
-                </ComboButton>
+                </Button>
               </div>
               <Popover
                 className="grid w-[--trigger-width] min-w-max select-none grid-flow-col divide-x divide-solid divide-[--hl-md] overflow-y-auto rounded-md border border-solid border-[--hl-sm] bg-[--color-bg] text-sm shadow-lg focus:outline-none"
@@ -131,10 +104,10 @@ export const GitHubRepositorySelect = ({ uri, token }: { uri?: string; token: st
             </ComboBox>
             <Button
               type="button"
-              disabled={loading}
-              className="m-2 flex aspect-square items-center justify-center gap-2 truncate rounded-sm border border-solid border-[--hl-sm] !p-0 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+              isDisabled={loading}
+              className="m-2 flex aspect-square size-[--line-height-xs] items-center justify-center gap-2 truncate rounded-sm border border-solid border-[--hl-sm] p-2 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
               aria-label="Refresh repositories"
-              onClick={() => {
+              onPress={() => {
                 setLoading(true);
                 getRepositories();
               }}
@@ -162,52 +135,7 @@ export const GitHubRepositorySelect = ({ uri, token }: { uri?: string; token: st
           )}
         </>
       )}
-      <ComboBox
-        key={selectedRepository?.clone_url || 'branch-select'}
-        aria-label="Branch to clone"
-        allowsCustomValue={false}
-        className="w-full"
-        defaultSelectedKey={remoteBranches[0] || 'main'}
-        isDisabled={remoteBranches.length === 0 || loading || isLoadingRemoteBranches}
-        items={remoteBranches.map(branch => ({
-          id: branch,
-          name: branch,
-        }))}
-      >
-        <div className="group flex items-center gap-2 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] text-[--color-font] transition-colors focus:outline-none focus:ring-1 focus:ring-[--hl-md]">
-          <Input
-            name="branch"
-            aria-label="Search branches"
-            placeholder={isLoadingRemoteBranches ? 'Fetching remote branches...' : 'Select a branch...'}
-            className="w-full py-1 pl-2 pr-7 placeholder:italic"
-          />
-          <ComboButton
-            type="button"
-            className="m-2 flex aspect-square items-center justify-center gap-2 truncate rounded-sm !border-none text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
-          >
-            <Icon icon="caret-down" className="w-5 flex-shrink-0" />
-          </ComboButton>
-        </div>
-        <Popover
-          className="grid w-[--trigger-width] min-w-max select-none grid-flow-col divide-x divide-solid divide-[--hl-md] overflow-y-auto rounded-md border border-solid border-[--hl-sm] bg-[--color-bg] text-sm shadow-lg focus:outline-none"
-          placement="bottom start"
-          offset={8}
-        >
-          <ListBox<{
-            id: string;
-            name: string;
-          }> className="flex min-w-max select-none flex-col p-2 text-sm focus:outline-none">
-            {item => (
-              <ListBoxItem
-                textValue={item.name}
-                className="text-md flex h-[--line-height-xs] w-full items-center gap-2 whitespace-nowrap rounded bg-transparent px-[--padding-md] text-[--color-font] transition-colors hover:bg-[--hl-sm] focus:bg-[--hl-xs] focus:outline-none disabled:cursor-not-allowed aria-disabled:cursor-not-allowed aria-disabled:opacity-30 aria-selected:bg-[--hl-sm] aria-selected:font-bold data-[focused]:bg-[--hl-xs]"
-              >
-                <span className="truncate">{item.name}</span>
-              </ListBoxItem>
-            )}
-          </ListBox>
-        </Popover>
-      </ComboBox>
+      {!uri && <GitRemoteBranchSelect isDisabled={loading} url={selectedRepository?.clone_url || ''} />}
       {cannotFindRepository && (
         <div className="text-sm text-red-500">
           <Icon icon="warning" /> Repository information could not be retrieved. Please <code>Reset</code> and select a

--- a/packages/insomnia/src/ui/components/git-credentials/github-repository-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/github-repository-select.tsx
@@ -151,7 +151,18 @@ export const GitHubRepositorySelect = ({ uri, token }: { uri?: string; token: st
           <Icon icon="warning" /> You do not have write access to this repository
         </div>
       )}
-      {!uri && <GitRemoteBranchSelect isDisabled={loading} url={selectedRepository?.clone_url || ''} />}
+      {!uri && (
+        <GitRemoteBranchSelect
+          credentials={{
+            oauth2format: 'github',
+            token: '',
+            password: '',
+            username: '',
+          }}
+          isDisabled={loading}
+          url={selectedRepository?.clone_url || ''}
+        />
+      )}
     </div>
   );
 };

--- a/packages/insomnia/src/ui/components/git-credentials/github-repository-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/github-repository-select.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, ComboBox, Input, ListBox, ListBoxItem, Popover } from 'react-aria-components';
+import { Button, ComboBox, Input, Label, ListBox, ListBoxItem, Popover } from 'react-aria-components';
 
 import { getAppWebsiteBaseURL } from '../../../common/constants';
 import { isGitHubAppUserToken } from '../github-app-config-link';
@@ -47,95 +47,99 @@ export const GitHubRepositorySelect = ({ uri, token }: { uri?: string; token: st
 
   return (
     <div className="flex flex-col">
-      <span className="flex gap-1 text-sm font-semibold">Repository</span>
-      {uri && (
-        <div className="form-control form-control--outlined">
-          <input className="form-control" disabled defaultValue={uri} />
-        </div>
-      )}
-      {!uri && (
-        <>
-          <div className="flex flex-row items-center gap-2 py-2">
-            <ComboBox
-              aria-label="Repositories"
-              allowsCustomValue={false}
-              className="w-full"
-              isDisabled={loading}
-              defaultItems={repositories.map(repo => ({
-                id: repo.clone_url,
-                name: repo.full_name,
-              }))}
-              onSelectionChange={key => setSelectedRepository(repositories.find(r => r.clone_url === key) || null)}
-            >
-              <div className="group flex items-center gap-2 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] text-[--color-font] transition-colors focus:outline-none focus:ring-1 focus:ring-[--hl-md]">
-                <Input
-                  aria-label="Repository Search"
-                  placeholder={loading ? 'Fetching...' : 'Find a repository...'}
-                  className="w-full py-1 pl-2 pr-7 placeholder:italic"
-                />
-                <Button
-                  id="github_repo_select_dropdown_button"
-                  type="button"
-                  className="m-2 flex aspect-square items-center justify-center gap-2 truncate rounded-sm !border-none text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
-                >
-                  <Icon icon="caret-down" className="w-5 flex-shrink-0" />
-                </Button>
-              </div>
-              <Popover
-                className="grid w-[--trigger-width] min-w-max select-none grid-flow-col divide-x divide-solid divide-[--hl-md] overflow-y-auto rounded-md border border-solid border-[--hl-sm] bg-[--color-bg] text-sm shadow-lg focus:outline-none"
-                placement="bottom start"
-                offset={8}
-              >
-                <ListBox<{
-                  id: string;
-                  name: string;
-                }> className="flex min-w-max select-none flex-col p-2 text-sm focus:outline-none">
-                  {item => (
-                    <ListBoxItem
-                      textValue={item.name}
-                      className="text-md flex h-[--line-height-xs] w-full items-center gap-2 whitespace-nowrap rounded bg-transparent px-[--padding-md] text-[--color-font] transition-colors hover:bg-[--hl-sm] focus:bg-[--hl-xs] focus:outline-none disabled:cursor-not-allowed aria-disabled:cursor-not-allowed aria-disabled:opacity-30 aria-selected:bg-[--hl-sm] aria-selected:font-bold data-[focused]:bg-[--hl-xs]"
-                    >
-                      <span className="truncate">{item.name}</span>
-                    </ListBoxItem>
-                  )}
-                </ListBox>
-              </Popover>
-              <input type="hidden" name="uri" value={selectedRepository?.clone_url || uri || ''} />
-            </ComboBox>
-            <Button
-              type="button"
-              isDisabled={loading}
-              className="m-2 flex aspect-square size-[--line-height-xs] items-center justify-center gap-2 truncate rounded-sm border border-solid border-[--hl-sm] p-2 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
-              aria-label="Refresh repositories"
-              onPress={() => {
-                setLoading(true);
-                getRepositories();
-              }}
-            >
-              <Icon icon="refresh" className={loading ? 'animate-spin' : ''} />
-            </Button>
-          </div>
-          {errors.length > 0 && (
-            <div className="notice error margin-bottom-sm">
-              {errors.map(error => (
-                <p key={error}>{error}</p>
-              ))}
-            </div>
-          )}
-          {isGitHubAppUserToken(token) && (
-            <div className={`flex gap-1 text-sm ${loading ? 'opacity-40' : ''}`}>
-              Can't find a repository?
+      <Label className="flex flex-col">
+        <div className="flex items-center gap-2">
+          <span className="flex-1 text-sm font-semibold">Repository</span>
+          {!uri && isGitHubAppUserToken(token) && (
+            <div className={`flex items-center gap-1 text-sm ${loading ? 'opacity-40' : ''}`}>
+              <Icon icon="info-circle" className="text-[--hl]" />
+              <span>Can't find a repository?</span>
               <a
-                className="flex items-center gap-1 text-purple-500"
+                className="flex items-center gap-1 text-[--color-surprise]"
                 href={`${getAppWebsiteBaseURL()}/oauth/github-app`}
               >
                 Configure the App <i className="fa-solid fa-up-right-from-square" />
               </a>
             </div>
           )}
-        </>
-      )}
-      {!uri && <GitRemoteBranchSelect isDisabled={loading} url={selectedRepository?.clone_url || ''} />}
+        </div>
+        {uri && (
+          <div className="form-control form-control--outlined">
+            <input className="form-control" disabled defaultValue={uri} />
+          </div>
+        )}
+        {!uri && (
+          <>
+            <div className="flex flex-row items-center gap-2">
+              <ComboBox
+                aria-label="Repositories"
+                allowsCustomValue={false}
+                className="w-full"
+                isDisabled={loading}
+                defaultItems={repositories.map(repo => ({
+                  id: repo.clone_url,
+                  name: repo.full_name,
+                }))}
+                onSelectionChange={key => setSelectedRepository(repositories.find(r => r.clone_url === key) || null)}
+              >
+                <div className="group flex items-center gap-2 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] text-[--color-font] transition-colors focus:outline-none focus:ring-1 focus:ring-[--hl-md]">
+                  <Input
+                    aria-label="Repository Search"
+                    placeholder={loading ? 'Fetching...' : 'Find a repository...'}
+                    className="w-full py-1 pl-2 pr-7 placeholder:italic"
+                  />
+                  <Button
+                    id="github_repo_select_dropdown_button"
+                    type="button"
+                    className="m-2 flex aspect-square items-center justify-center gap-2 truncate rounded-sm !border-none text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+                  >
+                    <Icon icon="caret-down" className="w-5 flex-shrink-0" />
+                  </Button>
+                </div>
+                <Popover
+                  className="grid w-[--trigger-width] min-w-max select-none grid-flow-col divide-x divide-solid divide-[--hl-md] overflow-y-auto rounded-md border border-solid border-[--hl-sm] bg-[--color-bg] text-sm shadow-lg focus:outline-none"
+                  placement="bottom start"
+                  offset={8}
+                >
+                  <ListBox<{
+                    id: string;
+                    name: string;
+                  }> className="flex min-w-max select-none flex-col p-2 text-sm focus:outline-none">
+                    {item => (
+                      <ListBoxItem
+                        textValue={item.name}
+                        className="text-md flex h-[--line-height-xs] w-full items-center gap-2 whitespace-nowrap rounded bg-transparent px-[--padding-md] text-[--color-font] transition-colors hover:bg-[--hl-sm] focus:bg-[--hl-xs] focus:outline-none disabled:cursor-not-allowed aria-disabled:cursor-not-allowed aria-disabled:opacity-30 aria-selected:bg-[--hl-sm] aria-selected:font-bold data-[focused]:bg-[--hl-xs]"
+                      >
+                        <span className="truncate">{item.name}</span>
+                      </ListBoxItem>
+                    )}
+                  </ListBox>
+                </Popover>
+                <input type="hidden" name="uri" value={selectedRepository?.clone_url || uri || ''} />
+              </ComboBox>
+              <Button
+                type="button"
+                isDisabled={loading}
+                className="m-2 flex aspect-square size-[--line-height-xs] items-center justify-center gap-2 truncate rounded-sm border border-solid border-[--hl-sm] p-2 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+                aria-label="Refresh repositories"
+                onPress={() => {
+                  setLoading(true);
+                  getRepositories();
+                }}
+              >
+                <Icon icon="refresh" className={loading ? 'animate-spin' : ''} />
+              </Button>
+            </div>
+            {errors.length > 0 && (
+              <div className="notice error margin-bottom-sm">
+                {errors.map(error => (
+                  <p key={error}>{error}</p>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </Label>
       {cannotFindRepository && (
         <div className="text-sm text-red-500">
           <Icon icon="warning" /> Repository information could not be retrieved. Please <code>Reset</code> and select a
@@ -147,6 +151,7 @@ export const GitHubRepositorySelect = ({ uri, token }: { uri?: string; token: st
           <Icon icon="warning" /> You do not have write access to this repository
         </div>
       )}
+      {!uri && <GitRemoteBranchSelect isDisabled={loading} url={selectedRepository?.clone_url || ''} />}
     </div>
   );
 };

--- a/packages/insomnia/src/ui/components/git-credentials/github-repository-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/github-repository-settings-form.tsx
@@ -61,7 +61,7 @@ const Avatar = ({ src }: { src: string }) => {
 
 interface GitHubRepositoryFormProps {
   uri?: string;
-  onSubmit: (args: Partial<GitRepository>) => void;
+  onSubmit: (args: Partial<GitRepository & { ref?: string }>) => void;
   credentials: GitCredentials;
 }
 
@@ -77,12 +77,14 @@ const GitHubRepositoryForm = ({ uri, credentials, onSubmit }: GitHubRepositoryFo
         event.preventDefault();
         const formData = new FormData(event.currentTarget);
         const uri = formData.get('uri') as string;
+        const ref = formData.get('branch') as string;
         if (!uri) {
           setError('Please select a repository');
           return;
         }
         onSubmit({
           uri,
+          ref,
           credentials: {
             oauth2format: 'github',
             password: '',

--- a/packages/insomnia/src/ui/components/git-credentials/gitlab-repository-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/gitlab-repository-settings-form.tsx
@@ -6,6 +6,7 @@ import type { GitCredentials } from '../../../models/git-credentials';
 import type { GitRepository } from '../../../models/git-repository';
 import { PromptButton } from '../base/prompt-button';
 import { Icon } from '../icon';
+import { GitRemoteBranchSelect } from './git-remote-branch-select';
 
 interface Props {
   uri?: string;
@@ -67,7 +68,7 @@ interface GitLabRepositoryFormProps {
 
 const GitLabRepositoryForm = ({ uri, credentials, onSubmit }: GitLabRepositoryFormProps) => {
   const [error, setError] = useState('');
-
+  const [gitlabUri, setGitlabUri] = useState(uri || '');
   const signOutFetcher = useFetcher();
 
   return (
@@ -111,11 +112,13 @@ const GitLabRepositoryForm = ({ uri, credentials, onSubmit }: GitLabRepositoryFo
         <Input
           type="url"
           defaultValue={uri}
+          onChange={e => setGitlabUri(e.currentTarget.value)}
           disabled={Boolean(uri)}
-          placeholder="https://github.com/org/repo.git"
+          placeholder="https://gitlab.com/org/repo.git"
           className="w-full rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] py-1 pl-2 pr-7 text-[--color-font] transition-colors placeholder:text-sm placeholder:italic focus:outline-none focus:ring-1 focus:ring-[--hl-md]"
         />
       </TextField>
+      <GitRemoteBranchSelect url={gitlabUri || ''} isDisabled={Boolean(uri)} />
       {error && (
         <p className="notice error margin-bottom-sm">
           <button className="pull-right icon" onClick={() => setError('')}>

--- a/packages/insomnia/src/ui/components/git-credentials/gitlab-repository-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/gitlab-repository-settings-form.tsx
@@ -118,7 +118,16 @@ const GitLabRepositoryForm = ({ uri, credentials, onSubmit }: GitLabRepositoryFo
           className="w-full rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] py-1 pl-2 pr-7 text-[--color-font] transition-colors placeholder:text-sm placeholder:italic focus:outline-none focus:ring-1 focus:ring-[--hl-md]"
         />
       </TextField>
-      <GitRemoteBranchSelect url={gitlabUri || ''} isDisabled={Boolean(uri)} />
+      <GitRemoteBranchSelect
+        credentials={{
+          oauth2format: 'gitlab',
+          token: '',
+          password: '',
+          username: '',
+        }}
+        url={gitlabUri || ''}
+        isDisabled={Boolean(uri)}
+      />
       {error && (
         <p className="notice error margin-bottom-sm">
           <button className="pull-right icon" onClick={() => setError('')}>

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -126,6 +126,11 @@ export const ProjectSettingsForm: FC<Props> = ({
       ? initCloneGitRepositoryFetcher.data.files
       : [];
 
+  const remoteBranches =
+    initCloneGitRepositoryFetcher.data && 'remoteBranches' in initCloneGitRepositoryFetcher.data
+      ? initCloneGitRepositoryFetcher.data.remoteBranches
+      : [];
+
   useEffect(() => {
     if (upsertProjectFetcher.data && upsertProjectFetcher.data.success && onSuccessUpdate) {
       onSuccessUpdate();
@@ -393,6 +398,18 @@ export const ProjectSettingsForm: FC<Props> = ({
                 </span>
                 <p className="p-2 text-center font-bold text-[--color-font]">Loading Insomnia files from repository</p>
               </div>
+            </div>
+          )}
+          {remoteBranches.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <Heading className="text-base">Remote branches</Heading>
+              <select>
+                {remoteBranches.map(branch => (
+                  <option key={branch} value={branch}>
+                    {branch}
+                  </option>
+                ))}
+              </select>
             </div>
           )}
           {insomniaFiles.length === 0 && initCloneGitRepositoryFetcher.state === 'idle' && (

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -97,6 +97,7 @@ export const ProjectSettingsForm: FC<Props> = ({
     authorName?: string;
     authorEmail?: string;
     uri?: string;
+    ref?: string;
     username?: string;
     password?: string;
     token?: string;
@@ -126,11 +127,6 @@ export const ProjectSettingsForm: FC<Props> = ({
       ? initCloneGitRepositoryFetcher.data.files
       : [];
 
-  const remoteBranches =
-    initCloneGitRepositoryFetcher.data && 'remoteBranches' in initCloneGitRepositoryFetcher.data
-      ? initCloneGitRepositoryFetcher.data.remoteBranches
-      : [];
-
   useEffect(() => {
     if (upsertProjectFetcher.data && upsertProjectFetcher.data.success && onSuccessUpdate) {
       onSuccessUpdate();
@@ -149,7 +145,7 @@ export const ProjectSettingsForm: FC<Props> = ({
     }
   }, [storageRules, project]);
 
-  const onGitRepoFormSubmit = (gitRepositoryPatch: Partial<GitRepository>) => {
+  const onGitRepoFormSubmit = (gitRepositoryPatch: Partial<GitRepository & { ref?: string }>) => {
     const { author, credentials, created, modified, isPrivate, needsFullClone, uriNeedsMigration, ...repoPatch } =
       gitRepositoryPatch;
 
@@ -159,6 +155,7 @@ export const ProjectSettingsForm: FC<Props> = ({
       authorName: author?.name || '',
       authorEmail: author?.email || '',
       uri: repoPatch.uri,
+      ref: repoPatch.ref,
     });
 
     initCloneGitRepositoryFetcher.submit(
@@ -398,18 +395,6 @@ export const ProjectSettingsForm: FC<Props> = ({
                 </span>
                 <p className="p-2 text-center font-bold text-[--color-font]">Loading Insomnia files from repository</p>
               </div>
-            </div>
-          )}
-          {remoteBranches.length > 0 && (
-            <div className="flex flex-col gap-2">
-              <Heading className="text-base">Remote branches</Heading>
-              <select>
-                {remoteBranches.map(branch => (
-                  <option key={branch} value={branch}>
-                    {branch}
-                  </option>
-                ))}
-              </select>
             </div>
           )}
           {insomniaFiles.length === 0 && initCloneGitRepositoryFetcher.state === 'idle' && (

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -260,6 +260,11 @@ async function renderApp() {
                           (await import('./routes/$organizationId.git')).initGitCloneAction(...args),
                       },
                       {
+                        path: 'remote-branches',
+                        action: async (...args) =>
+                          (await import('./routes/git-project-actions')).fetchRemoteBranchesAction(...args),
+                      },
+                      {
                         path: 'clone',
                         action: async (...args) =>
                           (await import('./routes/$organizationId.git')).cloneGitRepoAction(...args),

--- a/packages/insomnia/src/ui/index.tsx
+++ b/packages/insomnia/src/ui/index.tsx
@@ -262,7 +262,7 @@ async function renderApp() {
                       {
                         path: 'remote-branches',
                         action: async (...args) =>
-                          (await import('./routes/git-project-actions')).fetchRemoteBranchesAction(...args),
+                          (await import('./routes/$organizationId.git')).fetchRemoteBranchesAction(...args),
                       },
                       {
                         path: 'clone',

--- a/packages/insomnia/src/ui/routes/$organizationId.git.tsx
+++ b/packages/insomnia/src/ui/routes/$organizationId.git.tsx
@@ -2,6 +2,7 @@ import { type ActionFunction, redirect } from 'react-router';
 
 import type { WorkspaceScope } from '../../models/workspace';
 import { invariant } from '../../utils/invariant';
+import type { GitCredentials } from '../../sync/git/git-vcs';
 
 export type InitGitCloneResult =
   | {
@@ -77,4 +78,21 @@ export const cloneGitRepoAction: ActionFunction = async ({ request, params }): P
   invariant(projectId, 'Project ID is required');
 
   return redirect(`/organization/${organizationId}/project/${projectId}`);
+};
+
+export const fetchRemoteBranchesAction: ActionFunction = async ({ request }) => {
+  const data = (await request.json()) as {
+    uri: string;
+    token: string;
+    provider: 'github' | 'gitlab';
+  };
+
+  const { uri, provider } = data;
+
+  const credentials = {
+    oauth2format: provider,
+    token: data.token,
+  } as GitCredentials;
+
+  return window.main.git.fetchGitRemoteBranches({ uri, credentials });
 };

--- a/packages/insomnia/src/ui/routes/$organizationId.git.tsx
+++ b/packages/insomnia/src/ui/routes/$organizationId.git.tsx
@@ -1,8 +1,8 @@
 import { type ActionFunction, redirect } from 'react-router';
 
 import type { WorkspaceScope } from '../../models/workspace';
-import { invariant } from '../../utils/invariant';
 import type { GitCredentials } from '../../sync/git/git-vcs';
+import { invariant } from '../../utils/invariant';
 
 export type InitGitCloneResult =
   | {

--- a/packages/insomnia/src/ui/routes/$organizationId.git.tsx
+++ b/packages/insomnia/src/ui/routes/$organizationId.git.tsx
@@ -83,16 +83,10 @@ export const cloneGitRepoAction: ActionFunction = async ({ request, params }): P
 export const fetchRemoteBranchesAction: ActionFunction = async ({ request }) => {
   const data = (await request.json()) as {
     uri: string;
-    token: string;
-    provider: 'github' | 'gitlab';
+    credentials: GitCredentials;
   };
 
-  const { uri, provider } = data;
-
-  const credentials = {
-    oauth2format: provider,
-    token: data.token,
-  } as GitCredentials;
+  const { uri, credentials } = data;
 
   return window.main.git.fetchGitRemoteBranches({ uri, credentials });
 };

--- a/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.git.tsx
+++ b/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.git.tsx
@@ -105,6 +105,95 @@ export const canPushLoader: LoaderFunction = async ({ params }): Promise<GitCanP
 };
 
 // Actions
+export type InitGitCloneResult =
+  | {
+      files: {
+        scope: WorkspaceScope;
+        name: string;
+        path: string;
+      }[];
+    }
+  | {
+      errors: string[];
+    };
+
+export const initGitCloneAction: ActionFunction = async ({ request, params }) => {
+  const { organizationId } = params;
+  invariant(organizationId, 'Organization ID is required');
+
+  const formData = await request.formData();
+
+  const data = Object.fromEntries(formData.entries()) as {
+    authorEmail: string;
+    authorName: string;
+    token: string;
+    uri: string;
+    username: string;
+    oauth2format: string;
+    ref?: string;
+  };
+
+  const initCloneResult = await window.main.git.initGitRepoClone({
+    organizationId,
+    ...data,
+  });
+
+  if ('errors' in initCloneResult) {
+    return { errors: initCloneResult.errors };
+  }
+
+  return {
+    files: initCloneResult.files,
+  };
+};
+
+export const fetchRemoteBranchesAction: ActionFunction = async ({ request }) => {
+  const data = (await request.json()) as {
+    uri: string;
+    token: string;
+    provider: 'github' | 'gitlab';
+  };
+  const { uri, provider } = data;
+
+  return window.main.git.fetchGitRemoteBranches({ uri, credentials: { oauth2format: provider } });
+};
+
+type CloneGitActionResult =
+  | Response
+  | {
+      errors?: string[];
+    };
+export const cloneGitRepoAction: ActionFunction = async ({ request, params }): Promise<CloneGitActionResult> => {
+  const { organizationId } = params;
+  invariant(organizationId, 'Organization ID is required');
+
+  const formData = await request.formData();
+
+  const data = Object.fromEntries(formData.entries()) as {
+    authorEmail: string;
+    authorName: string;
+    token: string;
+    uri: string;
+    username: string;
+    oauth2format: string;
+    ref?: string;
+  };
+
+  const { errors, projectId } = await window.main.git.cloneGitRepo({
+    organizationId,
+    ...data,
+  });
+
+  if (errors) {
+    return { errors };
+  }
+
+  invariant(organizationId, 'Organization ID is required');
+  invariant(projectId, 'Project ID is required');
+
+  return redirect(`/organization/${organizationId}/project/${projectId}`);
+};
+
 export const updateGitRepoAction: ActionFunction = async ({ request, params }) => {
   const { projectId } = params;
   invariant(projectId, 'Project ID is required');

--- a/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.git.tsx
+++ b/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.git.tsx
@@ -1,4 +1,4 @@
-import { redirect, type ActionFunction, type LoaderFunction } from 'react-router';
+import { type ActionFunction, type LoaderFunction,redirect } from 'react-router';
 
 import * as models from '../../models';
 import type { GitRepository } from '../../models/git-repository';

--- a/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.git.tsx
+++ b/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.git.tsx
@@ -3,7 +3,7 @@ import { type ActionFunction, type LoaderFunction } from 'react-router';
 import * as models from '../../models';
 import type { GitRepository } from '../../models/git-repository';
 import type { WorkspaceScope } from '../../models/workspace';
-import type { GitLogEntry } from '../../sync/git/git-vcs';
+import type { GitCredentials, GitLogEntry } from '../../sync/git/git-vcs';
 import type { MergeConflict } from '../../sync/types';
 import { invariant } from '../../utils/invariant';
 
@@ -153,9 +153,15 @@ export const fetchRemoteBranchesAction: ActionFunction = async ({ request }) => 
     token: string;
     provider: 'github' | 'gitlab';
   };
+
   const { uri, provider } = data;
 
-  return window.main.git.fetchGitRemoteBranches({ uri, credentials: { oauth2format: provider } });
+  const credentials = {
+    oauth2format: provider,
+    token: data.token,
+  } as GitCredentials;
+
+  return window.main.git.fetchGitRemoteBranches({ uri, credentials });
 };
 
 type CloneGitActionResult =

--- a/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.git.tsx
+++ b/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.git.tsx
@@ -1,9 +1,9 @@
-import { type ActionFunction, type LoaderFunction } from 'react-router';
+import { redirect, type ActionFunction, type LoaderFunction } from 'react-router';
 
 import * as models from '../../models';
 import type { GitRepository } from '../../models/git-repository';
 import type { WorkspaceScope } from '../../models/workspace';
-import type { GitCredentials, GitLogEntry } from '../../sync/git/git-vcs';
+import type { GitLogEntry } from '../../sync/git/git-vcs';
 import type { MergeConflict } from '../../sync/types';
 import { invariant } from '../../utils/invariant';
 
@@ -145,23 +145,6 @@ export const initGitCloneAction: ActionFunction = async ({ request, params }) =>
   return {
     files: initCloneResult.files,
   };
-};
-
-export const fetchRemoteBranchesAction: ActionFunction = async ({ request }) => {
-  const data = (await request.json()) as {
-    uri: string;
-    token: string;
-    provider: 'github' | 'gitlab';
-  };
-
-  const { uri, provider } = data;
-
-  const credentials = {
-    oauth2format: provider,
-    token: data.token,
-  } as GitCredentials;
-
-  return window.main.git.fetchGitRemoteBranches({ uri, credentials });
 };
 
 type CloneGitActionResult =

--- a/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.git.tsx
+++ b/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.git.tsx
@@ -1,4 +1,4 @@
-import { type ActionFunction, type LoaderFunction,redirect } from 'react-router';
+import { type ActionFunction, type LoaderFunction, redirect } from 'react-router';
 
 import * as models from '../../models';
 import type { GitRepository } from '../../models/git-repository';
@@ -195,6 +195,7 @@ export const updateGitRepoAction: ActionFunction = async ({ request, params }) =
     uri: string;
     username: string;
     oauth2format: string;
+    ref?: string;
   };
 
   return window.main.git.updateGitRepo({

--- a/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.workspace.$workspaceId.git.tsx
+++ b/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.workspace.$workspaceId.git.tsx
@@ -187,6 +187,7 @@ export const updateGitRepoAction: ActionFunction = async ({ request, params }) =
     uri: string;
     username: string;
     oauth2format: string;
+    ref?: string; // Optional ref for shallow clone
   };
 
   return window.main.git.updateGitRepo({


### PR DESCRIPTION
# Overview

When cloning a remote repository we always default to cloning the remote HEAD ref as the default branch.
This PR introduces the (optional) ability to select the branch to clone in the repository clone modal.

TODO
- [x] Use a Combobox Picker to select the desired branch
- [x] Ensure this works with all providers (github/gitlab/custom)
- [x] Decide if users should be able to move forward and clone the repo on the default branch or have to wait for the branches to load
- [x] Cleanup repository info Form and update to loader/actions for async work