### PR TITLE
Fix the bug that it can not fetch oauth token for a folder [INS-1025]

### DIFF
--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -412,6 +412,11 @@ const sendAccessTokenRequest = async (
   const newRequest: Request = await models.initModel(
     models.request.type,
     {
+      // Do not inherit authentication from parent request or group since this is a special request
+      authentication: {
+        type: 'none',
+        disabled: false,
+      },
       headers: [...defaultHeaders, ...headers],
       url: setDefaultProtocol(authentication.accessTokenUrl),
       method: 'POST',


### PR DESCRIPTION
Close [INS-1025](https://konghq.atlassian.net/jira/software/c/projects/INS/issues/?jql=project%20%3D%20%22INS%22%20ORDER%20BY%20created%20DESC&selectedIssue=INS-1025)

[INS-1025]: https://konghq.atlassian.net/browse/INS-1025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

For the folder A that has OAuth authorization configured, when clicking "Fetch Token", a new window will first open to allow the user to authorize and obtain the authorization code.

After that, a "Get Token" request will be sent. During this process, a new request B is created in the database, and request B inherits the OAuth settings from folder A. As a result, when the "Get Token" request is sent, the authorization window pops up again to obtain the code.

This is why the user authorization window appears twice and the token cannot be obtained correctly.
