### PR TITLE
fix: add a NoSelectedProjectView and ensure it doesn't error when project not found

### DIFF
--- a/packages/insomnia/src/ui/components/panes/no-selected-project-view.tsx
+++ b/packages/insomnia/src/ui/components/panes/no-selected-project-view.tsx
@@ -1,0 +1,10 @@
+import React, { type FC } from 'react';
+
+export const NoSelectedProjectView: FC = () => {
+  return (
+    <div className="flex h-full w-full flex-col items-center gap-3 pt-[15%] text-center">
+      <span className="text-xl font-semibold">Welcome to your organization!</span>
+      <span className="text-md">Select a project to get started</span>
+    </div>
+  );
+};

--- a/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.delete.tsx
+++ b/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.delete.tsx
@@ -3,6 +3,7 @@ import { type ActionFunctionArgs, redirect } from 'react-router';
 import { database } from '../../common/database';
 import * as models from '../../models';
 import { invariant } from '../../utils/invariant';
+import { getInitialRouteForOrganization } from '../../utils/router';
 import { insomniaFetch } from '../insomniaFetch';
 
 export async function action({ params }: ActionFunctionArgs) {
@@ -47,7 +48,10 @@ export async function action({ params }: ActionFunctionArgs) {
     await models.project.remove(project);
 
     await database.flushChanges(bufferId);
-    return redirect(`/organization/${organizationId}`);
+
+    // When redirect to `/organizations/:organizationId`, it sometimes doesn't reload the index loader, so manually redirect to the initial route for the organization
+    const initialOrganizationRoute = await getInitialRouteForOrganization({ organizationId });
+    return redirect(initialOrganizationRoute);
   } catch (err) {
     console.log(err);
     return {

--- a/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.tsx
+++ b/packages/insomnia/src/ui/routes/$organizationId.project.$projectId.tsx
@@ -78,6 +78,7 @@ import { ImportModal } from '../components/modals/import-modal/import-modal';
 import { NewWorkspaceModal } from '../components/modals/new-workspace-modal';
 import { ProjectModal } from '../components/modals/project-modal';
 import { NoProjectView } from '../components/panes/no-project-view';
+import { NoSelectedProjectView } from '../components/panes/no-selected-project-view';
 import { ProjectEmptyView } from '../components/project/project-empty-view';
 import { OrganizationTabList } from '../components/tabs/tab-list';
 import { TimeFromNow } from '../components/time-from-now';
@@ -261,7 +262,7 @@ export interface InsomniaFile {
 }
 
 export interface ProjectIdLoaderData {
-  activeProject?: Project;
+  activeProject?: Project | null;
 }
 
 export interface ProjectLoaderData {
@@ -380,9 +381,8 @@ async function getAllLocalFiles({ projectId }: { projectId: string }) {
 async function getAllRemoteFiles({ projectId, organizationId }: { projectId: string; organizationId: string }) {
   try {
     const project = await models.project.getById(projectId);
-    invariant(project, 'Project not found');
 
-    const remoteId = project.remoteId;
+    const remoteId = project?.remoteId;
     console.log(
       '[getAllRemoteFiles] start fetching remote backend workspaces for project',
       projectId,
@@ -438,7 +438,7 @@ async function getAllRemoteFiles({ projectId, organizationId }: { projectId: str
 
 export interface ListWorkspacesLoaderData {
   files: InsomniaFile[];
-  activeProject?: Project;
+  activeProject?: Project | null;
   projects: Project[];
 }
 
@@ -448,7 +448,6 @@ export const listWorkspacesLoader: LoaderFunction = async ({ params }): Promise<
   invariant(projectId, 'Project ID is required');
 
   const project = await models.project.getById(projectId);
-  invariant(project, `Project was not found ${projectId}`);
   const organizationProjects =
     (await database.find<Project>(models.project.type, {
       parentId: organizationId,
@@ -469,7 +468,6 @@ export const projectIdLoader: LoaderFunction = async ({ params }): Promise<Proje
   invariant(projectId, 'Project ID is required');
 
   const project = await models.project.getById(projectId);
-  invariant(project, `Project was not found ${projectId}`);
 
   return {
     activeProject: project,
@@ -587,8 +585,7 @@ export const loader: LoaderFunction = async ({ params }) => {
   invariant(projectId, 'projectId parameter is required');
 
   const project = await models.project.getById(projectId);
-  invariant(project, `Project was not found ${projectId}`);
-  console.log('[project loader] Loading project:', project.name, projectId);
+  console.log('[project loader] Loading project:', project?.name, projectId);
   const [localFiles, organizationProjects = []] = await Promise.all([
     getAllLocalFiles({ projectId }),
     getProjectsWithGitRepositories({ organizationId }),
@@ -601,9 +598,8 @@ export const loader: LoaderFunction = async ({ params }) => {
 
   const projectsSyncStatusPromise = CheckAllProjectSyncStatus(projects);
 
-  const activeProjectGitRepository = isGitProject(project)
-    ? await models.gitRepository.getById(project.gitRepositoryId || '')
-    : null;
+  const activeProjectGitRepository =
+    project && isGitProject(project) ? await models.gitRepository.getById(project.gitRepositoryId || '') : null;
 
   return {
     localFiles,
@@ -1451,6 +1447,8 @@ const ProjectRoute: FC = () => {
                   </GridList>
                 </div>
               </div>
+            ) : projects.length ? (
+              <NoSelectedProjectView />
             ) : (
               <NoProjectView isGitSyncEnabled={isGitSyncEnabled} storageRules={storageRules} />
             )}


### PR DESCRIPTION
[INS-979](https://konghq.atlassian.net/browse/INS-979)

## Changes

- add a `NoSelectedProjectView`, but it's only for a transition state, so you wouldn't see it.
- redirect to the initial route instead of `/organization/${organizationId}`
- remove unnecessary invariants of the project to avoid errors

[INS-979]: https://konghq.atlassian.net/browse/INS-979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ