### PR TITLE
fix: closest folder auth determination logic [INS-638]

### DIFF
--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -72,9 +72,9 @@ export const getOrInheritAuthentication = ({
     return request.authentication;
   }
   const hasParentFolders = requestGroups.length > 0;
-  const closestParentFolderWithAuth = requestGroups.find(
-    ({ authentication }) => getAuthObjectOrNull(authentication) && isAuthEnabled(authentication),
-  );
+  const closestParentFolderWithAuth = requestGroups
+    .reverse()
+    .find(({ authentication }) => getAuthObjectOrNull(authentication) && isAuthEnabled(authentication));
   const closestAuth = getAuthObjectOrNull(closestParentFolderWithAuth?.authentication);
   const shouldCheckFolderAuth = hasParentFolders && closestAuth;
   if (shouldCheckFolderAuth) {

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -72,7 +72,7 @@ export const getOrInheritAuthentication = ({
     return request.authentication;
   }
   const hasParentFolders = requestGroups.length > 0;
-  const closestParentFolderWithAuth = requestGroups
+  const closestParentFolderWithAuth = [...requestGroups]
     .reverse()
     .find(({ authentication }) => getAuthObjectOrNull(authentication) && isAuthEnabled(authentication));
   const closestAuth = getAuthObjectOrNull(closestParentFolderWithAuth?.authentication);

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -213,9 +213,9 @@ async function getExistingAccessTokenAndRefreshIfExpired(
   const requestGroups = (
     await db.withAncestors<Request | RequestGroup>(activeRequest, [models.requestGroup.type])
   ).filter(isRequestGroup) as RequestGroup[];
-  const closestFolderAuth = requestGroups.find(
-    ({ authentication }) => getAuthObjectOrNull(authentication) && isAuthEnabled(authentication),
-  );
+  const closestFolderAuth = requestGroups
+    .reverse()
+    .find(({ authentication }) => getAuthObjectOrNull(authentication) && isAuthEnabled(authentication));
   const isRequestAuthEnabled =
     getAuthObjectOrNull(activeRequest?.authentication) && isAuthEnabled(activeRequest?.authentication);
   const closestAuthId = isRequestAuthEnabled ? requestId : closestFolderAuth?._id || requestId;

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -213,7 +213,7 @@ async function getExistingAccessTokenAndRefreshIfExpired(
   const requestGroups = (
     await db.withAncestors<Request | RequestGroup>(activeRequest, [models.requestGroup.type])
   ).filter(isRequestGroup) as RequestGroup[];
-  const closestFolderAuth = requestGroups
+  const closestFolderAuth = [...requestGroups]
     .reverse()
     .find(({ authentication }) => getAuthObjectOrNull(authentication) && isAuthEnabled(authentication));
   const isRequestAuthEnabled =


### PR DESCRIPTION
When request groups (folders) for a request are fetched from the database using `withAncestors`, the resulting array is sorted from highest level to lowest, so auth determinations will prioritize the highest if auth info is defined there.

This change performs an non-destructive reverse on that list so that the first found folder with auth info is closer to the request itself.