### PR TITLE
fix(GitRemoteBranchSelect): update fetcher key to use deferred URL value

### DIFF
--- a/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
@@ -14,11 +14,11 @@ export const GitRemoteBranchSelect = ({
   isDisabled: boolean;
   credentials: GitCredentials;
 }) => {
-  const remoteBranchesFetcher = useFetcher<{ branches: string[] }>({ key: url || 'branch-select' });
+  const uri = useDeferredValue(url);
+  const remoteBranchesFetcher = useFetcher<{ branches: string[] }>({ key: `branch-select:${uri}` });
   const { organizationId } = useParams<{ organizationId: string }>();
 
   const isLoadingRemoteBranches = remoteBranchesFetcher.state !== 'idle';
-  const uri = useDeferredValue(url);
 
   useEffect(() => {
     if (uri && remoteBranchesFetcher.state === 'idle' && !remoteBranchesFetcher.data) {


### PR DESCRIPTION
# Overview:

In the new remote-branch-select we use the deferred url to fetch the latest branches which can lead to a race condition and fetch the previous data.

We use the deferred url as a cache key for the fetcher instead to make sure these two are synchronized 