### PR TITLE
feat: add data folder constraint for read file tags - INS-1062

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 
-import { loadFixture } from '../../playwright/paths';
+import { getFixturePath, loadFixture } from '../../playwright/paths';
 import { test } from '../../playwright/test';
 
 const testVaultKey =
@@ -79,6 +79,11 @@ test.describe('Check vault used in environment', () => {
   });
 
   test('test global private sub environment to store vaults', async ({ page, app }) => {
+    await page.getByTestId('settings-button').click();
+    await page.getByTestId('dataFolders').fill(getFixturePath('vault-collection.yaml'));
+    await page.getByTestId('dataFolders-btn').click();
+    await page.locator('.app').press('Escape');
+    
     // import requests
     const requestColText = await loadFixture('vault-collection.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), requestColText);
@@ -205,6 +210,6 @@ test.describe('Check vault used in environment', () => {
     await page.getByTestId('legacy-invalid-vault').getByLabel('GET legacy-invalid-vault', { exact: true }).click();
     await page.getByRole('button', { name: 'Send' }).click(); // Expect to see error message
     await expect.soft(page.getByText('Unexpected Request Failure')).toBeVisible();
-    await expect.soft(page.getByText('vault is a reserved key for insomnia vault')).toBeVisible();
+    await expect.soft(page.getByText('Error: vault is a reserved')).toBeVisible();
   });
 });

--- a/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
@@ -76,6 +76,7 @@ test('Critical Path For Template Tags Interactions', async ({ page, app }) => {
 
   await page.getByTestId('settings-button').click();
   await page.getByTestId('dataFolders').fill(getFixturePath('files/template-file.txt'));
+  await page.getByTestId('dataFolders-btn').click();
   await page.locator('.app').press('Escape');
 
   // test common template tags

--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -478,6 +478,8 @@ export async function getRenderContext({
     getKeySource(transientVariables.data || {}, inKey, transientVariables.name || 'scriptLocalVariables');
   }
 
+  const settings = await models.settings.get();
+
   // Add meta data helper function
   const baseContext: BaseRenderContext = {
     getMeta: () => ({
@@ -493,6 +495,7 @@ export async function getRenderContext({
     getGlobalEnvironmentId: () => subGlobalEnvironment?._id || rootGlobalEnvironment?._id,
     // It is possible for a project to not exist because this code path can be reached via Inso which has no concept of a project.
     getProjectId: () => project?._id,
+    getSettings: () => ({ dataFolders: settings.dataFolders }),
   };
 
   // Generate the context we need to render
@@ -577,7 +580,7 @@ export async function getRenderedRequestAndContext({
       o.query = o.query.replace(/#}/g, '# }');
       request.body.text = JSON.stringify(o);
     }
-  } catch (err) {}
+  } catch (err) { }
 
   // Render description separately because it's lower priority
   const description = request.description;

--- a/packages/insomnia/src/templating/base-extension-worker.ts
+++ b/packages/insomnia/src/templating/base-extension-worker.ts
@@ -179,8 +179,13 @@ export default class BaseExtension {
       meta: renderMeta,
       renderPurpose,
       util: {
-        readFile: async (path: string, encoding?: string) =>
-          fetchFromTemplateWorkerDatabase('readFile', { path, encoding }),
+        readFile: async (path: string, encoding?: string) => {
+          const allowed = renderContext?.getSettings().dataFolders.some((folder: string) => folder !== '' && path.startsWith(folder));
+          if (!allowed) {
+            throw `Insomnia cannot access the file ‘${path}’. You can adjust this in Preferences → Security.`;
+          }
+          return fetchFromTemplateWorkerDatabase('readFile', { path, encoding });
+        },
         nodeOS: async () => fetchFromTemplateWorkerDatabase('nodeOS', {}),
         decode: async (buffer: Buffer, encoding?: string) =>
           fetchFromTemplateWorkerDatabase('decode', { buffer, encoding }),

--- a/packages/insomnia/src/templating/base-extension.ts
+++ b/packages/insomnia/src/templating/base-extension.ts
@@ -118,6 +118,11 @@ export default class BaseExtension {
           };
         },
         readFile: async (path: string, encoding = 'utf8') => {
+          const allowed = renderContext?.getSettings().dataFolders.some((folder: string) => folder !== '' && path.startsWith(folder));
+          if (!allowed) {
+            throw `Insomnia cannot access the file ‘${path}’. You can adjust this in Preferences → Security.`;
+          }
+                    
           const content = await fs.promises.readFile(path);
           return encoding === 'utf8' ? content.toString(encoding) : content;
         },

--- a/packages/insomnia/src/ui/components/rendered-query-string.tsx
+++ b/packages/insomnia/src/ui/components/rendered-query-string.tsx
@@ -14,6 +14,7 @@ import type { SocketIORequest } from '../../models/socket-io-request';
 import type { WebSocketRequest } from '../../models/websocket-request';
 import { getAuthObjectOrNull, isAuthEnabled } from '../../network/authentication';
 import { getOrInheritAuthentication } from '../../network/network';
+import { RenderError } from '../../templating/render-error';
 import { buildQueryStringFromParams, joinUrlAndQueryString, smartEncodeUrl } from '../../utils/url/querystring';
 import { useNunjucks } from '../context/nunjucks/use-nunjucks';
 import { CopyButton } from './base/copy-button';
@@ -108,7 +109,11 @@ export const RenderedQueryString: FC<Props> = ({ request }) => {
       } catch (error: unknown) {
         console.warn(error);
         setTooLong(false);
-        setPreviewString(defaultPreview);
+        if (typeof error === 'object' && error instanceof RenderError) {
+          setPreviewString(error.message);
+        } else {
+          setPreviewString(defaultPreview);
+        }
       }
     };
     fn();

--- a/packages/insomnia/src/ui/components/settings/text-array-setting.tsx
+++ b/packages/insomnia/src/ui/components/settings/text-array-setting.tsx
@@ -67,6 +67,7 @@ export const TextArraySetting: FC<{
             className="btn btn--outlined btn--super-compact flex items-center gap-2"
             disabled={disabled}
             onClick={onAddDataFolder}
+            data-testid={`${setting}-btn`}
           >
             Add
           </button>

--- a/packages/insomnia/src/ui/worker/templating-handler.ts
+++ b/packages/insomnia/src/ui/worker/templating-handler.ts
@@ -22,6 +22,7 @@ export function renderInWorker({ input, context, path, ignoreUndefinedEnvVariabl
       keysContext: context.getKeysContext(),
       projectId: context.getProjectId(),
       purpose: context.getPurpose(),
+      settings: context.getSettings(),
     },
   };
 

--- a/packages/insomnia/src/ui/worker/templating-worker.ts
+++ b/packages/insomnia/src/ui/worker/templating-worker.ts
@@ -27,6 +27,7 @@ self.onmessage = async event => {
     context.getKeysContext = () => context.serializedFunctions.keysContext;
     context.getProjectId = () => context.serializedFunctions.projectId;
     context.getPurpose = () => context.serializedFunctions.purpose;
+    context.getSettings = () => context.serializedFunctions.settings;
     const result = await performJob({ input, context, path, ignoreUndefinedEnvVariable });
     self.postMessage({ id, result });
   } catch (err) {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Changes
- [x] Add getSettings to the rendering context
- [x] In read file interface, get data folders from settings and validate template's file path
- [x] Return error message in tag modal and preview
- [x] Make it work in worker and renderer
- [x] Updated smoke test

<img width="2596" height="670" alt="image" src="https://github.com/user-attachments/assets/c2c4f5cd-6dd9-43a0-81df-9c2f74341290" />

<img width="1792" height="1122" alt="image" src="https://github.com/user-attachments/assets/57c84628-b4d6-422d-a600-f3e0fc9d51f5" />
