### PR TITLE
add iconv-lite encode

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
@@ -22,7 +22,7 @@ const templateTagTestCases: Record<string, TemplateTagTestCase[]> = {
   hash: [
     {
       tagPrefix: "{% hash 'md5', 'hex', 'insomnia-test' %}",
-      expectedResult: 'b79b28083768d54575eacc7389e9128624685310',
+      expectedResult: 'b9c076eabf32fa4cdd7573a6df12d33c',
     },
   ],
   jsonPath: [{ tagPrefix: '{% jsonpath', expectedResult: 'bar' }],

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -1,3 +1,5 @@
+import type { BinaryToTextEncoding } from 'node:crypto';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 
@@ -71,8 +73,8 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
   'decode': async (body: { buffer: Buffer; encoding: 'utf8' }) => {
     return iconv.decode(body.buffer, body.encoding || 'utf8');
   },
-  'encode': async (body: { input: string; encoding: 'utf8' }) => {
-    return iconv.encode(body.input, body.encoding || 'utf8');
+  'encode': async (body: { input: string; encoding: BinaryToTextEncoding }) => {
+    return crypto.createHash('md5').update(body.input).digest(body.encoding);
   },
   'request.getById': async (body: { id: string }) => {
     return await models.request.getById(body.id);

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -71,6 +71,9 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
   'decode': async (body: { buffer: Buffer; encoding: 'utf8' }) => {
     return iconv.decode(body.buffer, body.encoding || 'utf8');
   },
+  'encode': async (body: { input: string; encoding: 'utf8' }) => {
+    return iconv.encode(body.input, body.encoding || 'utf8');
+  },
   'request.getById': async (body: { id: string }) => {
     return await models.request.getById(body.id);
   },

--- a/packages/insomnia/src/templating/base-extension-worker.ts
+++ b/packages/insomnia/src/templating/base-extension-worker.ts
@@ -189,6 +189,8 @@ export default class BaseExtension {
         nodeOS: async () => fetchFromTemplateWorkerDatabase('nodeOS', {}),
         decode: async (buffer: Buffer, encoding?: string) =>
           fetchFromTemplateWorkerDatabase('decode', { buffer, encoding }),
+        encode: async (input: string, encoding?: string) =>
+          fetchFromTemplateWorkerDatabase('encode', { input, encoding }),
         render: (str: string) => templating.render(str, { context: renderContext }),
         openInBrowser: (url: string) => fetchFromTemplateWorkerDatabase('openInBrowser', { url }),
         models: {

--- a/packages/insomnia/src/templating/base-extension.ts
+++ b/packages/insomnia/src/templating/base-extension.ts
@@ -1,3 +1,5 @@
+import type { BinaryToTextEncoding } from 'node:crypto';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 
@@ -127,7 +129,8 @@ export default class BaseExtension {
           return encoding === 'utf8' ? content.toString(encoding) : content;
         },
         decode: async (buffer: Buffer, encoding = 'utf8') => iconv.decode(buffer, encoding),
-        encode: async (input: string, encoding = 'utf8') => iconv.encode(input, encoding),
+        encode: async (input: string, encoding: BinaryToTextEncoding) =>
+          crypto.createHash('md5').update(input).digest(encoding),
         render: (str: string) =>
           templating.render(str, {
             context: renderContext,

--- a/packages/insomnia/src/templating/base-extension.ts
+++ b/packages/insomnia/src/templating/base-extension.ts
@@ -126,9 +126,8 @@ export default class BaseExtension {
           const content = await fs.promises.readFile(path);
           return encoding === 'utf8' ? content.toString(encoding) : content;
         },
-        decode: async (buffer: Buffer, encoding = 'utf8') => {
-          return iconv.decode(buffer, encoding);
-        },
+        decode: async (buffer: Buffer, encoding = 'utf8') => iconv.decode(buffer, encoding),
+        encode: async (input: string, encoding = 'utf8') => iconv.encode(input, encoding),
         render: (str: string) =>
           templating.render(str, {
             context: renderContext,

--- a/packages/insomnia/src/templating/local-template-tags.ts
+++ b/packages/insomnia/src/templating/local-template-tags.ts
@@ -228,7 +228,7 @@ const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
       ],
       async run(context, algorithm: 'md5' | 'sha1' | 'sha256' | 'sha512', encoding: 'hex' | 'base64', value = '') {
         if (encoding !== 'hex' && encoding !== 'base64') {
-          throw new Error(`Invalid encoding ${encoding}. Choices are hex, latin1, base64`);
+          throw new Error(`Invalid encoding ${encoding}. Choices are hex, base64`);
         }
 
         const valueType = typeof value;

--- a/packages/insomnia/src/templating/local-template-tags.ts
+++ b/packages/insomnia/src/templating/local-template-tags.ts
@@ -226,8 +226,8 @@ const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
           placeholder: 'Value to hash',
         },
       ],
-      async run(context, algorithm: 'md5' | 'sha1' | 'sha256' | 'sha512', encoding, value = '') {
-        if (encoding !== 'hex' && encoding !== 'latin1' && encoding !== 'base64') {
+      async run(context, algorithm: 'md5' | 'sha1' | 'sha256' | 'sha512', encoding: 'hex' | 'base64', value = '') {
+        if (encoding !== 'hex' && encoding !== 'base64') {
           throw new Error(`Invalid encoding ${encoding}. Choices are hex, latin1, base64`);
         }
 
@@ -252,9 +252,6 @@ const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
 
         if (encoding === 'base64') {
           return btoa(String.fromCharCode.apply(null, hashArray));
-        }
-        if (encoding === 'latin1') {
-          return String.fromCharCode.apply(null, hashArray);
         }
         // hex
         return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');

--- a/packages/insomnia/src/templating/local-template-tags.ts
+++ b/packages/insomnia/src/templating/local-template-tags.ts
@@ -226,7 +226,7 @@ const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
           placeholder: 'Value to hash',
         },
       ],
-      async run(_context, algorithm: 'md5' | 'sha1' | 'sha256' | 'sha512', encoding, value = '') {
+      async run(context, algorithm: 'md5' | 'sha1' | 'sha256' | 'sha512', encoding, value = '') {
         if (encoding !== 'hex' && encoding !== 'latin1' && encoding !== 'base64') {
           throw new Error(`Invalid encoding ${encoding}. Choices are hex, latin1, base64`);
         }
@@ -235,9 +235,14 @@ const localTemplatePlugins: { templateTag: PluginTemplateTag }[] = [
         if (valueType !== 'string') {
           throw new Error(`Cannot hash value of type "${valueType}"`);
         }
+
+        const isMD5 = algorithm.toLowerCase() === 'md5';
+        if (isMD5) {
+          console.warn('MD5 is considered cryptographically broken');
+          return context.util.encode(value, encoding);
+        }
         const supportedAlgorithm: AlgorithmIdentifier =
           {
-            md5: 'SHA-1', //MD5 is considered cryptographically broken
             sha1: 'SHA-1',
             sha256: 'SHA-256',
             sha512: 'SHA-512',

--- a/packages/insomnia/src/templating/types.ts
+++ b/packages/insomnia/src/templating/types.ts
@@ -21,6 +21,7 @@ export type PluginToMainAPIPaths =
   | 'readFile'
   | 'nodeOS'
   | 'decode'
+  | 'encode'
   | 'request.getById'
   | 'request.getAncestors'
   | 'workspace.getById'
@@ -258,6 +259,7 @@ export interface PluginTemplateTagContext {
     }>;
     readFile: (path: string, encoding?: string) => Promise<string | Buffer>;
     decode: (buffer: Buffer, encoding?: string) => Promise<string>;
+    encode: (input: string, encoding?: string) => Promise<Buffer>;
     render: (str: string) => string | Promise<string | null>;
     openInBrowser?: (url: string) => void;
     models: {

--- a/packages/insomnia/src/templating/types.ts
+++ b/packages/insomnia/src/templating/types.ts
@@ -1,3 +1,5 @@
+import type { BinaryToTextEncoding } from 'node:crypto';
+
 import type { CloudProviderCredential } from '../models/cloud-credential';
 import type { CookieJar } from '../models/cookie-jar';
 import type { Environment, UserUploadEnvironment } from '../models/environment';
@@ -259,7 +261,7 @@ export interface PluginTemplateTagContext {
     }>;
     readFile: (path: string, encoding?: string) => Promise<string | Buffer>;
     decode: (buffer: Buffer, encoding?: string) => Promise<string>;
-    encode: (input: string, encoding?: string) => Promise<Buffer>;
+    encode: (input: string, encoding: BinaryToTextEncoding) => Promise<string>;
     render: (str: string) => string | Promise<string | null>;
     openInBrowser?: (url: string) => void;
     models: {


### PR DESCRIPTION
extend bridge to include encoding in order to continue support for md5 hash output

closes INS-1061
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
