### PR TITLE
feat(Inso CLI): Improve error messages when Inso cannot find Insomnia data or global environments

### DIFF
--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -562,7 +562,14 @@ export const go = (args?: string[]) => {
               env => matchIdIsh(env, options.globals) || env.name === options.globals,
             );
             if (!globalEnv) {
-              logger.warn('No global environment found with id or name', options.globals);
+              logger.warn(
+                `Error: No global environment found with ID or name "${options.globals}".
+                TIP: If you're running "inso" inside a Git project, specify the path to the Insomnia YAML file containing the global environment using the "--globals" option.
+                
+                Example:
+                  $ inso run collection --globals /path/to/global-environment.yaml
+                `,
+              );
               return process.exit(1);
             }
             if (globalEnv) {

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -564,10 +564,10 @@ export const go = (args?: string[]) => {
             if (!globalEnv) {
               logger.warn(
                 `Error: No global environment found with ID or name "${options.globals}".
-                TIP: If you're running "inso" inside a Git project, specify the path to the Insomnia YAML file containing the global environment using the "--globals" option.
-                
-                Example:
-                  $ inso run collection --globals /path/to/global-environment.yaml
+  TIP: If you're running "inso" inside a Git project, specify the path to the Insomnia YAML file containing the global environment using the "--globals" option.
+  
+  Example:
+    $ inso run collection --globals /path/to/global-environment.yaml
                 `,
               );
               return process.exit(1);
@@ -904,11 +904,10 @@ export const go = (args?: string[]) => {
       program.parseAsync(scriptArgs).catch(logErrorAndExit);
     });
 
-  program.command('generate-docs')
-    .action(() => {
-      generateDocumentation(program);
-      return process.exit(1);
-    });
+  program.command('generate-docs').action(() => {
+    generateDocumentation(program);
+    return process.exit(1);
+  });
 
   program.parseAsync(args || process.argv).catch(logErrorAndExit);
 };

--- a/packages/insomnia-inso/src/db/index.ts
+++ b/packages/insomnia-inso/src/db/index.ts
@@ -90,9 +90,23 @@ export const loadDb = async ({ pathToSearch, filterTypes }: Options) => {
   }
 
   logger.warn(
-    `No git, app data store or Insomnia V4 export file found at path "${pathToSearch}",
-     --workingDir/-w should point to a git repository root, an Insomnia export file or a directory containing Insomnia data.
-      re-run with --verbose to see tracing information`,
+    `Error: No data source found at path "${pathToSearch}".
+  TIP: Use "--workingDir/-w" to specify one of the following:
+    - A Git repository root
+    - An Insomnia export file
+    - A directory containing Insomnia data
+  
+  Examples:
+    1. Using a (legacy) Git repository:
+       $ inso run collection --workingDir /path/to/git-repo
+  
+    2. Using an Insomnia export file or inside a Git project:
+       $ inso run collection --workingDir /path/to/insomnia-file.yaml
+  
+    3. Using a directory with Insomnia app data:
+       $ inso run collection --workingDir /path/to/insomnia-data
+  
+  Re-run with "--verbose" for more details.`,
   );
 
   return emptyDb();


### PR DESCRIPTION
# Overview

- In some cases Inso supports loading global environments using a portion of their ID. For the cases it doesn't the user needs to pass the exported Insomnia YAML file path.
- Inso also can automatically figure out if it's running in a _legacy_ Git repository and load all the data from the `.insomnia` directory. When running in the new Git Project format the user needs to pass the file path instead.

This PR improves the error messages for when no data are found for either case and displays examples for how to load the data correctly.

Closes INS-755