### PR TITLE
Closes #8946. OAuth2 plugin refresh token issue using basic auth for client credentials.

### DIFF
--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -293,8 +293,7 @@ async function getExistingAccessTokenAndRefreshIfExpired(
   } else {
     headers.push(getBasicAuthHeader(authentication.clientId, authentication.clientSecret));
   }
-  // Why not send headers here?
-  const response = await sendAccessTokenRequest(requestId, authentication, params, []);
+  const response = await sendAccessTokenRequest(requestId, authentication, params, headers);
 
   const statusCode = response.statusCode || 0;
   const bodyBuffer = await models.response.getBodyBuffer(response);


### PR DESCRIPTION

Closes #8946

Fixes issue when using Basic Auth for client credentials on OAuth2 authentication.
When using Basic Auth for client credentials, the refresh token functionality fails as it doesn't send the credentials in Authorization header.