### PR TITLE
fix: Support list folder environment keys in the editor auto-complete list

### DIFF
--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -11,7 +11,7 @@ import {
 import type { GrpcRequest, GrpcRequestBody } from '../models/grpc-request';
 import { isProject } from '../models/project';
 import { PATH_PARAMETER_REGEX, type Request } from '../models/request';
-import { isRequestGroup } from '../models/request-group';
+import { isRequestGroup, type RequestGroup } from '../models/request-group';
 import type { SocketIORequest } from '../models/socket-io-request';
 import type { WebSocketRequest } from '../models/websocket-request';
 import { isWorkspace, type Workspace } from '../models/workspace';
@@ -704,7 +704,7 @@ function _getOrderedEnvironmentKeys(finalRenderContext: Record<string, any>): st
 }
 
 export async function getRenderContextAncestors(
-  base?: Request | GrpcRequest | WebSocketRequest | SocketIORequest | Workspace,
+  base?: Request | GrpcRequest | WebSocketRequest | SocketIORequest | RequestGroup | Workspace,
 ): Promise<RenderContextAncestor[]> {
   return await db.withAncestors<RenderContextAncestor>(base || null, [
     models.request.type,

--- a/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
+++ b/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
@@ -23,7 +23,9 @@ initializeNunjucksRenderPromiseCache();
  * Access to functions useful for Nunjucks rendering
  */
 export const useNunjucks = (options?: UseNunjucksOptions) => {
+  // for all types of requests
   const requestData = useRequestLoaderData();
+  // for request group (folder)
   const { activeRequestGroup } = useRequestGroupLoaderData() || {};
   const workspaceData = useWorkspaceLoaderData();
 

--- a/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
+++ b/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { getRenderContext, getRenderContextAncestors, render } from '~/common/render';
 import { useWorkspaceLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { useRequestLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId';
+import { useRequestGroupLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.$requestGroupId';
 import { NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME } from '~/templating';
 import type { HandleRender, RenderContextOptions } from '~/templating/types';
 import { getKeys } from '~/templating/utils';
@@ -23,10 +24,13 @@ initializeNunjucksRenderPromiseCache();
  */
 export const useNunjucks = (options?: UseNunjucksOptions) => {
   const requestData = useRequestLoaderData();
+  const { activeRequestGroup } = useRequestGroupLoaderData() || {};
   const workspaceData = useWorkspaceLoaderData();
 
   const fetchRenderContext = useCallback(async () => {
-    const ancestors = await getRenderContextAncestors(requestData?.activeRequest || workspaceData?.activeWorkspace);
+    const ancestors = await getRenderContextAncestors(
+      requestData?.activeRequest || activeRequestGroup || workspaceData?.activeWorkspace,
+    );
     return getRenderContext({
       request: requestData?.activeRequest || undefined,
       environment: workspaceData?.activeEnvironment._id,
@@ -38,6 +42,7 @@ export const useNunjucks = (options?: UseNunjucksOptions) => {
     workspaceData?.activeWorkspace,
     workspaceData?.activeEnvironment._id,
     options?.renderContext,
+    activeRequestGroup,
   ]);
 
   const handleGetRenderContext = useCallback(


### PR DESCRIPTION
**Changes:** 
If user is in folder(request group), the folder environment is not added into Nunjuck render context.
Include the request group as render context ancestors when the request group is activated.

Close [INS-1109](https://konghq.atlassian.net/browse/INS-1109) https://github.com/Kong/insomnia/issues/8787

[INS-1109]: https://konghq.atlassian.net/browse/INS-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ