### PR TITLE
prune db methods, and improve type-checking

### DIFF
--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -9,8 +9,8 @@ import consola, { BasicReporter, FancyReporter, LogLevel } from 'consola';
 import { cosmiconfig } from 'cosmiconfig';
 import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from 'insomnia/src/common/constants';
 import { getSendRequestCallbackMemDb } from 'insomnia/src/common/send-request';
-import type { UserUploadEnvironment } from 'insomnia/src/models/environment';
-import { init, type as EnvironmentType } from 'insomnia/src/models/environment';
+import type { Environment, UserUploadEnvironment } from 'insomnia/src/models/environment';
+import { init } from 'insomnia/src/models/environment';
 import type { Request } from 'insomnia/src/models/request';
 import type { RequestGroup } from 'insomnia/src/models/request-group';
 import { deserializeNDJSON } from 'insomnia/src/utils/ndjson';
@@ -150,7 +150,7 @@ export const logErrorAndExit = (err?: Error) => {
 };
 const noConsoleLog = async <T>(callback: () => Promise<T>): Promise<T> => {
   const oldConsoleLog = console.log;
-  console.log = () => { };
+  console.log = () => {};
   try {
     return await callback();
   } finally {
@@ -313,9 +313,9 @@ export const go = (args?: string[]) => {
     cmd: T,
   ): Promise<
     GlobalOptions &
-    T & {
-      configFileContent: Awaited<ReturnType<typeof tryToReadInsoConfigFile>>;
-    }
+      T & {
+        configFileContent: Awaited<ReturnType<typeof tryToReadInsoConfigFile>>;
+      }
   > => {
     const globals: GlobalOptions = program.optsWithGlobals();
 
@@ -388,7 +388,11 @@ export const go = (args?: string[]) => {
       'Comma separated list of hostnames that do not require a proxy to get reached, even if one is specified.',
       proxySettings.noProxy,
     )
-    .option('-f, --dataFolders [dataFolders...]', 'This allows you to control what folders Insomnia (and scripts within Insomnia) can read/write to.', [])
+    .option(
+      '-f, --dataFolders [dataFolders...]',
+      'This allows you to control what folders Insomnia (and scripts within Insomnia) can read/write to.',
+      [],
+    )
     .action(
       async (
         identifier,
@@ -440,10 +444,10 @@ export const go = (args?: string[]) => {
           return process.exit(1);
         }
 
-        const transientVariables = {
+        const transientVariables: Environment = {
           ...init(),
           _id: uuidv4(),
-          type: EnvironmentType,
+          type: 'Environment',
           parentId: '',
           modified: 0,
           created: Date.now(),
@@ -519,7 +523,11 @@ export const go = (args?: string[]) => {
       'Comma separated list of hostnames that do not require a proxy to get reached, even if one is specified.',
       proxySettings.noProxy,
     )
-    .option('-f, --dataFolders [dataFolders...]', 'This allows you to control what folders Insomnia (and scripts within Insomnia) can read/write to.', [])
+    .option(
+      '-f, --dataFolders [dataFolders...]',
+      'This allows you to control what folders Insomnia (and scripts within Insomnia) can read/write to.',
+      [],
+    )
     .action(
       async (
         identifier,
@@ -697,10 +705,10 @@ export const go = (args?: string[]) => {
           const iterationCount = parseInt(options.iterationCount, 10);
 
           const iterationData = await pathToIterationData(options.iterationData, options.envVar);
-          const transientVariables = {
+          const transientVariables: Environment = {
             ...init(),
             _id: uuidv4(),
-            type: EnvironmentType,
+            type: 'Environment',
             parentId: '',
             modified: 0,
             created: Date.now(),
@@ -805,7 +813,7 @@ export const go = (args?: string[]) => {
       let isIdentifierAFile = false;
       try {
         isIdentifierAFile = identifier && (await fs.promises.stat(identifierAsAbsPath)).isFile();
-      } catch (err) { }
+      } catch (err) {}
       const pathToSearch = '';
       let specContent;
       let rulesetFileName;

--- a/packages/insomnia-inso/vitest.config.ts
+++ b/packages/insomnia-inso/vitest.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     hideSkippedTests: true,
+    alias: {
+      '~/': new URL('../insomnia/src/', import.meta.url).pathname,
+    },
     env: {
       DEFAULT_APP_NAME: process.env.DEFAULT_APP_NAME || 'insomnia-app',
     },

--- a/packages/insomnia-scripting-environment/src/objects/request.ts
+++ b/packages/insomnia-scripting-environment/src/objects/request.ts
@@ -534,6 +534,7 @@ export function mergeClientCertificates(
   if (updatedReq.certificate.pfx && updatedReq.certificate.pfx?.src !== '') {
     const specifiedCert: ClientCertificate = {
       ...baseCertificate,
+      type: 'ClientCertificate',
       key: null,
       cert: null,
       name: updatedReq.certificate.name || '',
@@ -555,7 +556,7 @@ export function mergeClientCertificates(
       ...baseCertificate,
 
       _id: '',
-      type: '',
+      type: 'ClientCertificate',
       parentId: '',
       modified: 0,
       created: 0,

--- a/packages/insomnia-scripting-environment/vitest.config.ts
+++ b/packages/insomnia-scripting-environment/vitest.config.ts
@@ -3,5 +3,8 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     hideSkippedTests: true,
+    alias: {
+      '~/': new URL('../insomnia/src/', import.meta.url).pathname,
+    },
   },
 });

--- a/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
+++ b/packages/insomnia-smoke-test/fixtures/pre-request-collection.yaml
@@ -1529,8 +1529,8 @@ environments:
   data:
     fromUrlValue: 'fromUrlValue'
     fromEditorValue: 'fromEditorValue'
-    examplehost: https://mock.insomnia.rest
+    examplehost: http://127.0.0.1:4010/echo
     a:
       b:
         c:
-          url: https://mock.insomnia.rest
+          url: http://127.0.0.1:4010/echo

--- a/packages/insomnia-smoke-test/tests/smoke/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/app.test.ts
@@ -26,12 +26,11 @@ test('can send requests', async ({ app, page }) => {
 
   await page.getByLabel('Create in collection').click();
   await page.getByRole('menuitemradio', { name: 'From Curl' }).click();
-  const curl = 'curl --request GET --url https://mock.insomnia.rest';
-  await page.locator('.CodeMirror textarea').fill(curl);
+  await page.locator('.CodeMirror textarea').fill('curl --request GET --url http://127.0.0.1:4010/echo');
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
 
   await expect
-    .soft(page.getByTestId('request-pane').getByTestId('OneLineEditor').getByText(`https://mock.insomnia.rest`))
+    .soft(page.getByTestId('request-pane').getByTestId('OneLineEditor').getByText(`http://127.0.0.1:4010/echo`))
     .toBeVisible();
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
   await expect.soft(statusTag).toContainText('200 OK');

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -445,7 +445,7 @@ test.describe('pre-request features tests', () => {
     await page.getByLabel('Request Collection').getByTestId('test certificate manipulation').press('Enter');
 
     await page.getByTestId('settings-button').click();
-    await page.getByTestId('dataFolders').fill("invalid");
+    await page.getByTestId('dataFolders').fill('invalid');
     await page.getByTestId('dataFolders-btn').click();
     await expect.soft(page.getByText('invalid')).toBeVisible();
     await page.locator('.app').press('Escape');
@@ -501,11 +501,11 @@ test.describe('pre-request features tests', () => {
       __fromScript1: 'baseEnvironment',
       __fromScript2: 'collection',
       __fromScript: 'environment',
-      examplehost: 'https://mock.insomnia.rest',
+      examplehost: 'http://127.0.0.1:4010/echo',
       a: {
         b: {
           c: {
-            url: 'https://mock.insomnia.rest',
+            url: 'http://127.0.0.1:4010/echo',
           },
         },
       },

--- a/packages/insomnia/setup-vitest.ts
+++ b/packages/insomnia/setup-vitest.ts
@@ -3,9 +3,8 @@ import { vi } from 'vitest';
 import { nodeLibcurlMock } from './src/__mocks__/@getinsomnia/node-libcurl';
 import { electronMock } from './src/__mocks__/electron';
 import { database as db } from './src/common/database';
-import * as models from './src/models';
 import { v4Mock } from './src/models/__mocks__/uuid';
-await db.init(models.types(), { inMemoryOnly: true }, true, () => {});
+await db.init({ inMemoryOnly: true }, true, () => {});
 vi.mock('electron', () => ({ default: electronMock }));
 
 vi.mock('uuid', () => ({

--- a/packages/insomnia/setup-vitest.ts
+++ b/packages/insomnia/setup-vitest.ts
@@ -4,7 +4,7 @@ import { nodeLibcurlMock } from './src/__mocks__/@getinsomnia/node-libcurl';
 import { electronMock } from './src/__mocks__/electron';
 import { database as db } from './src/common/database';
 import { v4Mock } from './src/models/__mocks__/uuid';
-await db.init({ inMemoryOnly: true }, true, () => {});
+await db.init({ inMemoryOnly: true }, true);
 vi.mock('electron', () => ({ default: electronMock }));
 
 vi.mock('uuid', () => ({

--- a/packages/insomnia/src/common/__tests__/database.test.ts
+++ b/packages/insomnia/src/common/__tests__/database.test.ts
@@ -563,25 +563,25 @@ describe('_repairDatabase()', async () => {
       uri: 'https://github.com/foo/bar',
     });
     await _repairDatabase();
-    expect(await db.get(models.gitRepository.type, oldRepoWithSuffix._id)).toEqual(
+    expect(await db.findOne(models.gitRepository.type, { _id: oldRepoWithSuffix._id })).toEqual(
       expect.objectContaining({
         uri: 'https://github.com/foo/bar.git',
         uriNeedsMigration: false,
       }),
     );
-    expect(await db.get(models.gitRepository.type, oldRepoWithoutSuffix._id)).toEqual(
+    expect(await db.findOne(models.gitRepository.type, { _id: oldRepoWithoutSuffix._id })).toEqual(
       expect.objectContaining({
         uri: 'https://github.com/foo/bar.git',
         uriNeedsMigration: false,
       }),
     );
-    expect(await db.get(models.gitRepository.type, newRepoWithSuffix._id)).toEqual(
+    expect(await db.findOne(models.gitRepository.type, { _id: newRepoWithSuffix._id })).toEqual(
       expect.objectContaining({
         uri: 'https://github.com/foo/bar.git',
         uriNeedsMigration: false,
       }),
     );
-    expect(await db.get(models.gitRepository.type, newRepoWithoutSuffix._id)).toEqual(
+    expect(await db.findOne(models.gitRepository.type, { _id: newRepoWithoutSuffix._id })).toEqual(
       expect.objectContaining({
         uri: 'https://github.com/foo/bar',
         uriNeedsMigration: false,

--- a/packages/insomnia/src/common/__tests__/database.test.ts
+++ b/packages/insomnia/src/common/__tests__/database.test.ts
@@ -39,9 +39,6 @@ describe('onChange()', () => {
       name: 'bar',
     });
     expect(changesSeen).toEqual([[['insert', newDoc, false, []]], [['update', updatedDoc, false, [{ name: 'bar' }]]]]);
-    db.offChange(callback);
-    await models.request.create(doc);
-    expect(changesSeen.length).toBe(2);
   });
 });
 

--- a/packages/insomnia/src/common/__tests__/database.test.ts
+++ b/packages/insomnia/src/common/__tests__/database.test.ts
@@ -19,7 +19,7 @@ describe('init()', () => {
 
 describe('onChange()', () => {
   beforeEach(async () => {
-    await db.init({ inMemoryOnly: true }, true, () => {});
+    await db.init({ inMemoryOnly: true }, true);
   });
   it('handles change listeners', async () => {
     const doc = {
@@ -206,7 +206,7 @@ describe('requestCreate()', () => {
 
 describe('_repairDatabase()', async () => {
   beforeEach(async () => {
-    await db.init({ inMemoryOnly: true }, true, () => {});
+    await db.init({ inMemoryOnly: true }, true);
   });
 
   it('fixes duplicate environments', async () => {

--- a/packages/insomnia/src/common/__tests__/database.test.ts
+++ b/packages/insomnia/src/common/__tests__/database.test.ts
@@ -13,7 +13,7 @@ describe('init()', () => {
     await db.init(models.types(), {
       inMemoryOnly: true,
     });
-    expect((await db.all(models.request.type)).length).toBe(0);
+    expect((await db.find(models.request.type)).length).toBe(0);
   });
 });
 

--- a/packages/insomnia/src/common/__tests__/database.test.ts
+++ b/packages/insomnia/src/common/__tests__/database.test.ts
@@ -7,10 +7,10 @@ import { _repairDatabase, database as db } from '../database';
 
 describe('init()', () => {
   it('handles being initialized twice', async () => {
-    await db.init(models.types(), {
+    await db.init({
       inMemoryOnly: true,
     });
-    await db.init(models.types(), {
+    await db.init({
       inMemoryOnly: true,
     });
     expect((await db.find(models.request.type)).length).toBe(0);
@@ -19,7 +19,7 @@ describe('init()', () => {
 
 describe('onChange()', () => {
   beforeEach(async () => {
-    await db.init(models.types(), { inMemoryOnly: true }, true, () => {});
+    await db.init({ inMemoryOnly: true }, true, () => {});
   });
   it('handles change listeners', async () => {
     const doc = {
@@ -206,7 +206,7 @@ describe('requestCreate()', () => {
 
 describe('_repairDatabase()', async () => {
   beforeEach(async () => {
-    await db.init(models.types(), { inMemoryOnly: true }, true, () => {});
+    await db.init({ inMemoryOnly: true }, true, () => {});
   });
 
   it('fixes duplicate environments', async () => {

--- a/packages/insomnia/src/common/__tests__/har.test.ts
+++ b/packages/insomnia/src/common/__tests__/har.test.ts
@@ -13,7 +13,7 @@ import { getRenderedRequestAndContext } from '../render';
 
 describe('export', () => {
   beforeEach(async () => {
-    await db.init(models.types(), { inMemoryOnly: true }, true, () => {});
+    await db.init({ inMemoryOnly: true }, true, () => {});
     await models.project.all();
     await models.settings.getOrCreate();
   });

--- a/packages/insomnia/src/common/__tests__/har.test.ts
+++ b/packages/insomnia/src/common/__tests__/har.test.ts
@@ -13,7 +13,7 @@ import { getRenderedRequestAndContext } from '../render';
 
 describe('export', () => {
   beforeEach(async () => {
-    await db.init({ inMemoryOnly: true }, true, () => {});
+    await db.init({ inMemoryOnly: true }, true);
     await models.project.all();
     await models.settings.getOrCreate();
   });

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -596,7 +596,24 @@ export const EXPORT_TYPE_ENVIRONMENT = 'environment';
 export const EXPORT_TYPE_API_SPEC = 'api_spec';
 export const EXPORT_TYPE_PROTO_FILE = 'proto_file';
 export const EXPORT_TYPE_PROTO_DIRECTORY = 'proto_directory';
-export const EXPORT_TYPE_RUNNER_TEST_RESULT = 'runner_result';
+export type AllExportTypes =
+  | 'request'
+  | 'grpc_request'
+  | 'websocket_request'
+  | 'websocket_payload'
+  | 'socketio_request'
+  | 'socketio_payload'
+  | 'mock'
+  | 'mock_route'
+  | 'request_group'
+  | 'unit_test_suite'
+  | 'unit_test'
+  | 'workspace'
+  | 'cookie_jar'
+  | 'environment'
+  | 'api_spec'
+  | 'proto_file'
+  | 'proto_directory';
 
 // (ms) curently server timeout is 30s
 export const INSOMNIA_FETCH_TIME_OUT = 30_000;

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -3,9 +3,16 @@
 /* eslint-disable prefer-rest-params -- don't want to change ...arguments usage for these sensitive functions without more testing */
 import fsPath from 'node:path';
 
+import { Api } from '@bufbuild/protobuf';
 import NeDB from '@seald-io/nedb';
 import electron from 'electron';
 import { v4 as uuidv4 } from 'uuid';
+
+import type { ApiSpec } from '~/models/api-spec';
+import type { CaCertificate } from '~/models/ca-certificate';
+import type { ClientCertificate } from '~/models/client-certificate';
+import type { CloudProviderCredential } from '~/models/cloud-credential';
+import type { WorkspaceMeta } from '~/models/workspace-meta';
 
 import { mustGetModel } from '../models';
 import type { CookieJar } from '../models/cookie-jar';
@@ -215,7 +222,6 @@ export const database = {
 
   /** init in main process */
   init: async (
-    types: AllTypes[],
     config: NeDB.DataStoreOptions = {},
     forceReset = false,
     consoleLog: typeof console.log = console.log,
@@ -224,26 +230,185 @@ export const database = {
       changeListeners = [];
       nedbBucket = {} as Record<AllTypes, NeDB>;
     }
+    const defaultConfig: NeDB.DataStoreOptions = {
+      autoload: true,
+      corruptAlertThreshold: 0.9,
+      ...config,
+    };
+    const dbPath = process.env['INSOMNIA_DATA_PATH'] || electron.app.getPath('userData');
 
-    // Fill in the defaults
-    for (const modelType of types) {
-      if (nedbBucket?.[modelType]) {
-        consoleLog(`[db] Already initialized DB.${modelType}`);
-        continue;
-      }
+    nedbBucket = {
+      ApiSpec: new NeDB<ApiSpec>({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.ApiSpec.db'),
+      }),
+      CaCertificate: new NeDB<CaCertificate>({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.CaCertificate.db'),
+      }),
+      ClientCertificate: new NeDB<ClientCertificate>({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.ClientCertificate.db'),
+      }),
+      CloudCredential: new NeDB<CloudProviderCredential>({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.CloudCredential.db'),
+      }),
+      CookieJar: new NeDB<CookieJar>({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.CookieJar.db'),
+      }),
+      Environment: new NeDB<Environment>({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.Environment.db'),
+      }),
+      GitCredentials: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.GitCredentials.db'),
+      }),
+      GitRepository: new NeDB<GitRepository>({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.GitRepository.db'),
+      }),
+      GrpcRequest: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.GrpcRequest.db'),
+      }),
+      GrpcRequestMeta: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.GrpcRequestMeta.db'),
+      }),
+      MockRoute: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.MockRoute.db'),
+      }),
+      MockServer: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.MockServer.db'),
+      }),
+      OAuth2Token: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.OAuth2Token.db'),
+      }),
+      PluginData: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.PluginData.db'),
+      }),
+      Project: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.Project.db'),
+      }),
+      ProtoDirectory: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.ProtoDirectory.db'),
+      }),
+      ProtoFile: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.ProtoFile.db'),
+      }),
+      Request: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.Request.db'),
+      }),
+      RequestGroup: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.RequestGroup.db'),
+      }),
+      RequestGroupMeta: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.RequestGroupMeta.db'),
+      }),
+      RequestMeta: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.RequestMeta.db'),
+      }),
+      RequestVersion: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.RequestVersion.db'),
+      }),
+      Response: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.Response.db'),
+      }),
+      RunnerTestResult: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.RunnerTestResult.db'),
+      }),
+      Settings: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.Settings.db'),
+      }),
+      SocketIOPayload: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.SocketIOPayload.db'),
+      }),
+      SocketIORequest: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.SocketIORequest.db'),
+      }),
+      SocketIOResponse: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.SocketIOResponse.db'),
+      }),
+      Stats: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.Stats.db'),
+      }),
+      UnitTest: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.UnitTest.db'),
+      }),
+      UnitTestResult: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.UnitTestResult.db'),
+      }),
+      UnitTestSuite: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.UnitTestSuite.db'),
+      }),
+      UserSession: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.UserSession.db'),
+      }),
+      WebSocketPayload: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.WebSocketPayload.db'),
+      }),
+      WebSocketRequest: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.WebSocketRequest.db'),
+      }),
+      WebSocketResponse: new NeDB({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.WebSocketResponse.db'),
+      }),
+      Workspace: new NeDB<Workspace>({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.Workspace.db'),
+      }),
+      WorkspaceMeta: new NeDB<WorkspaceMeta>({
+        ...defaultConfig,
+        filename: fsPath.join(dbPath, 'insomnia.WorkspaceMeta.db'),
+      }),
+    };
+    // for (const modelType of types) {
+    //   if (nedbBucket?.[modelType]) {
+    //     consoleLog(`[db] Already initialized DB.${modelType}`);
+    //     continue;
+    //   }
 
-      const filePath = fsPath.join(
-        process.env['INSOMNIA_DATA_PATH'] || electron.app.getPath('userData'),
-        `insomnia.${modelType}.db`,
-      );
+    //   const filePath = fsPath.join(
+    //     process.env['INSOMNIA_DATA_PATH'] || electron.app.getPath('userData'),
+    //     `insomnia.${modelType}.db`,
+    //   );
 
-      nedbBucket[modelType] = new NeDB({
-        autoload: true,
-        filename: filePath,
-        corruptAlertThreshold: 0.9,
-        ...config,
-      });
-    }
+    //   nedbBucket[modelType] = new NeDB({
+    //     autoload: true,
+    //     filename: filePath,
+    //     corruptAlertThreshold: 0.9,
+    //     ...config,
+    //   });
+    // }
 
     electron.ipcMain.on('db.fn', async (e, fnName, replyChannel, ...args) => {
       try {

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -360,52 +360,6 @@ export const database = {
       await _repairDatabase();
       consoleLog(`[db] Initialized DB at ${getDBFilePath('$TYPE')}`);
     }
-
-    // This isn't the best place for this but w/e
-    // Listen for response deletions and delete corresponding response body files
-    database.onChange(async (changes: ChangeBufferEvent[]) => {
-      for (const [type, doc] of changes) {
-        // TODO(TSCONVERSION) what's returned here is the entire model implementation, not just a model
-        // The type definition will be a little confusing
-        const m: Record<string, any> | null = models.getModel(doc.type);
-
-        if (!m) {
-          continue;
-        }
-
-        if (type === 'remove' && typeof m.hookRemove === 'function') {
-          try {
-            await m.hookRemove(doc, consoleLog);
-          } catch (err) {
-            consoleLog(`[db] Delete hook failed for ${type} ${doc._id}: ${err.message}`);
-          }
-        }
-
-        if (type === 'insert' && typeof m.hookInsert === 'function') {
-          try {
-            await m.hookInsert(doc, consoleLog);
-          } catch (err) {
-            consoleLog(`[db] Insert hook failed for ${type} ${doc._id}: ${err.message}`);
-          }
-        }
-
-        if (type === 'update' && typeof m.hookUpdate === 'function') {
-          try {
-            await m.hookUpdate(doc, consoleLog);
-          } catch (err) {
-            consoleLog(`[db] Update hook failed for ${type} ${doc._id}: ${err.message}`);
-          }
-        }
-      }
-    });
-
-    for (const model of models.all()) {
-      // @ts-expect-error -- TSCONVERSION optional type on response
-      if (typeof model.hookDatabaseInit === 'function') {
-        // @ts-expect-error -- TSCONVERSION optional type on response
-        await model.hookDatabaseInit?.(consoleLog);
-      }
-    }
   },
 
   /** init in renderer process */

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -151,17 +151,22 @@ export const database = {
     await database.flushChanges(flushId);
     return createdDoc;
   },
-  findOne: async function <T extends BaseModel>(type: AllTypes, query: Query<T> | string = {}): Promise<T | undefined> {
+  findOne: async function <T extends BaseModel>(
+    type: AllTypes,
+    query: Query<T> | string = {},
+    sort: Sort = { created: 1 },
+  ): Promise<T | undefined> {
     if (process.type === 'renderer') {
       return _send<T>('findOne', ...arguments);
     }
-    return await nedbBucket[type]?.findOneAsync<T>(query);
+    return await nedbBucket[type]?.findOneAsync<T>(query).sort(sort);
   },
   /** find documents matching query */
   find: async function <T extends BaseModel>(
     type: AllTypes,
     query: Query<T> | string = {},
     sort: Sort = { created: 1 },
+    limit = 0,
   ): Promise<T[]> {
     if (process.type === 'renderer') {
       return _send<T[]>('find', ...arguments);
@@ -170,23 +175,10 @@ export const database = {
       console.warn(`[db] No collection for type "${type}"`);
       return [];
     }
-    const docs = await nedbBucket[type].findAsync<T>(query).sort(sort);
+    const docs = await nedbBucket[type].findAsync<T>(query).sort(sort).limit(limit);
     // TODO: create a db init phase for migrations rather than doing it on every find.
     const migrated = [];
     for (const rawDoc of docs) {
-      migrated.push(await models.initModel<T>(type, rawDoc));
-    }
-    return migrated;
-  },
-
-  findMostRecentlyModified: async function <T extends BaseModel>(type: AllTypes, query: Query<T> = {}, limit = 1) {
-    if (process.type === 'renderer') {
-      return _send<T[]>('findMostRecentlyModified', ...arguments);
-    }
-    const docs = await nedbBucket[type]?.findAsync<T>(query).sort({ modified: -1 }).limit(limit);
-    // TODO: create a db init phase for migrations rather than doing it on every find.
-    const migrated = [];
-    for (const rawDoc of docs || []) {
       migrated.push(await models.initModel<T>(type, rawDoc));
     }
     return migrated;

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -545,7 +545,7 @@ export const database = {
    * @param types - Only query specified types, if provided
    * @returns A promise that resolves to an array of documents
    */
-  getWithDescendants: async function <T extends BaseModel>(doc: T, types: models.ModelTypes = []) {
+  getWithDescendants: async function <T extends BaseModel>(doc: T, types: AllTypes[] = []) {
     if (process.type === 'renderer') {
       return _send<T[]>('getWithDescendants', ...arguments);
     }

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -36,14 +36,6 @@ export interface SpecificQuery {
 
 export type ChangeType = 'insert' | 'update' | 'remove';
 export const database = {
-  // Get all documents of a certain type
-  all: async function <T extends BaseModel>(type: string) {
-    if (process.type === 'renderer') {
-      return _send<T[]>('all', ...arguments);
-    }
-    return database.find<T>(type);
-  },
-
   batchModifyDocs: async function ({ upsert = [], remove = [] }: Operation) {
     if (process.type === 'renderer') {
       return _send<void>('batchModifyDocs', ...arguments);

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -18,12 +18,6 @@ import * as models from '../models/index';
 import type { Workspace } from '../models/workspace';
 import { generateId } from './misc';
 
-export type Query<T extends BaseModel = BaseModel> = {
-  [key in keyof T]?: string | SpecificQuery | null | undefined;
-};
-
-type Sort = Record<string, any>;
-
 export interface Operation {
   upsert?: BaseModel[];
   remove?: BaseModel[];
@@ -35,6 +29,10 @@ export interface SpecificQuery {
   $nin?: string[];
   $ne?: string | null;
 }
+
+export type Query<T extends BaseModel = BaseModel> = {
+  [key in keyof T]?: string | SpecificQuery | null | undefined;
+};
 
 export type ChangeType = 'insert' | 'update' | 'remove';
 export const database = {
@@ -80,7 +78,7 @@ export const database = {
     return total || 0;
   },
 
-  docCreate: async <T extends BaseModel>(type: AllTypes, ...patches: Patch<T>[]) => {
+  docCreate: async <T extends BaseModel>(type: AllTypes, ...patches: Partial<T>[]) => {
     const doc = await models.initModel<T>(
       type,
       ...patches,
@@ -92,7 +90,7 @@ export const database = {
     return database.insert<T>(doc);
   },
 
-  docUpdate: async <T extends BaseModel>(originalDoc: T, ...patches: Patch<T>[]) => {
+  docUpdate: async <T extends BaseModel>(originalDoc: T, ...patches: Partial<T>[]) => {
     // No need to re-initialize the model during update; originalDoc will be in a valid state by virtue of loading
     const doc = await models.initModel<T>(
       originalDoc.type,
@@ -108,13 +106,13 @@ export const database = {
   },
 
   /** duplicate doc and its descendents recursively */
-  duplicate: async function <T extends BaseModel>(originalDoc: T, patch: Patch<T> = {}) {
+  duplicate: async function <T extends BaseModel>(originalDoc: T, patch: Partial<T> = {}) {
     if (process.type === 'renderer') {
       return _send<T>('duplicate', ...arguments);
     }
     const flushId = await database.bufferChanges();
 
-    async function next<T extends BaseModel>(docToCopy: T, patch: Patch<T>) {
+    async function next<T extends BaseModel>(docToCopy: T, patch: Partial<T>) {
       const model = mustGetModel(docToCopy.type);
       const overrides = {
         _id: generateId(model.prefix),
@@ -124,7 +122,7 @@ export const database = {
       };
 
       // 1. Copy the doc
-      const newDoc = Object.assign({}, docToCopy, patch, overrides);
+      const newDoc = { ...docToCopy, ...patch, ...overrides };
 
       // Don't initialize the model during insert, and simply duplicate
       const createdDoc = await database.insert(newDoc, false, false);
@@ -136,10 +134,7 @@ export const database = {
           continue;
         }
 
-        const parentId = docToCopy._id;
-        const children = await database.find(type, { parentId });
-
-        for (const doc of children) {
+        for (const doc of await database.find(type, { parentId: docToCopy._id })) {
           await next(doc, { parentId: createdDoc._id });
         }
       }
@@ -154,7 +149,7 @@ export const database = {
   findOne: async function <T extends BaseModel>(
     type: AllTypes,
     query: Query<T> | string = {},
-    sort: Sort = { created: 1 },
+    sort: Record<string, any> = { created: 1 },
   ): Promise<T | undefined> {
     if (process.type === 'renderer') {
       return _send<T>('findOne', ...arguments);
@@ -165,7 +160,7 @@ export const database = {
   find: async function <T extends BaseModel>(
     type: AllTypes,
     query: Query<T> | string = {},
-    sort: Sort = { created: 1 },
+    sort: Record<string, any> = { created: 1 },
     limit = 0,
   ): Promise<T[]> {
     if (process.type === 'renderer') {
@@ -242,19 +237,17 @@ export const database = {
         continue;
       }
 
-      const filePath = getDBFilePath(modelType);
-      const collection = new NeDB(
-        Object.assign(
-          {
-            autoload: true,
-            filename: filePath,
-            corruptAlertThreshold: 0.9,
-          },
-          config,
-        ),
+      const filePath = fsPath.join(
+        process.env['INSOMNIA_DATA_PATH'] || electron.app.getPath('userData'),
+        `insomnia.${modelType}.db`,
       );
 
-      nedbBucket[modelType] = collection;
+      nedbBucket[modelType] = new NeDB({
+        autoload: true,
+        filename: filePath,
+        corruptAlertThreshold: 0.9,
+        ...config,
+      });
     }
 
     electron.ipcMain.on('db.fn', async (e, fnName, replyChannel, ...args) => {
@@ -366,7 +359,7 @@ export const database = {
     notifyOfChange('remove', doc, fromSync);
   },
 
-  update: async function <T extends BaseModel>(doc: T, fromSync = false, patches: Patch<T>[] = []) {
+  update: async function <T extends BaseModel>(doc: T, fromSync = false, patches: Partial<T>[] = []) {
     if (process.type === 'renderer') {
       return _send<T>('update', ...arguments);
     }
@@ -390,7 +383,7 @@ export const database = {
     return database.insert<T>(doc, fromSync);
   },
 
-  /** get all ancestors of specified types of a document */
+  /** get all ancestors of specified types of a document including the original */
   withAncestors: async function <T extends BaseModel>(doc: T | undefined, types: AllTypes[] = []) {
     if (process.type === 'renderer') {
       return _send<T[]>('withAncestors', ...arguments);
@@ -400,7 +393,7 @@ export const database = {
       return [];
     }
 
-    let docsToReturn: T[] = doc ? [doc] : [];
+    let docsToReturn: T[] = [];
     if (types.length === 0) {
       types = Object.keys(nedbBucket) as AllTypes[];
     }
@@ -410,13 +403,12 @@ export const database = {
       for (const d of docs) {
         for (const type of types) {
           // If the doc is null, we want to search for parentId === null
-          const another = await database.findOne<T>(type, { _id: d.parentId });
-          another && foundDocs.push(another);
+          const parent = await database.findOne<T>(type, { _id: d.parentId });
+          parent && foundDocs.push(parent);
         }
       }
 
       if (foundDocs.length === 0) {
-        // Didn't find anything. We're done
         return docsToReturn;
       }
 
@@ -491,15 +483,6 @@ export const database = {
 
 let nedbBucket: Partial<Record<AllTypes, NeDB>> = {};
 
-// ~~~~~~~ //
-// HELPERS //
-// ~~~~~~~ //
-
-function getDBFilePath(modelType: AllTypes) {
-  // NOTE: Do not EVER change this. EVER!
-  return fsPath.join(process.env['INSOMNIA_DATA_PATH'] || electron.app.getPath('userData'), `insomnia.${modelType}.db`);
-}
-
 // ~~~~~~~~~~~~~~~~ //
 // Change Listeners //
 // ~~~~~~~~~~~~~~~~ //
@@ -510,7 +493,7 @@ export type ChangeBufferEvent<T extends BaseModel = BaseModel> = [
   event: ChangeType,
   doc: T,
   fromSync: boolean,
-  patches: Patch<T>[],
+  patches: Partial<T>[],
 ];
 
 let changeBuffer: ChangeBufferEvent[] = [];
@@ -525,7 +508,7 @@ async function notifyOfChange<T extends BaseModel>(
   event: ChangeType,
   doc: T,
   fromSync: boolean,
-  patches: Patch<T>[] = [],
+  patches: Partial<T>[] = [],
 ) {
   const updatedDoc = doc;
 
@@ -538,27 +521,15 @@ async function notifyOfChange<T extends BaseModel>(
   }
 }
 
-// ~~~~~~~~~~~~~~~~~~~ //
-// DEFAULT MODEL STUFF //
-// ~~~~~~~~~~~~~~~~~~~ //
-
-type Patch<T> = Partial<T>;
-
 // ~~~~~~~ //
 // Helpers //
 // ~~~~~~~ //
-// If you call database.x methods within the render process, you can obtain results by this helper function. In renderer process, db._empty is true.
+// If you call database.x methods within the render process, you can obtain results by this helper function
 async function _send<T>(fnName: string, ...args: any[]) {
   return new Promise<T>((resolve, reject) => {
     const replyChannel = `db.fn.reply:${uuidv4()}`;
     electron.ipcRenderer.send('db.fn', fnName, replyChannel, ...args);
-    electron.ipcRenderer.once(replyChannel, (_e, err, result: T) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(result);
-      }
-    });
+    electron.ipcRenderer.once(replyChannel, (_e, err, result: T) => (err ? reject(err) : resolve(result)));
   });
 }
 

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -74,8 +74,7 @@ export const database = {
     if (process.type === 'renderer') {
       return _send<number>('count', ...arguments);
     }
-    const total = await nedbBucket[type]?.countAsync(query);
-    return total || 0;
+    return nedbBucket[type].countAsync(query);
   },
 
   docCreate: async <T extends BaseModel>(type: AllTypes, ...patches: Partial<T>[]) => {
@@ -124,8 +123,7 @@ export const database = {
       // 1. Copy the doc
       const newDoc = { ...docToCopy, ...patch, ...overrides };
 
-      const createdDoc = await nedbBucket[docToCopy.type]?.insertAsync(newDoc);
-      invariant(createdDoc, `Failed to duplicate document of type ${docToCopy.type}`);
+      const createdDoc = await nedbBucket[docToCopy.type].insertAsync(newDoc);
       // 2. Get all the children
       for (const type of Object.keys(nedbBucket) as AllTypes[]) {
         // Note: We never want to duplicate a response
@@ -153,7 +151,7 @@ export const database = {
     if (process.type === 'renderer') {
       return _send<T>('findOne', ...arguments);
     }
-    return await nedbBucket[type]?.findOneAsync<T>(query).sort(sort);
+    return nedbBucket[type].findOneAsync<T>(query).sort(sort);
   },
   /** find documents matching query */
   find: async function <T extends BaseModel>(
@@ -231,7 +229,7 @@ export const database = {
 
     // Fill in the defaults
     for (const modelType of types) {
-      if (nedbBucket[modelType]) {
+      if (nedbBucket?.[modelType]) {
         consoleLog(`[db] Already initialized DB.${modelType}`);
         continue;
       }
@@ -274,8 +272,7 @@ export const database = {
       return _send<T>('insert', ...arguments);
     }
     const docWithDefaults = await models.initModel<T>(doc.type, doc);
-    const newDoc = await nedbBucket[doc.type]?.insertAsync(docWithDefaults);
-    invariant(newDoc, `Failed to insert document of type ${doc.type}`);
+    const newDoc = await nedbBucket[doc.type].insertAsync(docWithDefaults);
     notifyOfChange('insert', newDoc, fromSync);
     return newDoc;
   },
@@ -354,7 +351,7 @@ export const database = {
       return _send<void>('unsafeRemove', ...arguments);
     }
 
-    nedbBucket[doc.type]?.remove({ _id: doc._id });
+    nedbBucket[doc.type].remove({ _id: doc._id });
     notifyOfChange('remove', doc, fromSync);
   },
 
@@ -364,7 +361,7 @@ export const database = {
     }
 
     const docWithDefaults = await models.initModel<T>(doc.type, doc);
-    await nedbBucket[doc.type]?.updateAsync({ _id: docWithDefaults._id }, docWithDefaults, { upsert: true });
+    await nedbBucket[doc.type].updateAsync({ _id: docWithDefaults._id }, docWithDefaults, { upsert: true });
     notifyOfChange('update', docWithDefaults, fromSync, patches);
     return docWithDefaults;
   },
@@ -467,7 +464,7 @@ export const database = {
   },
 };
 
-let nedbBucket: Partial<Record<AllTypes, NeDB>> = {};
+let nedbBucket: Record<AllTypes, NeDB>;
 
 // ~~~~~~~~~~~~~~~~ //
 // Change Listeners //

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -270,14 +270,6 @@ export const database = {
     }
   },
 
-  getMostRecentlyModified: async function <T extends BaseModel>(type: AllTypes, query: Query<T> = {}) {
-    if (process.type === 'renderer') {
-      return _send<T>('getMostRecentlyModified', ...arguments);
-    }
-    const docs = await database.findMostRecentlyModified<T>(type, query, 1);
-    return docs.length ? docs[0] : null;
-  },
-
   /** init in main process */
   init: async (
     types: AllTypes[],

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -11,7 +11,7 @@ import { mustGetModel } from '../models';
 import type { CookieJar } from '../models/cookie-jar';
 import { type Environment } from '../models/environment';
 import type { GitRepository } from '../models/git-repository';
-import type { BaseModel } from '../models/index';
+import type { AllTypes, BaseModel } from '../models/index';
 import * as models from '../models/index';
 import type { Workspace } from '../models/workspace';
 import { generateId } from './misc';
@@ -70,7 +70,7 @@ export const database = {
   },
 
   /** return count num of documents matching query */
-  count: async function <T extends BaseModel>(type: string, query: Query<T> = {}) {
+  count: async function <T extends BaseModel>(type: AllTypes, query: Query<T> = {}) {
     if (process.type === 'renderer') {
       return _send<number>('count', ...arguments);
     }
@@ -85,7 +85,7 @@ export const database = {
     });
   },
 
-  docCreate: async <T extends BaseModel>(type: string, ...patches: Patch<T>[]) => {
+  docCreate: async <T extends BaseModel>(type: AllTypes, ...patches: Patch<T>[]) => {
     const doc = await models.initModel<T>(
       type,
       ...patches,
@@ -156,14 +156,18 @@ export const database = {
     await database.flushChanges(flushId);
     return createdDoc;
   },
-  findOne: async function <T extends BaseModel>(type: string, query: Query<T> | string = {}): Promise<T | null> {
+  findOne: async function <T extends BaseModel>(type: AllTypes, query: Query<T> | string = {}): Promise<T | null> {
     if (process.type === 'renderer') {
       return _send<T>('findOne', ...arguments);
     }
     return (nedbBucket[type] as NeDB<T>).findOneAsync(query);
   },
   /** find documents matching query */
-  find: async function <T extends BaseModel>(type: string, query: Query<T> | string = {}, sort: Sort = { created: 1 }) {
+  find: async function <T extends BaseModel>(
+    type: AllTypes,
+    query: Query<T> | string = {},
+    sort: Sort = { created: 1 },
+  ) {
     if (process.type === 'renderer') {
       return _send<T[]>('find', ...arguments);
     }
@@ -194,7 +198,7 @@ export const database = {
   },
 
   findMostRecentlyModified: async function <T extends BaseModel>(
-    type: string,
+    type: AllTypes,
     query: Query<T> = {},
     limit: number | null = null,
   ) {
@@ -266,7 +270,7 @@ export const database = {
     }
   },
 
-  getMostRecentlyModified: async function <T extends BaseModel>(type: string, query: Query<T> = {}) {
+  getMostRecentlyModified: async function <T extends BaseModel>(type: AllTypes, query: Query<T> = {}) {
     if (process.type === 'renderer') {
       return _send<T>('getMostRecentlyModified', ...arguments);
     }
@@ -276,7 +280,7 @@ export const database = {
 
   /** init in main process */
   init: async (
-    types: string[],
+    types: AllTypes[],
     config: NeDB.DataStoreOptions = {},
     forceReset = false,
     consoleLog: typeof console.log = console.log,
@@ -332,7 +336,6 @@ export const database = {
     // TODO: Figure out why this makes tests hang
     if (!config.inMemoryOnly) {
       await _repairDatabase();
-      consoleLog(`[db] Initialized DB at ${getDBFilePath('$TYPE')}`);
     }
   },
 
@@ -413,7 +416,7 @@ export const database = {
     await database.flushChanges(flushId);
   },
 
-  removeWhere: async function <T extends BaseModel>(type: string, query: Query<T>) {
+  removeWhere: async function <T extends BaseModel>(type: AllTypes, query: Query<T>) {
     if (process.type === 'renderer') {
       return _send<void>('removeWhere', ...arguments);
     }
@@ -499,7 +502,7 @@ export const database = {
   },
 
   /** get all ancestors of specified types of a document */
-  withAncestors: async function <T extends BaseModel>(doc: T | null, types: string[] = allTypes()) {
+  withAncestors: async function <T extends BaseModel>(doc: T | null, types: AllTypes[] = allTypes()) {
     if (process.type === 'renderer') {
       return _send<T[]>('withAncestors', ...arguments);
     }
@@ -557,8 +560,8 @@ export const database = {
         // Find all descendants of the current docs
         const promises: Promise<BaseModel[]>[] = [];
 
-        const uniqueDescendantTypes = new Set<string>();
-        const parentIdsMap = new Map<string, (string | null)[]>();
+        const uniqueDescendantTypes = new Set<AllTypes>();
+        const parentIdsMap = new Map<AllTypes, (string | null)[]>();
 
         for (const d of docs) {
           if (d.type) {
@@ -602,9 +605,9 @@ const nedbBucket: DB = {} as DB;
 // ~~~~~~~ //
 // HELPERS //
 // ~~~~~~~ //
-const allTypes = () => Object.keys(nedbBucket);
+const allTypes = () => Object.keys(nedbBucket) as AllTypes[];
 
-function getDBFilePath(modelType: string) {
+function getDBFilePath(modelType: AllTypes) {
   // NOTE: Do not EVER change this. EVER!
   return fsPath.join(process.env['INSOMNIA_DATA_PATH'] || electron.app.getPath('userData'), `insomnia.${modelType}.db`);
 }

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -435,7 +435,7 @@ export const database = {
 
     // Don't really need to wait for this to be over;
     types.map(t =>
-      nedbBucket[t]?.remove(
+      nedbBucket[t].remove(
         {
           _id: {
             $in: docIds,
@@ -464,7 +464,7 @@ export const database = {
 
       // Don't really need to wait for this to be over;
       types.map(t =>
-        nedbBucket[t]?.remove(
+        nedbBucket[t].remove(
           {
             _id: {
               $in: docIds,

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -3,7 +3,6 @@
 /* eslint-disable prefer-rest-params -- don't want to change ...arguments usage for these sensitive functions without more testing */
 import fsPath from 'node:path';
 
-import { Api } from '@bufbuild/protobuf';
 import NeDB from '@seald-io/nedb';
 import electron from 'electron';
 import { v4 as uuidv4 } from 'uuid';
@@ -221,11 +220,7 @@ export const database = {
   },
 
   /** init in main process */
-  init: async (
-    config: NeDB.DataStoreOptions = {},
-    forceReset = false,
-    consoleLog: typeof console.log = console.log,
-  ) => {
+  init: async (config: NeDB.DataStoreOptions = {}, forceReset = false) => {
     if (forceReset) {
       changeListeners = [];
       nedbBucket = {} as Record<AllTypes, NeDB>;

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -7,6 +7,8 @@ import NeDB from '@seald-io/nedb';
 import electron from 'electron';
 import { v4 as uuidv4 } from 'uuid';
 
+import { invariant } from '~/utils/invariant';
+
 import { mustGetModel } from '../models';
 import type { CookieJar } from '../models/cookie-jar';
 import { type Environment } from '../models/environment';
@@ -288,7 +290,8 @@ export const database = {
       return _send<T>('insert', ...arguments);
     }
     const docWithDefaults = initializeModel ? await models.initModel<T>(doc.type, doc) : doc;
-    const newDoc = await (nedbBucket[doc.type] as NeDB<T>).insertAsync(docWithDefaults);
+    const newDoc = await nedbBucket[doc.type]?.insertAsync(docWithDefaults);
+    invariant(newDoc, `Failed to insert document of type ${doc.type}`);
     notifyOfChange('insert', newDoc, fromSync);
     return newDoc;
   },
@@ -367,7 +370,7 @@ export const database = {
       return _send<void>('unsafeRemove', ...arguments);
     }
 
-    (nedbBucket[doc.type] as NeDB<T>).remove({ _id: doc._id });
+    nedbBucket[doc.type]?.remove({ _id: doc._id });
     notifyOfChange('remove', doc, fromSync);
   },
 
@@ -377,7 +380,7 @@ export const database = {
     }
 
     const docWithDefaults = await models.initModel<T>(doc.type, doc);
-    await (nedbBucket[doc.type] as NeDB<T>).updateAsync({ _id: docWithDefaults._id }, docWithDefaults);
+    await nedbBucket[doc.type]?.updateAsync({ _id: docWithDefaults._id }, docWithDefaults);
     notifyOfChange('update', docWithDefaults, fromSync, patches);
     return docWithDefaults;
   },

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -156,7 +156,12 @@ export const database = {
     await database.flushChanges(flushId);
     return createdDoc;
   },
-
+  findOne: async function <T extends BaseModel>(type: string, query: Query<T> | string = {}): Promise<T | null> {
+    if (process.type === 'renderer') {
+      return _send<T>('findOne', ...arguments);
+    }
+    return (nedbBucket[type] as NeDB<T>).findOneAsync(query);
+  },
   /** find documents matching query */
   find: async function <T extends BaseModel>(type: string, query: Query<T> | string = {}, sort: Sort = { created: 1 }) {
     if (process.type === 'renderer') {
@@ -261,33 +266,11 @@ export const database = {
     }
   },
 
-  /** get the exact document by id */
-  get: async function <T extends BaseModel>(type: string, id?: string) {
-    if (process.type === 'renderer') {
-      return _send<T>('get', ...arguments);
-    }
-
-    // Short circuit IDs used to represent nothing
-    if (!id || id === 'n/a') {
-      return null;
-    }
-    return database.getWhere<T>(type, { _id: id });
-  },
-
   getMostRecentlyModified: async function <T extends BaseModel>(type: string, query: Query<T> = {}) {
     if (process.type === 'renderer') {
       return _send<T>('getMostRecentlyModified', ...arguments);
     }
     const docs = await database.findMostRecentlyModified<T>(type, query, 1);
-    return docs.length ? docs[0] : null;
-  },
-
-  /** get the first document matching query */
-  getWhere: async function <T extends BaseModel>(type: string, query: Query<T>) {
-    if (process.type === 'renderer') {
-      return _send<T>('getWhere', ...arguments);
-    }
-    const docs = await database.find<T>(type, query);
     return docs.length ? docs[0] : null;
   },
 
@@ -507,7 +490,7 @@ export const database = {
     if (process.type === 'renderer') {
       return _send<T>('upsert', ...arguments);
     }
-    const existingDoc = await database.get<T>(doc.type, doc._id);
+    const existingDoc = await database.findOne<T>(doc.type, { _id: doc._id });
 
     if (existingDoc) {
       return database.update<T>(doc, fromSync);
@@ -533,7 +516,7 @@ export const database = {
       for (const d of docs) {
         for (const type of types) {
           // If the doc is null, we want to search for parentId === null
-          const another = await database.get<T>(type, d.parentId);
+          const another = await database.findOne<T>(type, { _id: d.parentId });
           another && foundDocs.push(another);
         }
       }

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -38,14 +38,14 @@ export type ChangeType = 'insert' | 'update' | 'remove';
 export const database = {
   // Get all documents of a certain type
   all: async function <T extends BaseModel>(type: string) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<T[]>('all', ...arguments);
     }
     return database.find<T>(type);
   },
 
   batchModifyDocs: async function ({ upsert = [], remove = [] }: Operation) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<void>('batchModifyDocs', ...arguments);
     }
     const flushId = await database.bufferChanges();
@@ -60,7 +60,7 @@ export const database = {
   /** buffers database changes and returns a buffer id, automatically call flushChanges in millis,
    * bufferChanges and flushChanges should be called in pair every time documents changes are made to trigger change listeners */
   bufferChanges: async function (millis = 1000) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<number>('bufferChanges', ...arguments);
     }
     bufferingChanges = true;
@@ -70,7 +70,7 @@ export const database = {
 
   /** buffers database changes and returns a buffer id */
   bufferChangesIndefinitely: async function () {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<number>('bufferChangesIndefinitely', ...arguments);
     }
     bufferingChanges = true;
@@ -79,11 +79,11 @@ export const database = {
 
   /** return count num of documents matching query */
   count: async function <T extends BaseModel>(type: string, query: Query<T> = {}) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<number>('count', ...arguments);
     }
     return new Promise<number>((resolve, reject) => {
-      (db[type] as NeDB<T>).count(query, (err, count) => {
+      (nedbBucket[type] as NeDB<T>).count(query, (err, count) => {
         if (err) {
           return reject(err);
         }
@@ -122,7 +122,7 @@ export const database = {
 
   /** duplicate doc and its descendents recursively */
   duplicate: async function <T extends BaseModel>(originalDoc: T, patch: Patch<T> = {}) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<T>('duplicate', ...arguments);
     }
     const flushId = await database.bufferChanges();
@@ -167,16 +167,16 @@ export const database = {
 
   /** find documents matching query */
   find: async function <T extends BaseModel>(type: string, query: Query<T> | string = {}, sort: Sort = { created: 1 }) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<T[]>('find', ...arguments);
     }
     return new Promise<T[]>((resolve, reject) => {
-      if (!db[type]) {
+      if (!nedbBucket[type]) {
         console.warn(`[db] No collection for type "${type}"`);
         resolve([]);
         return;
       }
-      (db[type] as NeDB<T>)
+      (nedbBucket[type] as NeDB<T>)
         .find(query)
         .sort(sort)
         .exec(async (err, rawDocs) => {
@@ -201,11 +201,11 @@ export const database = {
     query: Query<T> = {},
     limit: number | null = null,
   ) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<T[]>('findMostRecentlyModified', ...arguments);
     }
     return new Promise<T[]>(resolve => {
-      (db[type] as NeDB<T>)
+      (nedbBucket[type] as NeDB<T>)
         .find(query)
         .sort({
           modified: -1,
@@ -232,7 +232,7 @@ export const database = {
 
   /** trigger all changeListeners */
   flushChanges: async function (id = 0, fake = false) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<void>('flushChanges', ...arguments);
     }
 
@@ -271,7 +271,7 @@ export const database = {
 
   /** get the exact document by id */
   get: async function <T extends BaseModel>(type: string, id?: string) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<T>('get', ...arguments);
     }
 
@@ -283,7 +283,7 @@ export const database = {
   },
 
   getMostRecentlyModified: async function <T extends BaseModel>(type: string, query: Query<T> = {}) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<T>('getMostRecentlyModified', ...arguments);
     }
     const docs = await database.findMostRecentlyModified<T>(type, query, 1);
@@ -292,7 +292,7 @@ export const database = {
 
   /** get the first document matching query */
   getWhere: async function <T extends BaseModel>(type: string, query: Query<T>) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<T>('getWhere', ...arguments);
     }
     const docs = await database.find<T>(type, query);
@@ -309,18 +309,18 @@ export const database = {
     if (forceReset) {
       changeListeners = [];
 
-      for (const attr of Object.keys(db)) {
+      for (const attr of Object.keys(nedbBucket)) {
         if (attr === '_empty') {
           continue;
         }
 
-        delete db[attr];
+        delete nedbBucket[attr];
       }
     }
 
     // Fill in the defaults
     for (const modelType of types) {
-      if (db[modelType]) {
+      if (nedbBucket[modelType]) {
         consoleLog(`[db] Already initialized DB.${modelType}`);
         continue;
       }
@@ -337,10 +337,9 @@ export const database = {
         ),
       );
 
-      db[modelType] = collection;
+      nedbBucket[modelType] = collection;
     }
 
-    delete db._empty;
     electron.ipcMain.on('db.fn', async (e, fnName, replyChannel, ...args) => {
       try {
         // @ts-expect-error -- mapping unsoundness
@@ -373,7 +372,7 @@ export const database = {
   },
 
   insert: async function <T extends BaseModel>(doc: T, fromSync = false, initializeModel = true) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<T>('insert', ...arguments);
     }
     return new Promise<T>(async (resolve, reject) => {
@@ -389,7 +388,7 @@ export const database = {
         return reject(err);
       }
 
-      (db[doc.type] as NeDB<T>).insert(docWithDefaults, (err, newDoc: T) => {
+      (nedbBucket[doc.type] as NeDB<T>).insert(docWithDefaults, (err, newDoc: T) => {
         if (err) {
           return reject(err);
         }
@@ -411,7 +410,7 @@ export const database = {
 
   /** remove doc and its descendants */
   remove: async function <T extends BaseModel>(doc: T, fromSync = false) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<void>('remove', ...arguments);
     }
 
@@ -423,7 +422,7 @@ export const database = {
 
     // Don't really need to wait for this to be over;
     types.map(t =>
-      db[t].remove(
+      nedbBucket[t].remove(
         {
           _id: {
             $in: docIds,
@@ -440,7 +439,7 @@ export const database = {
   },
 
   removeWhere: async function <T extends BaseModel>(type: string, query: Query<T>) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<void>('removeWhere', ...arguments);
     }
     const flushId = await database.bufferChanges();
@@ -452,7 +451,7 @@ export const database = {
 
       // Don't really need to wait for this to be over;
       types.map(t =>
-        db[t].remove(
+        nedbBucket[t].remove(
           {
             _id: {
               $in: docIds,
@@ -471,16 +470,16 @@ export const database = {
 
   /** Removes entries without removing their children */
   unsafeRemove: async function <T extends BaseModel>(doc: T, fromSync = false) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<void>('unsafeRemove', ...arguments);
     }
 
-    (db[doc.type] as NeDB<T>).remove({ _id: doc._id });
+    (nedbBucket[doc.type] as NeDB<T>).remove({ _id: doc._id });
     notifyOfChange('remove', doc, fromSync);
   },
 
   update: async function <T extends BaseModel>(doc: T, fromSync = false, patches: Patch<T>[] = []) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<T>('update', ...arguments);
     }
 
@@ -493,7 +492,7 @@ export const database = {
         return reject(err);
       }
 
-      (db[doc.type] as NeDB<T>).update(
+      (nedbBucket[doc.type] as NeDB<T>).update(
         { _id: docWithDefaults._id },
         docWithDefaults,
         // TODO(TSCONVERSION) see comment below, upsert can happen automatically as part of the update
@@ -513,7 +512,7 @@ export const database = {
 
   // TODO(TSCONVERSION) the update method above can now take an upsert property
   upsert: async function <T extends BaseModel>(doc: T, fromSync = false) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<T>('upsert', ...arguments);
     }
     const existingDoc = await database.get<T>(doc.type, doc._id);
@@ -526,7 +525,7 @@ export const database = {
 
   /** get all ancestors of specified types of a document */
   withAncestors: async function <T extends BaseModel>(doc: T | null, types: string[] = allTypes()) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<T[]>('withAncestors', ...arguments);
     }
 
@@ -567,7 +566,7 @@ export const database = {
    * @returns A promise that resolves to an array of documents
    */
   getWithDescendants: async function <T extends BaseModel>(doc: T, types: models.ModelTypes = []) {
-    if (db._empty) {
+    if (process.type === 'renderer') {
       return _send<T[]>('getWithDescendants', ...arguments);
     }
 
@@ -623,16 +622,12 @@ export const database = {
 
 type DB = Record<string, NeDB>;
 
-// @ts-expect-error -- TSCONVERSION _empty doesn't match the index signature, use something other than _empty in future
-const db: DB = {
-  // _empty is true if it's in the renderer process
-  _empty: true,
-} as DB;
+const nedbBucket: DB = {} as DB;
 
 // ~~~~~~~ //
 // HELPERS //
 // ~~~~~~~ //
-const allTypes = () => Object.keys(db);
+const allTypes = () => Object.keys(nedbBucket);
 
 function getDBFilePath(modelType: string) {
   // NOTE: Do not EVER change this. EVER!

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -386,24 +386,6 @@ export const database = {
         filename: fsPath.join(dbPath, 'insomnia.WorkspaceMeta.db'),
       }),
     };
-    // for (const modelType of types) {
-    //   if (nedbBucket?.[modelType]) {
-    //     consoleLog(`[db] Already initialized DB.${modelType}`);
-    //     continue;
-    //   }
-
-    //   const filePath = fsPath.join(
-    //     process.env['INSOMNIA_DATA_PATH'] || electron.app.getPath('userData'),
-    //     `insomnia.${modelType}.db`,
-    //   );
-
-    //   nedbBucket[modelType] = new NeDB({
-    //     autoload: true,
-    //     filename: filePath,
-    //     corruptAlertThreshold: 0.9,
-    //     ...config,
-    //   });
-    // }
 
     electron.ipcMain.on('db.fn', async (e, fnName, replyChannel, ...args) => {
       try {
@@ -437,10 +419,6 @@ export const database = {
 
   onChange: (callback: ChangeListener) => {
     changeListeners.push(callback);
-  },
-
-  offChange: (callback: ChangeListener) => {
-    changeListeners = changeListeners.filter(l => l !== callback);
   },
 
   /** remove doc and its descendants */

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -124,9 +124,8 @@ export const database = {
       // 1. Copy the doc
       const newDoc = { ...docToCopy, ...patch, ...overrides };
 
-      // Don't initialize the model during insert, and simply duplicate
-      const createdDoc = await database.insert(newDoc, false, false);
-
+      const createdDoc = await nedbBucket[docToCopy.type]?.insertAsync(newDoc);
+      invariant(createdDoc, `Failed to duplicate document of type ${docToCopy.type}`);
       // 2. Get all the children
       for (const type of Object.keys(nedbBucket) as AllTypes[]) {
         // Note: We never want to duplicate a response
@@ -270,11 +269,11 @@ export const database = {
     }
   },
 
-  insert: async function <T extends BaseModel>(doc: T, fromSync = false, initializeModel = true) {
+  insert: async function <T extends BaseModel>(doc: T, fromSync = false) {
     if (process.type === 'renderer') {
       return _send<T>('insert', ...arguments);
     }
-    const docWithDefaults = initializeModel ? await models.initModel<T>(doc.type, doc) : doc;
+    const docWithDefaults = await models.initModel<T>(doc.type, doc);
     const newDoc = await nedbBucket[doc.type]?.insertAsync(docWithDefaults);
     invariant(newDoc, `Failed to insert document of type ${doc.type}`);
     notifyOfChange('insert', newDoc, fromSync);

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -43,7 +43,7 @@ export const database = {
     const flushId = await database.bufferChanges();
 
     // Perform from least to most dangerous
-    await Promise.all(upsert.map(doc => database.upsert(doc, true)));
+    await Promise.all(upsert.map(doc => database.update(doc, true)));
     await Promise.all(remove.map(doc => database.unsafeRemove(doc, true)));
 
     await database.flushChanges(flushId);
@@ -364,22 +364,9 @@ export const database = {
     }
 
     const docWithDefaults = await models.initModel<T>(doc.type, doc);
-    await nedbBucket[doc.type]?.updateAsync({ _id: docWithDefaults._id }, docWithDefaults);
+    await nedbBucket[doc.type]?.updateAsync({ _id: docWithDefaults._id }, docWithDefaults, { upsert: true });
     notifyOfChange('update', docWithDefaults, fromSync, patches);
     return docWithDefaults;
-  },
-
-  // TODO(TSCONVERSION) the update method above can now take an upsert property
-  upsert: async function <T extends BaseModel>(doc: T, fromSync = false) {
-    if (process.type === 'renderer') {
-      return _send<T>('upsert', ...arguments);
-    }
-    const existingDoc = await database.findOne<T>(doc.type, { _id: doc._id });
-
-    if (existingDoc) {
-      return database.update<T>(doc, fromSync);
-    }
-    return database.insert<T>(doc, fromSync);
   },
 
   /** get all ancestors of specified types of a document including the original */

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -7,8 +7,6 @@ import NeDB from '@seald-io/nedb';
 import electron from 'electron';
 import { v4 as uuidv4 } from 'uuid';
 
-import { invariant } from '~/utils/invariant';
-
 import { mustGetModel } from '../models';
 import type { CookieJar } from '../models/cookie-jar';
 import { type Environment } from '../models/environment';
@@ -464,7 +462,7 @@ export const database = {
   },
 };
 
-let nedbBucket: Record<AllTypes, NeDB>;
+let nedbBucket: Record<AllTypes, NeDB> = {} as Record<AllTypes, NeDB>;
 
 // ~~~~~~~~~~~~~~~~ //
 // Change Listeners //

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -331,16 +331,6 @@ export const database = {
     }
   },
 
-  /** init in renderer process */
-  initClient: async () => {
-    electron.ipcRenderer.on('db.changes', async (_e, changes) => {
-      for (const fn of changeListeners) {
-        await fn(changes);
-      }
-    });
-    console.log('[db] Initialized DB client');
-  },
-
   insert: async function <T extends BaseModel>(doc: T, fromSync = false, initializeModel = true) {
     if (process.type === 'renderer') {
       return _send<T>('insert', ...arguments);

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -74,7 +74,8 @@ export const database = {
     if (process.type === 'renderer') {
       return _send<number>('count', ...arguments);
     }
-    return (nedbBucket[type] as NeDB<T>).countAsync(query);
+    const total = await nedbBucket[type]?.countAsync(query);
+    return total || 0;
   },
 
   docCreate: async <T extends BaseModel>(type: AllTypes, ...patches: Patch<T>[]) => {
@@ -127,7 +128,7 @@ export const database = {
       const createdDoc = await database.insert(newDoc, false, false);
 
       // 2. Get all the children
-      for (const type of allTypes()) {
+      for (const type of Object.keys(nedbBucket) as AllTypes[]) {
         // Note: We never want to duplicate a response
         if (!models.canDuplicate(type)) {
           continue;
@@ -148,18 +149,18 @@ export const database = {
     await database.flushChanges(flushId);
     return createdDoc;
   },
-  findOne: async function <T extends BaseModel>(type: AllTypes, query: Query<T> | string = {}): Promise<T | null> {
+  findOne: async function <T extends BaseModel>(type: AllTypes, query: Query<T> | string = {}): Promise<T | undefined> {
     if (process.type === 'renderer') {
       return _send<T>('findOne', ...arguments);
     }
-    return (nedbBucket[type] as NeDB<T>).findOneAsync(query);
+    return await nedbBucket[type]?.findOneAsync<T>(query);
   },
   /** find documents matching query */
   find: async function <T extends BaseModel>(
     type: AllTypes,
     query: Query<T> | string = {},
     sort: Sort = { created: 1 },
-  ) {
+  ): Promise<T[]> {
     if (process.type === 'renderer') {
       return _send<T[]>('find', ...arguments);
     }
@@ -167,11 +168,11 @@ export const database = {
       console.warn(`[db] No collection for type "${type}"`);
       return [];
     }
-    const docs = await nedbBucket[type].findAsync(query).sort(sort);
+    const docs = await nedbBucket[type].findAsync<T>(query).sort(sort);
     // TODO: create a db init phase for migrations rather than doing it on every find.
     const migrated = [];
     for (const rawDoc of docs) {
-      migrated.push(await models.initModel(type, rawDoc));
+      migrated.push(await models.initModel<T>(type, rawDoc));
     }
     return migrated;
   },
@@ -180,11 +181,11 @@ export const database = {
     if (process.type === 'renderer') {
       return _send<T[]>('findMostRecentlyModified', ...arguments);
     }
-    const docs = await (nedbBucket[type] as NeDB<T>).findAsync(query).sort({ modified: -1 }).limit(limit);
+    const docs = await nedbBucket[type]?.findAsync<T>(query).sort({ modified: -1 }).limit(limit);
     // TODO: create a db init phase for migrations rather than doing it on every find.
     const migrated = [];
-    for (const rawDoc of docs) {
-      migrated.push(await models.initModel(type, rawDoc));
+    for (const rawDoc of docs || []) {
+      migrated.push(await models.initModel<T>(type, rawDoc));
     }
     return migrated;
   },
@@ -237,14 +238,7 @@ export const database = {
   ) => {
     if (forceReset) {
       changeListeners = [];
-
-      for (const attr of Object.keys(nedbBucket)) {
-        if (attr === '_empty') {
-          continue;
-        }
-
-        delete nedbBucket[attr];
-      }
+      nedbBucket = {} as Record<AllTypes, NeDB>;
     }
 
     // Fill in the defaults
@@ -321,7 +315,7 @@ export const database = {
 
     // Don't really need to wait for this to be over;
     types.map(t =>
-      nedbBucket[t].remove(
+      nedbBucket[t]?.remove(
         {
           _id: {
             $in: docIds,
@@ -350,7 +344,7 @@ export const database = {
 
       // Don't really need to wait for this to be over;
       types.map(t =>
-        nedbBucket[t].remove(
+        nedbBucket[t]?.remove(
           {
             _id: {
               $in: docIds,
@@ -383,9 +377,9 @@ export const database = {
     }
 
     const docWithDefaults = await models.initModel<T>(doc.type, doc);
-    const newDoc = await (nedbBucket[doc.type] as NeDB<T>).updateAsync({ _id: docWithDefaults._id }, docWithDefaults);
+    await (nedbBucket[doc.type] as NeDB<T>).updateAsync({ _id: docWithDefaults._id }, docWithDefaults);
     notifyOfChange('update', docWithDefaults, fromSync, patches);
-    return newDoc;
+    return docWithDefaults;
   },
 
   // TODO(TSCONVERSION) the update method above can now take an upsert property
@@ -402,7 +396,7 @@ export const database = {
   },
 
   /** get all ancestors of specified types of a document */
-  withAncestors: async function <T extends BaseModel>(doc: T | null, types: AllTypes[] = allTypes()) {
+  withAncestors: async function <T extends BaseModel>(doc: T | undefined, types: AllTypes[] = []) {
     if (process.type === 'renderer') {
       return _send<T[]>('withAncestors', ...arguments);
     }
@@ -412,7 +406,9 @@ export const database = {
     }
 
     let docsToReturn: T[] = doc ? [doc] : [];
-
+    if (types.length === 0) {
+      types = Object.keys(nedbBucket) as AllTypes[];
+    }
     async function next(docs: T[]): Promise<T[]> {
       const foundDocs: T[] = [];
 
@@ -498,14 +494,11 @@ export const database = {
   },
 };
 
-type DB = Record<string, NeDB>;
-
-const nedbBucket: DB = {} as DB;
+let nedbBucket: Partial<Record<AllTypes, NeDB>> = {};
 
 // ~~~~~~~ //
 // HELPERS //
 // ~~~~~~~ //
-const allTypes = () => Object.keys(nedbBucket) as AllTypes[];
 
 function getDBFilePath(modelType: AllTypes) {
   // NOTE: Do not EVER change this. EVER!
@@ -598,14 +591,10 @@ export async function _repairDatabase() {
  */
 async function _applyApiSpecName(workspace: Workspace) {
   const apiSpec = await models.apiSpec.getByParentId(workspace._id);
-  if (apiSpec === null) {
-    return;
-  }
-
-  if (!apiSpec.fileName || apiSpec.fileName === models.apiSpec.init().fileName) {
-    await models.apiSpec.update(apiSpec, {
-      fileName: workspace.name,
-    });
+  const existsAndFilenameIsDefaultOrMissing =
+    apiSpec && (!apiSpec.fileName || apiSpec.fileName === models.apiSpec.init().fileName);
+  if (existsAndFilenameIsDefaultOrMissing) {
+    await models.apiSpec.update(apiSpec, { fileName: workspace.name });
   }
 }
 

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -74,15 +74,7 @@ export const database = {
     if (process.type === 'renderer') {
       return _send<number>('count', ...arguments);
     }
-    return new Promise<number>((resolve, reject) => {
-      (nedbBucket[type] as NeDB<T>).count(query, (err, count) => {
-        if (err) {
-          return reject(err);
-        }
-
-        resolve(count);
-      });
-    });
+    return (nedbBucket[type] as NeDB<T>).countAsync(query);
   },
 
   docCreate: async <T extends BaseModel>(type: AllTypes, ...patches: Patch<T>[]) => {
@@ -171,64 +163,30 @@ export const database = {
     if (process.type === 'renderer') {
       return _send<T[]>('find', ...arguments);
     }
-    return new Promise<T[]>((resolve, reject) => {
-      if (!nedbBucket[type]) {
-        console.warn(`[db] No collection for type "${type}"`);
-        resolve([]);
-        return;
-      }
-      (nedbBucket[type] as NeDB<T>)
-        .find(query)
-        .sort(sort)
-        .exec(async (err, rawDocs) => {
-          if (err) {
-            reject(err);
-            return;
-          }
-
-          const docs: T[] = [];
-
-          for (const rawDoc of rawDocs) {
-            docs.push(await models.initModel(type, rawDoc));
-          }
-
-          resolve(docs);
-        });
-    });
+    if (!nedbBucket[type]) {
+      console.warn(`[db] No collection for type "${type}"`);
+      return [];
+    }
+    const docs = await nedbBucket[type].findAsync(query).sort(sort);
+    // TODO: create a db init phase for migrations rather than doing it on every find.
+    const migrated = [];
+    for (const rawDoc of docs) {
+      migrated.push(await models.initModel(type, rawDoc));
+    }
+    return migrated;
   },
 
-  findMostRecentlyModified: async function <T extends BaseModel>(
-    type: AllTypes,
-    query: Query<T> = {},
-    limit: number | null = null,
-  ) {
+  findMostRecentlyModified: async function <T extends BaseModel>(type: AllTypes, query: Query<T> = {}, limit = 1) {
     if (process.type === 'renderer') {
       return _send<T[]>('findMostRecentlyModified', ...arguments);
     }
-    return new Promise<T[]>(resolve => {
-      (nedbBucket[type] as NeDB<T>)
-        .find(query)
-        .sort({
-          modified: -1,
-        })
-        // @ts-expect-error -- TSCONVERSION limit shouldn't be applied if it's null, or default to something that means no-limit
-        .limit(limit)
-        .exec(async (err, rawDocs) => {
-          if (err) {
-            console.warn('[db] Failed to find docs', err);
-            resolve([]);
-            return;
-          }
-
-          const docs: T[] = [];
-
-          for (const rawDoc of rawDocs) {
-            docs.push(await models.initModel(type, rawDoc));
-          }
-
-          resolve(docs);
-        });
-    });
+    const docs = await (nedbBucket[type] as NeDB<T>).findAsync(query).sort({ modified: -1 }).limit(limit);
+    // TODO: create a db init phase for migrations rather than doing it on every find.
+    const migrated = [];
+    for (const rawDoc of docs) {
+      migrated.push(await models.initModel(type, rawDoc));
+    }
+    return migrated;
   },
 
   /** trigger all changeListeners */
@@ -335,29 +293,10 @@ export const database = {
     if (process.type === 'renderer') {
       return _send<T>('insert', ...arguments);
     }
-    return new Promise<T>(async (resolve, reject) => {
-      let docWithDefaults: T | null = null;
-
-      try {
-        if (initializeModel) {
-          docWithDefaults = await models.initModel<T>(doc.type, doc);
-        } else {
-          docWithDefaults = doc;
-        }
-      } catch (err) {
-        return reject(err);
-      }
-
-      (nedbBucket[doc.type] as NeDB<T>).insert(docWithDefaults, (err, newDoc: T) => {
-        if (err) {
-          return reject(err);
-        }
-
-        resolve(newDoc);
-        // NOTE: This needs to be after we resolve
-        notifyOfChange('insert', newDoc, fromSync);
-      });
-    });
+    const docWithDefaults = initializeModel ? await models.initModel<T>(doc.type, doc) : doc;
+    const newDoc = await (nedbBucket[doc.type] as NeDB<T>).insertAsync(docWithDefaults);
+    notifyOfChange('insert', newDoc, fromSync);
+    return newDoc;
   },
 
   onChange: (callback: ChangeListener) => {
@@ -443,31 +382,10 @@ export const database = {
       return _send<T>('update', ...arguments);
     }
 
-    return new Promise<T>(async (resolve, reject) => {
-      let docWithDefaults: T;
-
-      try {
-        docWithDefaults = await models.initModel<T>(doc.type, doc);
-      } catch (err) {
-        return reject(err);
-      }
-
-      (nedbBucket[doc.type] as NeDB<T>).update(
-        { _id: docWithDefaults._id },
-        docWithDefaults,
-        // TODO(TSCONVERSION) see comment below, upsert can happen automatically as part of the update
-        // @ts-expect-error -- TSCONVERSION expects 4 args but only sent 3. Need to validate what UpdateOptions should be.
-        err => {
-          if (err) {
-            return reject(err);
-          }
-
-          resolve(docWithDefaults);
-          // NOTE: This needs to be after we resolve
-          notifyOfChange('update', docWithDefaults, fromSync, patches);
-        },
-      );
-    });
+    const docWithDefaults = await models.initModel<T>(doc.type, doc);
+    const newDoc = await (nedbBucket[doc.type] as NeDB<T>).updateAsync({ _id: docWithDefaults._id }, docWithDefaults);
+    notifyOfChange('update', docWithDefaults, fromSync, patches);
+    return newDoc;
   },
 
   // TODO(TSCONVERSION) the update method above can now take an upsert property

--- a/packages/insomnia/src/common/database.ts
+++ b/packages/insomnia/src/common/database.ts
@@ -379,7 +379,7 @@ export const database = {
       return [];
     }
 
-    let docsToReturn: T[] = [];
+    let docsToReturn: T[] = doc ? [doc] : [];
     if (types.length === 0) {
       types = Object.keys(nedbBucket) as AllTypes[];
     }

--- a/packages/insomnia/src/common/har.ts
+++ b/packages/insomnia/src/common/har.ts
@@ -138,7 +138,7 @@ export async function exportHar(exportRequests: ExportRequest[]) {
   const entries: Har.Entry[] = [];
 
   for (const exportRequest of exportRequests) {
-    const request: Request | null = await models.request.getById(exportRequest.requestId);
+    const request = await models.request.getById(exportRequest.requestId);
 
     if (!request) {
       continue;
@@ -150,7 +150,7 @@ export async function exportHar(exportRequests: ExportRequest[]) {
       continue;
     }
 
-    let response: Response | null = null;
+    let response;
     if (exportRequest.responseId) {
       response = await models.response.getById(exportRequest.responseId);
     } else {
@@ -199,7 +199,7 @@ export async function exportHar(exportRequests: ExportRequest[]) {
   return har;
 }
 
-export async function exportHarResponse(response: Response | null) {
+export async function exportHarResponse(response?: Response) {
   if (!response) {
     return {
       status: 0,

--- a/packages/insomnia/src/common/har.ts
+++ b/packages/insomnia/src/common/har.ts
@@ -154,7 +154,7 @@ export async function exportHar(exportRequests: ExportRequest[]) {
     if (exportRequest.responseId) {
       response = await models.response.getById(exportRequest.responseId);
     } else {
-      response = await models.response.getLatestForRequest(
+      response = await models.response.getLatestForRequestId(
         exportRequest.requestId,
         exportRequest.environmentId || null,
       );

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -28,7 +28,7 @@ import { tryImportV5Data } from './insomnia-v5';
 import { generateId } from './misc';
 
 export interface ExportedModel extends BaseModel {
-  _type: string;
+  _type: models.AllTypes;
 }
 
 interface ConvertResult {
@@ -175,7 +175,7 @@ export async function scanResources(importEntries: ImportEntry[]): Promise<ScanR
         .filter(r => r._type)
         .map(r => {
           const { _type, ...model } = r;
-          return { ...model, type: models.MODELS_BY_EXPORT_TYPE[_type].type };
+          return { ...model, type: models.MODELS_BY_EXPORT_TYPE[_type] };
         });
 
       resourceCacheList.push({

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 
 import { z, type ZodError } from 'zod/v4';
 
+import type { AllExportTypes } from '~/common/constants';
 import type { CurrentPlan } from '~/models/organization';
 
 import { type ApiSpec, isApiSpec } from '../models/api-spec';
@@ -28,7 +29,7 @@ import { tryImportV5Data } from './insomnia-v5';
 import { generateId } from './misc';
 
 export interface ExportedModel extends BaseModel {
-  _type: models.AllTypes;
+  _type: AllExportTypes;
 }
 
 interface ConvertResult {

--- a/packages/insomnia/src/common/insomnia-v5.ts
+++ b/packages/insomnia/src/common/insomnia-v5.ts
@@ -503,7 +503,7 @@ export async function getInsomniaV5DataExport({
     const workspaceDescendants = await database.getWithDescendants(workspace, models.EXPORTABLE_TYPES);
 
     const exportableResources = workspaceDescendants.filter(resource => {
-      if (models.EXPORTABLE_TYPES.includes(resource.type as models.ModelTypes[number])) {
+      if (models.EXPORTABLE_TYPES.includes(resource.type)) {
         return true;
       }
 

--- a/packages/insomnia/src/common/render.ts
+++ b/packages/insomnia/src/common/render.ts
@@ -580,7 +580,7 @@ export async function getRenderedRequestAndContext({
       o.query = o.query.replace(/#}/g, '# }');
       request.body.text = JSON.stringify(o);
     }
-  } catch (err) { }
+  } catch (err) {}
 
   // Render description separately because it's lower priority
   const description = request.description;
@@ -706,7 +706,7 @@ function _getOrderedEnvironmentKeys(finalRenderContext: Record<string, any>): st
 export async function getRenderContextAncestors(
   base?: Request | GrpcRequest | WebSocketRequest | SocketIORequest | RequestGroup | Workspace,
 ): Promise<RenderContextAncestor[]> {
-  return await db.withAncestors<RenderContextAncestor>(base || null, [
+  return await db.withAncestors<RenderContextAncestor>(base, [
     models.request.type,
     models.grpcRequest.type,
     models.webSocketRequest.type,

--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -61,7 +61,8 @@ export async function getSendRequestCallbackMemDb(
       docs.push(doc);
     }
   }
-
+  // init database with the provided documents
+  // TODO: this could be done with database.init instead
   await database.batchModifyDocs({
     upsert: docs,
     remove: [],

--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { type BaseModel, types as modelTypes } from '../models';
+import { type BaseModel } from '../models';
 import * as models from '../models';
 import type { Environment, UserUploadEnvironment } from '../models/environment';
 import { getBodyBuffer } from '../models/response';
@@ -44,7 +44,6 @@ export async function getSendRequestCallbackMemDb(
 ) {
   // Initialize the DB in-memory and fill it with data if we're given one
   await database.init(
-    modelTypes(),
     {
       inMemoryOnly: true,
     },

--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -48,7 +48,6 @@ export async function getSendRequestCallbackMemDb(
       inMemoryOnly: true,
     },
     true,
-    () => {},
   );
   const docs: BaseModel[] = [];
 

--- a/packages/insomnia/src/entry.client.tsx
+++ b/packages/insomnia/src/entry.client.tsx
@@ -8,7 +8,6 @@ import { HydratedRouter } from 'react-router/dom';
 
 import { migrateFromLocalStorage, setSessionData, setVaultSessionData } from './account/session';
 import { getInsomniaSession, getInsomniaVaultKey, getInsomniaVaultSalt, getSkipOnboarding } from './common/constants';
-import { database } from './common/database';
 import { settings } from './models';
 import { initNewOAuthSession } from './network/o-auth-2/get-token';
 import { init as initPlugins } from './plugins';
@@ -23,7 +22,6 @@ import { getInitialEntry } from './utils/router';
 
 initializeSentry();
 
-await database.initClient();
 await initPlugins();
 
 await migrateFromLocalStorage();

--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -100,7 +100,7 @@ app.on('ready', async () => {
   }
 
   // Init some important things first
-  await database.init(models.types());
+  await database.init();
   await _createModelInstances();
   sentryWatchAnalyticsEnabled();
   watchProxySettings();

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -552,7 +552,7 @@ async function importLegacyInsomniaFolder({ fsClient, projectId }: { fsClient: P
         });
       }
 
-      await database.upsert(doc, true);
+      await database.update(doc, true);
       changes.push({
         path: legacyInsomniaFile.filePath,
         // It existed and was removed from the git repository

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -136,9 +136,9 @@ export type MainOnChannels =
   | 'startExecution';
 
 export type RendererOnChannels =
+  | 'db.changes'
   | 'clear-all-models'
   | 'clear-model'
-  | 'nunjucks-context-menu-command'
   | 'contextMenuCommand'
   | 'grpc.data'
   | 'grpc.end'
@@ -146,14 +146,15 @@ export type RendererOnChannels =
   | 'grpc.start'
   | 'grpc.status'
   | 'loggedIn'
+  | 'mainWindowFocusChange'
+  | 'nunjucks-context-menu-command'
   | 'reload-plugins'
   | 'shell:open'
   | 'show-notification'
   | 'toggle-preferences-shortcuts'
   | 'toggle-preferences'
   | 'toggle-sidebar'
-  | 'updaterStatus'
-  | 'mainWindowFocusChange';
+  | 'updaterStatus';
 
 export const ipcMainOn = (
   channel: MainOnChannels,

--- a/packages/insomnia/src/main/network/curl.ts
+++ b/packages/insomnia/src/main/network/curl.ts
@@ -9,7 +9,6 @@ import { v4 as uuidV4 } from 'uuid';
 import { describeByteSize, generateId, getSetCookieHeaders } from '../../common/misc';
 import * as models from '../../models';
 import type { CookieJar } from '../../models/cookie-jar';
-import type { Environment } from '../../models/environment';
 import type { RequestAuthentication, RequestHeader } from '../../models/request';
 import type { Response } from '../../models/response';
 import { readCurlResponse } from '../../models/response';
@@ -113,7 +112,7 @@ const openCurlConnection = async (
 
   const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(options.workspaceId);
   const environmentId: string = workspaceMeta.activeEnvironmentId || 'n/a';
-  const environment: Environment | null = await models.environment.getById(environmentId || 'n/a');
+  const environment = await models.environment.getById(environmentId || 'n/a');
   const responseEnvironmentId = environment ? environment._id : null;
 
   const caCert = await models.caCertificate.findByParentId(options.workspaceId);

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -537,9 +537,10 @@ const sendPayload = async (ws: WebSocket, options: { payload: string; requestId:
   };
 
   eventLogFileStreams.get(options.requestId)?.write(JSON.stringify(lastMessage) + '\n');
-  const response = database.getMostRecentlyModified<WebSocketResponse>('WebSocketResponse', {
+  const responses = await database.findMostRecentlyModified<WebSocketResponse>('WebSocketResponse', {
     parentId: options.requestId,
   });
+  const response = responses[0];
   if (!response) {
     console.error('something went wrong');
     return;

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -537,10 +537,13 @@ const sendPayload = async (ws: WebSocket, options: { payload: string; requestId:
   };
 
   eventLogFileStreams.get(options.requestId)?.write(JSON.stringify(lastMessage) + '\n');
-  const responses = await database.findMostRecentlyModified<WebSocketResponse>('WebSocketResponse', {
-    parentId: options.requestId,
-  });
-  const response = responses[0];
+  const response = await database.findOne<WebSocketResponse>(
+    'WebSocketResponse',
+    {
+      parentId: options.requestId,
+    },
+    { modified: -1 },
+  );
   if (!response) {
     console.error('something went wrong');
     return;

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -10,6 +10,8 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import { v4 as uuidV4 } from 'uuid';
 import { type CloseEvent, type ErrorEvent, type Event, type MessageEvent, WebSocket } from 'ws';
 
+import { database } from '~/common/database';
+
 import { AUTH_API_KEY, AUTH_BASIC, AUTH_BEARER } from '../../common/constants';
 import { jarFromCookies } from '../../common/cookies';
 import { generateId, getSetCookieHeaders } from '../../common/misc';
@@ -535,7 +537,9 @@ const sendPayload = async (ws: WebSocket, options: { payload: string; requestId:
   };
 
   eventLogFileStreams.get(options.requestId)?.write(JSON.stringify(lastMessage) + '\n');
-  const response = await models.webSocketResponse.getLatestByParentId(options.requestId);
+  const response = database.getMostRecentlyModified<WebSocketResponse>('WebSocketResponse', {
+    parentId: options.requestId,
+  });
   if (!response) {
     console.error('something went wrong');
     return;

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -25,7 +25,11 @@ const bundlePluginModuleMap: Record<string, Plugin['module']> = {};
 
 export const resolveDbByKey = async (request: Request) => {
   const url = new URL(request.url);
-  const body = await request.json();
+  let body;
+  try {
+    // We expect this to throw if a db call returns undefined
+    body = await request.json();
+  } catch {}
   // url get normalized to lowercase, so we need to normalize the keys to lower case as well
   const withLowercasedKeys = Object.fromEntries(
     Object.entries(pluginToMainAPI).map(([key, value]) => [key.toLowerCase(), value]),
@@ -92,7 +96,7 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     return await models.cookieJar.getOrCreateForParentId(body.parentId);
   },
   'response.getLatestForRequestId': async (body: { requestId: string; environmentId: string }) => {
-    return await models.response.getLatestForRequest(body.requestId, body.environmentId);
+    return await models.response.getLatestForRequestId(body.requestId, body.environmentId);
   },
   'response.getBodyBuffer': async (body: { response: Response; readFailureValue: string }) => {
     return await models.response.getBodyBuffer(body.response, body.readFailureValue);

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -79,7 +79,7 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
   'request.getById': async (body: { id: string }) => {
     return await models.request.getById(body.id);
   },
-  'request.getAncestors': async (body: { request: DBRequest | RequestGroup | Workspace; types: string[] }) => {
+  'request.getAncestors': async (body: { request: DBRequest | RequestGroup | Workspace; types: models.AllTypes[] }) => {
     return await db.withAncestors<DBRequest | RequestGroup | Workspace>(body.request, body.types);
   },
   'workspace.getById': async (body: { id: string }) => {

--- a/packages/insomnia/src/models/__schemas__/model-schemas.ts
+++ b/packages/insomnia/src/models/__schemas__/model-schemas.ts
@@ -29,7 +29,7 @@ export const baseModelSchema: Schema<BaseModel> = {
   modified: () => 5678,
   name: () => 'name',
   parentId: () => '',
-  type: () => 'base',
+  type: () => 'Request',
 };
 
 export const workspaceModelSchema: Schema<Workspace> = {

--- a/packages/insomnia/src/models/__schemas__/model-schemas.ts
+++ b/packages/insomnia/src/models/__schemas__/model-schemas.ts
@@ -1,7 +1,7 @@
 import type { Schema } from '@develohpanda/fluent-builder';
 import clone from 'clone';
 
-import { type BaseModel, environment, grpcRequest, request, requestGroup, workspace } from '..';
+import { type AllTypes, type BaseModel, environment, grpcRequest, request, requestGroup, workspace } from '..';
 import type { Environment } from '../environment';
 import type { GrpcRequest } from '../grpc-request';
 import type { Request } from '../request';
@@ -29,7 +29,7 @@ export const baseModelSchema: Schema<BaseModel> = {
   modified: () => 5678,
   name: () => 'name',
   parentId: () => '',
-  type: () => 'Request',
+  type: () => 'base' as AllTypes,
 };
 
 export const workspaceModelSchema: Schema<Workspace> = {

--- a/packages/insomnia/src/models/api-spec.ts
+++ b/packages/insomnia/src/models/api-spec.ts
@@ -35,11 +35,11 @@ export function migrate(doc: ApiSpec) {
 }
 
 export function getByParentId(workspaceId: string) {
-  return db.getWhere<ApiSpec>(type, { parentId: workspaceId });
+  return db.findOne<ApiSpec>(type, { parentId: workspaceId });
 }
 
 export async function getOrCreateForParentId(workspaceId: string, patch: Partial<ApiSpec> = {}) {
-  const spec = await db.getWhere<ApiSpec>(type, {
+  const spec = await db.findOne<ApiSpec>(type, {
     parentId: workspaceId,
   });
 

--- a/packages/insomnia/src/models/api-spec.ts
+++ b/packages/insomnia/src/models/api-spec.ts
@@ -56,7 +56,7 @@ export async function updateOrCreateForParentId(workspaceId: string, patch: Part
 }
 
 export async function all() {
-  return db.all<ApiSpec>(type);
+  return db.find<ApiSpec>(type);
 }
 
 export function update(apiSpec: ApiSpec, patch: Partial<ApiSpec> = {}) {

--- a/packages/insomnia/src/models/ca-certificate.ts
+++ b/packages/insomnia/src/models/ca-certificate.ts
@@ -49,11 +49,11 @@ export function update(cert: CaCertificate, patch: Partial<CaCertificate> = {}) 
 }
 
 export function getById(id: string) {
-  return db.get<CaCertificate>(type, id);
+  return db.findOne<CaCertificate>(type, { _id: id });
 }
 
 export function findByParentId(parentId: string) {
-  return db.getWhere<CaCertificate>(type, { parentId });
+  return db.findOne<CaCertificate>(type, { parentId });
 }
 
 export function removeWhere(parentId: string) {

--- a/packages/insomnia/src/models/ca-certificate.ts
+++ b/packages/insomnia/src/models/ca-certificate.ts
@@ -61,5 +61,5 @@ export function removeWhere(parentId: string) {
 }
 
 export function all() {
-  return db.all<CaCertificate>(type);
+  return db.find<CaCertificate>(type);
 }

--- a/packages/insomnia/src/models/client-certificate.ts
+++ b/packages/insomnia/src/models/client-certificate.ts
@@ -57,7 +57,7 @@ export function update(cert: ClientCertificate, patch: Partial<ClientCertificate
 }
 
 export function getById(id: string) {
-  return db.get<ClientCertificate>(type, id);
+  return db.findOne<ClientCertificate>(type, { _id: id });
 }
 
 export function findByParentId(parentId: string) {

--- a/packages/insomnia/src/models/client-certificate.ts
+++ b/packages/insomnia/src/models/client-certificate.ts
@@ -69,5 +69,5 @@ export function remove(cert: ClientCertificate) {
 }
 
 export function all() {
-  return db.all<ClientCertificate>(type);
+  return db.find<ClientCertificate>(type);
 }

--- a/packages/insomnia/src/models/cloud-credential.ts
+++ b/packages/insomnia/src/models/cloud-credential.ts
@@ -129,7 +129,7 @@ export function create(patch: Partial<CloudProviderCredential> = {}) {
 }
 
 export async function getById(id: string) {
-  return db.getWhere<CloudProviderCredential>(type, { _id: id });
+  return db.findOne<CloudProviderCredential>(type, { _id: id });
 }
 
 export function update(credential: CloudProviderCredential, patch: Partial<CloudProviderCredential>) {

--- a/packages/insomnia/src/models/cloud-credential.ts
+++ b/packages/insomnia/src/models/cloud-credential.ts
@@ -145,5 +145,5 @@ export function getByName(name: string, provider: CloudProviderName) {
 }
 
 export function all() {
-  return db.all<CloudProviderCredential>(type);
+  return db.find<CloudProviderCredential>(type);
 }

--- a/packages/insomnia/src/models/cookie-jar.ts
+++ b/packages/insomnia/src/models/cookie-jar.ts
@@ -84,7 +84,7 @@ export async function all() {
 }
 
 export async function getById(id: string): Promise<CookieJar | null> {
-  return db.get(type, id);
+  return db.findOne<CookieJar>(type, { _id: id });
 }
 
 export async function update(cookieJar: CookieJar, patch: Partial<CookieJar> = {}) {

--- a/packages/insomnia/src/models/cookie-jar.ts
+++ b/packages/insomnia/src/models/cookie-jar.ts
@@ -83,7 +83,7 @@ export async function all() {
   return db.find<BaseModel>(type);
 }
 
-export async function getById(id: string): Promise<CookieJar | null> {
+export async function getById(id: string): Promise<CookieJar | undefined> {
   return db.findOne<CookieJar>(type, { _id: id });
 }
 

--- a/packages/insomnia/src/models/cookie-jar.ts
+++ b/packages/insomnia/src/models/cookie-jar.ts
@@ -80,7 +80,7 @@ export async function getOrCreateForParentId(parentId: string) {
 }
 
 export async function all() {
-  return db.all<BaseModel>(type);
+  return db.find<BaseModel>(type);
 }
 
 export async function getById(id: string): Promise<CookieJar | null> {

--- a/packages/insomnia/src/models/environment.ts
+++ b/packages/insomnia/src/models/environment.ts
@@ -288,5 +288,5 @@ export function remove(environment: Environment) {
 }
 
 export function all() {
-  return db.all<Environment>(type);
+  return db.find<Environment>(type);
 }

--- a/packages/insomnia/src/models/environment.ts
+++ b/packages/insomnia/src/models/environment.ts
@@ -257,11 +257,11 @@ export async function getOrCreateForParentId(parentId: string) {
   return environments[environments.length - 1];
 }
 
-export function getById(id: string): Promise<Environment | null> {
+export function getById(id: string): Promise<Environment | undefined> {
   return db.findOne<Environment>(type, { _id: id });
 }
 
-export function getByParentId(parentId: string): Promise<Environment | null> {
+export function getByParentId(parentId: string): Promise<Environment | undefined> {
   return db.findOne<Environment>(type, { parentId });
 }
 

--- a/packages/insomnia/src/models/environment.ts
+++ b/packages/insomnia/src/models/environment.ts
@@ -258,11 +258,11 @@ export async function getOrCreateForParentId(parentId: string) {
 }
 
 export function getById(id: string): Promise<Environment | null> {
-  return db.get(type, id);
+  return db.findOne<Environment>(type, { _id: id });
 }
 
 export function getByParentId(parentId: string): Promise<Environment | null> {
-  return db.getWhere<Environment>(type, { parentId });
+  return db.findOne<Environment>(type, { parentId });
 }
 
 export async function duplicate(environment: Environment) {

--- a/packages/insomnia/src/models/git-credentials.ts
+++ b/packages/insomnia/src/models/git-credentials.ts
@@ -64,5 +64,5 @@ export function remove(credentials: GitCredentials) {
 }
 
 export function all() {
-  return db.all<GitCredentials>(type);
+  return db.find<GitCredentials>(type);
 }

--- a/packages/insomnia/src/models/git-credentials.ts
+++ b/packages/insomnia/src/models/git-credentials.ts
@@ -48,11 +48,11 @@ export function create(patch: Partial<GitCredentials> = {}) {
 }
 
 export async function getById(id: string) {
-  return db.getWhere<GitCredentials>(type, { _id: id });
+  return db.findOne<GitCredentials>(type, { _id: id });
 }
 
 export async function getByProvider(provider: OauthProviderName) {
-  return db.getWhere<GitCredentials>(type, provider === 'github' ? { provider: 'githubapp' } : { provider: 'gitlab' });
+  return db.findOne<GitCredentials>(type, provider === 'github' ? { provider: 'githubapp' } : { provider: 'gitlab' });
 }
 
 export function update(credentials: GitCredentials, patch: Partial<GitCredentials>) {

--- a/packages/insomnia/src/models/git-repository.ts
+++ b/packages/insomnia/src/models/git-repository.ts
@@ -75,7 +75,7 @@ export function remove(repo: GitRepository) {
 }
 
 export function all() {
-  return db.all<GitRepository>(type);
+  return db.find<GitRepository>(type);
 }
 export interface GitAuthor {
   name: string;

--- a/packages/insomnia/src/models/git-repository.ts
+++ b/packages/insomnia/src/models/git-repository.ts
@@ -63,7 +63,7 @@ export function create(patch: Partial<GitRepository> = {}) {
 }
 
 export async function getById(id: string) {
-  return db.getWhere<GitRepository>(type, { _id: id });
+  return db.findOne<GitRepository>(type, { _id: id });
 }
 
 export function update(repo: GitRepository, patch: Partial<GitRepository>) {

--- a/packages/insomnia/src/models/grpc-request-meta.ts
+++ b/packages/insomnia/src/models/grpc-request-meta.ts
@@ -77,7 +77,7 @@ export async function updateOrCreateByParentId(parentId: string, patch: Partial<
 }
 
 export function all() {
-  return db.all<GrpcRequestMeta>(type);
+  return db.find<GrpcRequestMeta>(type);
 }
 
 function expectParentToBeGrpcRequest(parentId: string | null) {

--- a/packages/insomnia/src/models/grpc-request-meta.ts
+++ b/packages/insomnia/src/models/grpc-request-meta.ts
@@ -48,7 +48,7 @@ export function update(requestMeta: GrpcRequestMeta, patch: Partial<GrpcRequestM
 
 export function getByParentId(parentId: string) {
   expectParentToBeGrpcRequest(parentId);
-  return db.getWhere<GrpcRequestMeta>(type, { parentId });
+  return db.findOne<GrpcRequestMeta>(type, { parentId });
 }
 
 export async function getOrCreateByParentId(parentId: string) {

--- a/packages/insomnia/src/models/grpc-request.ts
+++ b/packages/insomnia/src/models/grpc-request.ts
@@ -128,5 +128,5 @@ export async function duplicate(request: GrpcRequest, patch: Partial<GrpcRequest
 }
 
 export function all() {
-  return db.all<GrpcRequest>(type);
+  return db.find<GrpcRequest>(type);
 }

--- a/packages/insomnia/src/models/grpc-request.ts
+++ b/packages/insomnia/src/models/grpc-request.ts
@@ -85,7 +85,7 @@ export function update(obj: GrpcRequest, patch: Partial<GrpcRequest> = {}) {
 }
 
 export function getById(_id: string) {
-  return db.getWhere<GrpcRequest>(type, { _id });
+  return db.findOne<GrpcRequest>(type, { _id });
 }
 
 export function findByProtoFileId(protoFileId: string) {

--- a/packages/insomnia/src/models/helpers/request-operations.ts
+++ b/packages/insomnia/src/models/helpers/request-operations.ts
@@ -4,7 +4,9 @@ import type { Request } from '../request';
 import { isSocketIORequest, isSocketIORequestId, type SocketIORequest } from '../socket-io-request';
 import { isWebSocketRequest, isWebSocketRequestId, type WebSocketRequest } from '../websocket-request';
 
-export function getById(requestId: string): Promise<Request | GrpcRequest | WebSocketRequest | SocketIORequest | null> {
+export function getById(
+  requestId: string,
+): Promise<Request | GrpcRequest | WebSocketRequest | SocketIORequest | undefined> {
   if (isGrpcRequestId(requestId)) {
     return models.grpcRequest.getById(requestId);
   }

--- a/packages/insomnia/src/models/index.ts
+++ b/packages/insomnia/src/models/index.ts
@@ -1,4 +1,5 @@
 import {
+  type AllExportTypes,
   EXPORT_TYPE_API_SPEC,
   EXPORT_TYPE_COOKIE_JAR,
   EXPORT_TYPE_ENVIRONMENT,
@@ -200,8 +201,6 @@ export type AllTypes =
   | 'Workspace'
   | 'WorkspaceMeta';
 
-export type ModelTypes = ReturnType<typeof types>;
-
 export const isValidType = (type: string): type is AllTypes => {
   return types().includes(type as AllTypes);
 };
@@ -283,7 +282,7 @@ export async function initModel<T extends BaseModel>(type: string, ...sources: R
   return migratedDoc as T;
 }
 
-export const MODELS_BY_EXPORT_TYPE: Record<string, AllTypes> = {
+export const MODELS_BY_EXPORT_TYPE: Record<AllExportTypes, AllTypes> = {
   [EXPORT_TYPE_REQUEST]: 'Request',
   [EXPORT_TYPE_WEBSOCKET_PAYLOAD]: 'WebSocketPayload',
   [EXPORT_TYPE_WEBSOCKET_REQUEST]: 'WebSocketRequest',
@@ -365,7 +364,7 @@ const getChildToParentMap = () => {
   return childToParents;
 };
 
-export const generateDescendantMap = (queryTypes: ModelTypes): Partial<Record<AllTypes, AllTypes[]>> => {
+export const generateDescendantMap = (queryTypes: AllTypes[]): Partial<Record<AllTypes, AllTypes[]>> => {
   const result: Partial<Record<AllTypes, AllTypes[]>> = {};
 
   const visited = new Set<string>();

--- a/packages/insomnia/src/models/index.ts
+++ b/packages/insomnia/src/models/index.ts
@@ -60,7 +60,7 @@ import * as _workspaceMeta from './workspace-meta';
 
 export interface BaseModel {
   _id: string;
-  type: string;
+  type: AllTypes;
   // TSCONVERSION -- parentId is always required for all models, except 4:
   //   - Stats, Settings, and Project, which never have a parentId
   //   - Workspace optionally has a parentId (which will be the id of a Project)
@@ -157,13 +157,54 @@ export function all() {
     cloudCredential,
   ] as const;
 }
-
 export function types() {
   return all().map(model => model.type);
 }
+export type AllTypes =
+  | 'ApiSpec'
+  | 'CaCertificate'
+  | 'ClientCertificate'
+  | 'CloudCredential'
+  | 'CookieJar'
+  | 'Environment'
+  | 'GitCredentials'
+  | 'GitRepository'
+  | 'GrpcRequest'
+  | 'GrpcRequestMeta'
+  | 'MockRoute'
+  | 'MockServer'
+  | 'OAuth2Token'
+  | 'PluginData'
+  | 'Project'
+  | 'ProtoDirectory'
+  | 'ProtoFile'
+  | 'Request'
+  | 'RequestGroup'
+  | 'RequestGroupMeta'
+  | 'RequestMeta'
+  | 'RequestVersion'
+  | 'Response'
+  | 'RunnerTestResult'
+  | 'Settings'
+  | 'SocketIOPayload'
+  | 'SocketIORequest'
+  | 'SocketIOResponse'
+  | 'Stats'
+  | 'UnitTest'
+  | 'UnitTestResult'
+  | 'UnitTestSuite'
+  | 'UserSession'
+  | 'WebSocketPayload'
+  | 'WebSocketRequest'
+  | 'WebSocketResponse'
+  | 'Workspace'
+  | 'WorkspaceMeta';
 
 export type ModelTypes = ReturnType<typeof types>;
 
+export const isValidType = (type: string): type is AllTypes => {
+  return types().includes(type as AllTypes);
+};
 export function canSync(d: BaseModel) {
   if (d.isPrivate) {
     return false;
@@ -265,7 +306,7 @@ export const MODELS_BY_EXPORT_TYPE: Record<string, ReturnType<typeof all>[number
 export const EXPORTABLE_TYPES = Object.values(MODELS_BY_EXPORT_TYPE).map(m => m.type);
 
 // Use function instead of object to avoid issues with circular dependencies
-export const getAllDescendantMap = (): Record<string, string[]> => {
+export const getAllDescendantMap = (): Partial<Record<AllTypes, AllTypes[]>> => {
   return {
     [workspace.type]: [
       requestGroup.type,
@@ -307,28 +348,28 @@ export const getAllDescendantMap = (): Record<string, string[]> => {
   };
 };
 
-let childToParentMap: Record<string, string[]> | undefined = undefined;
+let childToParentMap: Partial<Record<AllTypes, AllTypes[]>> | undefined = undefined;
 
 const getChildToParentMap = () => {
   if (childToParentMap) {
     return childToParentMap;
   }
-  const childToParents: Record<string, string[]> = {};
+  const childToParents: Partial<Record<AllTypes, AllTypes[]>> = {};
   for (const [parent, children] of Object.entries(getAllDescendantMap())) {
     for (const child of children) {
       if (!childToParents[child]) childToParents[child] = [];
-      childToParents[child].push(parent);
+      childToParents[child].push(parent as AllTypes);
     }
   }
   childToParentMap = childToParents;
   return childToParents;
 };
 
-export const generateDescendantMap = (queryTypes: ModelTypes): Record<string, string[]> => {
-  const result: Record<string, string[]> = {};
+export const generateDescendantMap = (queryTypes: ModelTypes): Partial<Record<AllTypes, AllTypes[]>> => {
+  const result: Partial<Record<AllTypes, AllTypes[]>> = {};
 
   const visited = new Set<string>();
-  const collectAncestors = (child: string) => {
+  const collectAncestors = (child: AllTypes) => {
     if (!child || visited.has(child)) {
       return;
     }

--- a/packages/insomnia/src/models/index.ts
+++ b/packages/insomnia/src/models/index.ts
@@ -283,27 +283,27 @@ export async function initModel<T extends BaseModel>(type: string, ...sources: R
   return migratedDoc as T;
 }
 
-export const MODELS_BY_EXPORT_TYPE: Record<string, ReturnType<typeof all>[number]> = {
-  [EXPORT_TYPE_REQUEST]: request,
-  [EXPORT_TYPE_WEBSOCKET_PAYLOAD]: webSocketPayload,
-  [EXPORT_TYPE_WEBSOCKET_REQUEST]: webSocketRequest,
-  [EXPORT_TYPE_SOCKETIO_PAYLOAD]: socketIOPayload,
-  [EXPORT_TYPE_SOCKETIO_REQUEST]: socketIORequest,
-  [EXPORT_TYPE_MOCK_SERVER]: mockServer,
-  [EXPORT_TYPE_MOCK_ROUTE]: mockRoute,
-  [EXPORT_TYPE_GRPC_REQUEST]: grpcRequest,
-  [EXPORT_TYPE_REQUEST_GROUP]: requestGroup,
-  [EXPORT_TYPE_UNIT_TEST_SUITE]: unitTestSuite,
-  [EXPORT_TYPE_UNIT_TEST]: unitTest,
-  [EXPORT_TYPE_WORKSPACE]: workspace,
-  [EXPORT_TYPE_COOKIE_JAR]: cookieJar,
-  [EXPORT_TYPE_ENVIRONMENT]: environment,
-  [EXPORT_TYPE_API_SPEC]: apiSpec,
-  [EXPORT_TYPE_PROTO_FILE]: protoFile,
-  [EXPORT_TYPE_PROTO_DIRECTORY]: protoDirectory,
+export const MODELS_BY_EXPORT_TYPE: Record<string, AllTypes> = {
+  [EXPORT_TYPE_REQUEST]: 'Request',
+  [EXPORT_TYPE_WEBSOCKET_PAYLOAD]: 'WebSocketPayload',
+  [EXPORT_TYPE_WEBSOCKET_REQUEST]: 'WebSocketRequest',
+  [EXPORT_TYPE_SOCKETIO_PAYLOAD]: 'SocketIOPayload',
+  [EXPORT_TYPE_SOCKETIO_REQUEST]: 'SocketIORequest',
+  [EXPORT_TYPE_MOCK_SERVER]: 'MockServer',
+  [EXPORT_TYPE_MOCK_ROUTE]: 'MockRoute',
+  [EXPORT_TYPE_GRPC_REQUEST]: 'GrpcRequest',
+  [EXPORT_TYPE_REQUEST_GROUP]: 'RequestGroup',
+  [EXPORT_TYPE_UNIT_TEST_SUITE]: 'UnitTestSuite',
+  [EXPORT_TYPE_UNIT_TEST]: 'UnitTest',
+  [EXPORT_TYPE_WORKSPACE]: 'Workspace',
+  [EXPORT_TYPE_COOKIE_JAR]: 'CookieJar',
+  [EXPORT_TYPE_ENVIRONMENT]: 'Environment',
+  [EXPORT_TYPE_API_SPEC]: 'ApiSpec',
+  [EXPORT_TYPE_PROTO_FILE]: 'ProtoFile',
+  [EXPORT_TYPE_PROTO_DIRECTORY]: 'ProtoDirectory',
 };
 
-export const EXPORTABLE_TYPES = Object.values(MODELS_BY_EXPORT_TYPE).map(m => m.type);
+export const EXPORTABLE_TYPES = Object.values(MODELS_BY_EXPORT_TYPE);
 
 // Use function instead of object to avoid issues with circular dependencies
 export const getAllDescendantMap = (): Partial<Record<AllTypes, AllTypes[]>> => {

--- a/packages/insomnia/src/models/mock-route.ts
+++ b/packages/insomnia/src/models/mock-route.ts
@@ -57,7 +57,7 @@ export function update(mockRoute: MockRoute, patch: Partial<MockRoute> = {}) {
 }
 
 export function getById(id: string) {
-  return db.get<MockRoute>(type, id);
+  return db.findOne<MockRoute>(type, { _id: id });
 }
 
 export function findByParentId(parentId: string) {

--- a/packages/insomnia/src/models/mock-route.ts
+++ b/packages/insomnia/src/models/mock-route.ts
@@ -73,5 +73,5 @@ export function remove(mockRoute: MockRoute) {
 }
 
 export function all() {
-  return db.all<MockRoute>(type);
+  return db.find<MockRoute>(type);
 }

--- a/packages/insomnia/src/models/mock-server.ts
+++ b/packages/insomnia/src/models/mock-server.ts
@@ -79,5 +79,5 @@ export function remove(mockServer: MockServer) {
 }
 
 export function all() {
-  return db.all<MockServer>(type);
+  return db.find<MockServer>(type);
 }

--- a/packages/insomnia/src/models/mock-server.ts
+++ b/packages/insomnia/src/models/mock-server.ts
@@ -43,7 +43,7 @@ export function create(patch: Partial<MockServer> = {}) {
   return db.docCreate<MockServer>(type, patch);
 }
 export async function getOrCreateForParentId(workspaceId: string, patch: Partial<MockServer> = {}) {
-  const mockServer = await db.getWhere<MockServer>(type, {
+  const mockServer = await db.findOne<MockServer>(type, {
     parentId: workspaceId,
   });
 
@@ -58,11 +58,11 @@ export function update(mockServer: MockServer, patch: Partial<MockServer> = {}) 
 }
 
 export function getById(id: string) {
-  return db.get<MockServer>(type, id);
+  return db.findOne<MockServer>(type, { _id: id });
 }
 
 export function getByParentId(parentId: string) {
-  return db.getWhere<MockServer>(type, { parentId });
+  return db.findOne<MockServer>(type, { parentId });
 }
 
 export async function findByProjectId(projectId: string) {

--- a/packages/insomnia/src/models/o-auth-2-token.ts
+++ b/packages/insomnia/src/models/o-auth-2-token.ts
@@ -68,11 +68,11 @@ export function remove(token: OAuth2Token) {
 }
 
 export function getByParentId(parentId: string) {
-  return db.getWhere<OAuth2Token>(type, { parentId });
+  return db.findOne<OAuth2Token>(type, { parentId });
 }
 
 export async function getOrCreateByParentId(parentId: string) {
-  let token = await db.getWhere<OAuth2Token>(type, {
+  let token = await db.findOne<OAuth2Token>(type, {
     parentId,
   });
 

--- a/packages/insomnia/src/models/o-auth-2-token.ts
+++ b/packages/insomnia/src/models/o-auth-2-token.ts
@@ -86,5 +86,5 @@ export async function getOrCreateByParentId(parentId: string) {
 }
 
 export function all() {
-  return db.all<OAuth2Token>(type);
+  return db.find<OAuth2Token>(type);
 }

--- a/packages/insomnia/src/models/plugin-data.ts
+++ b/packages/insomnia/src/models/plugin-data.ts
@@ -67,5 +67,5 @@ export async function removeAll(plugin: string) {
 }
 
 export async function getByKey(plugin: string, key: string) {
-  return db.getWhere<PluginData>(type, { plugin, key });
+  return db.findOne<PluginData>(type, { plugin, key });
 }

--- a/packages/insomnia/src/models/project.ts
+++ b/packages/insomnia/src/models/project.ts
@@ -90,7 +90,7 @@ export function update(project: Project, patch: Partial<Project>) {
 }
 
 export async function all() {
-  const projects = await db.all<Project>(type);
+  const projects = await db.find<Project>(type);
   return projects;
 }
 

--- a/packages/insomnia/src/models/project.ts
+++ b/packages/insomnia/src/models/project.ts
@@ -74,11 +74,11 @@ export function create(patch: Partial<Project> = {}) {
 }
 
 export function getById(_id: string) {
-  return db.getWhere<Project>(type, { _id });
+  return db.findOne<Project>(type, { _id });
 }
 
 export function getByRemoteId(remoteId: string) {
-  return db.getWhere<Project>(type, { remoteId });
+  return db.findOne<Project>(type, { remoteId });
 }
 
 export function remove(project: Project) {

--- a/packages/insomnia/src/models/proto-directory.ts
+++ b/packages/insomnia/src/models/proto-directory.ts
@@ -58,18 +58,6 @@ export function remove(obj: ProtoDirectory) {
   return db.remove(obj);
 }
 
-export async function batchRemoveIds(ids: string[]) {
-  const dirs = await db.find(type, {
-    _id: {
-      $in: ids,
-    },
-  });
-  await db.batchModifyDocs({
-    upsert: [],
-    remove: dirs,
-  });
-}
-
 export function all() {
   return db.find<ProtoDirectory>(type);
 }

--- a/packages/insomnia/src/models/proto-directory.ts
+++ b/packages/insomnia/src/models/proto-directory.ts
@@ -71,5 +71,5 @@ export async function batchRemoveIds(ids: string[]) {
 }
 
 export function all() {
-  return db.all<ProtoDirectory>(type);
+  return db.find<ProtoDirectory>(type);
 }

--- a/packages/insomnia/src/models/proto-directory.ts
+++ b/packages/insomnia/src/models/proto-directory.ts
@@ -43,11 +43,11 @@ export function create(patch: Partial<ProtoDirectory> = {}) {
 }
 
 export function getById(_id: string) {
-  return db.getWhere<ProtoDirectory>(type, { _id });
+  return db.findOne<ProtoDirectory>(type, { _id });
 }
 
 export function getByParentId(parentId: string) {
-  return db.getWhere<ProtoDirectory>(type, { parentId });
+  return db.findOne<ProtoDirectory>(type, { parentId });
 }
 
 export function findByParentId(parentId: string) {

--- a/packages/insomnia/src/models/proto-file.ts
+++ b/packages/insomnia/src/models/proto-file.ts
@@ -72,5 +72,5 @@ export function findByParentId(parentId: string) {
 }
 
 export function all() {
-  return db.all<ProtoFile>(type);
+  return db.find<ProtoFile>(type);
 }

--- a/packages/insomnia/src/models/proto-file.ts
+++ b/packages/insomnia/src/models/proto-file.ts
@@ -60,11 +60,11 @@ export function update(protoFile: ProtoFile, patch: Partial<ProtoFile> = {}) {
 }
 
 export function getById(_id: string) {
-  return db.getWhere<ProtoFile>(type, { _id });
+  return db.findOne<ProtoFile>(type, { _id });
 }
 
 export function getByParentId(parentId: string) {
-  return db.getWhere<ProtoFile>(type, { parentId });
+  return db.findOne<ProtoFile>(type, { parentId });
 }
 
 export function findByParentId(parentId: string) {

--- a/packages/insomnia/src/models/proto-file.ts
+++ b/packages/insomnia/src/models/proto-file.ts
@@ -43,18 +43,6 @@ export function remove(protoFile: ProtoFile) {
   return db.remove(protoFile);
 }
 
-export async function batchRemoveIds(ids: string[]) {
-  const files = await db.find(type, {
-    _id: {
-      $in: ids,
-    },
-  });
-  await db.batchModifyDocs({
-    upsert: [],
-    remove: files,
-  });
-}
-
 export function update(protoFile: ProtoFile, patch: Partial<ProtoFile> = {}) {
   return db.docUpdate<ProtoFile>(protoFile, patch);
 }

--- a/packages/insomnia/src/models/request-group-meta.ts
+++ b/packages/insomnia/src/models/request-group-meta.ts
@@ -47,5 +47,5 @@ export function getByParentId(parentId: string) {
 }
 
 export function all() {
-  return db.all<RequestGroupMeta>(type);
+  return db.find<RequestGroupMeta>(type);
 }

--- a/packages/insomnia/src/models/request-group-meta.ts
+++ b/packages/insomnia/src/models/request-group-meta.ts
@@ -43,7 +43,7 @@ export function update(requestGroupMeta: RequestGroupMeta, patch: Partial<Reques
 }
 
 export function getByParentId(parentId: string) {
-  return db.getWhere<RequestGroupMeta>(type, { parentId });
+  return db.findOne<RequestGroupMeta>(type, { parentId });
 }
 
 export function all() {

--- a/packages/insomnia/src/models/request-group.ts
+++ b/packages/insomnia/src/models/request-group.ts
@@ -63,7 +63,7 @@ export function update(requestGroup: RequestGroup, patch: Partial<RequestGroup> 
 }
 
 export function getById(id: string) {
-  return db.get<RequestGroup>(type, id);
+  return db.findOne<RequestGroup>(type, { _id: id });
 }
 
 export function findByParentId(parentId: string) {

--- a/packages/insomnia/src/models/request-group.ts
+++ b/packages/insomnia/src/models/request-group.ts
@@ -75,7 +75,7 @@ export function remove(requestGroup: RequestGroup) {
 }
 
 export function all() {
-  return db.all<RequestGroup>(type);
+  return db.find<RequestGroup>(type);
 }
 
 export async function duplicate(requestGroup: RequestGroup, patch: Partial<RequestGroup> = {}) {

--- a/packages/insomnia/src/models/request-meta.ts
+++ b/packages/insomnia/src/models/request-meta.ts
@@ -58,7 +58,7 @@ export function update(requestMeta: RequestMeta, patch: Partial<RequestMeta>) {
   return db.docUpdate<RequestMeta>(requestMeta, patch);
 }
 
-export function getByParentId(parentId: string): Promise<RequestMeta | null> {
+export function getByParentId(parentId: string): Promise<RequestMeta | undefined> {
   return db.findOne<RequestMeta>(type, { parentId });
 }
 

--- a/packages/insomnia/src/models/request-meta.ts
+++ b/packages/insomnia/src/models/request-meta.ts
@@ -51,18 +51,15 @@ export function create(patch: Partial<RequestMeta> = {}) {
     throw new Error('New RequestMeta missing `parentId` ' + JSON.stringify(patch));
   }
 
-  // expectParentToBeRequest(patch.parentId);
   return db.docCreate<RequestMeta>(type, patch);
 }
 
 export function update(requestMeta: RequestMeta, patch: Partial<RequestMeta>) {
-  // expectParentToBeRequest(patch.parentId || requestMeta.parentId);
   return db.docUpdate<RequestMeta>(requestMeta, patch);
 }
 
 export function getByParentId(parentId: string): Promise<RequestMeta | null> {
-  // expectParentToBeRequest(parentId);
-  return db.getWhere<RequestMeta>(type, { parentId });
+  return db.findOne<RequestMeta>(type, { parentId });
 }
 
 export async function getOrCreateByParentId(parentId: string) {

--- a/packages/insomnia/src/models/request-meta.ts
+++ b/packages/insomnia/src/models/request-meta.ts
@@ -91,5 +91,5 @@ export async function updateOrCreateByParentId(parentId: string, patch: Partial<
 }
 
 export function all() {
-  return db.all<RequestMeta>(type);
+  return db.find<RequestMeta>(type);
 }

--- a/packages/insomnia/src/models/request-version.ts
+++ b/packages/insomnia/src/models/request-version.ts
@@ -136,5 +136,5 @@ function _diffRequests(
 }
 
 export function all() {
-  return db.all<RequestVersion>(type);
+  return db.find<RequestVersion>(type);
 }

--- a/packages/insomnia/src/models/request-version.ts
+++ b/packages/insomnia/src/models/request-version.ts
@@ -62,10 +62,13 @@ export async function create(request: Request | WebSocketRequest | GrpcRequest |
   }
 
   const parentId = request._id;
-  const versions = await database.findMostRecentlyModified<RequestVersion>('RequestVersion', {
-    parentId,
-  });
-  const latestRequestVersion = versions.length ? versions[0] : null;
+  const latestRequestVersion = await database.findOne<RequestVersion>(
+    'RequestVersion',
+    {
+      parentId,
+    },
+    { modified: -1 },
+  );
   const latestRequest = latestRequestVersion
     ? decompressObject<Request | WebSocketRequest | SocketIORequest>(latestRequestVersion.compressedRequest)
     : null;

--- a/packages/insomnia/src/models/request-version.ts
+++ b/packages/insomnia/src/models/request-version.ts
@@ -49,7 +49,7 @@ export function migrate(doc: RequestVersion) {
 }
 
 export function getById(id: string) {
-  return db.get<RequestVersion>(type, id);
+  return db.findOne<RequestVersion>(type, { _id: id });
 }
 
 export function findByParentId(parentId: string) {

--- a/packages/insomnia/src/models/request-version.ts
+++ b/packages/insomnia/src/models/request-version.ts
@@ -1,6 +1,6 @@
 import deepEqual from 'deep-equal';
 
-import { database as db } from '../common/database';
+import { database, database as db } from '../common/database';
 import { compressObject, decompressObject } from '../common/misc';
 import * as requestOperations from '../models/helpers/request-operations';
 import type { GrpcRequest } from './grpc-request';
@@ -62,7 +62,10 @@ export async function create(request: Request | WebSocketRequest | GrpcRequest |
   }
 
   const parentId = request._id;
-  const latestRequestVersion: RequestVersion | null = await getLatestByParentId(parentId);
+  const versions = await database.findMostRecentlyModified<RequestVersion>('RequestVersion', {
+    parentId,
+  });
+  const latestRequestVersion = versions.length ? versions[0] : null;
   const latestRequest = latestRequestVersion
     ? decompressObject<Request | WebSocketRequest | SocketIORequest>(latestRequestVersion.compressedRequest)
     : null;
@@ -79,10 +82,6 @@ export async function create(request: Request | WebSocketRequest | GrpcRequest |
   }
   // Re-use the latest version if not modified since
   return latestRequestVersion;
-}
-
-export function getLatestByParentId(parentId: string) {
-  return db.getMostRecentlyModified<RequestVersion>(type, { parentId });
 }
 
 export async function restore(requestVersionId: string) {

--- a/packages/insomnia/src/models/request.ts
+++ b/packages/insomnia/src/models/request.ts
@@ -335,7 +335,7 @@ export function create(patch: Partial<Request> = {}) {
   return db.docCreate<Request>(type, patch);
 }
 
-export function getById(id: string): Promise<Request | null> {
+export function getById(id: string): Promise<Request | undefined> {
   return db.findOne<Request>(type, { _id: id });
 }
 

--- a/packages/insomnia/src/models/request.ts
+++ b/packages/insomnia/src/models/request.ts
@@ -387,7 +387,7 @@ export function remove(request: Request) {
 }
 
 export async function all() {
-  return db.all<Request>(type);
+  return db.find<Request>(type);
 }
 
 // ~~~~~~~~~~ //

--- a/packages/insomnia/src/models/request.ts
+++ b/packages/insomnia/src/models/request.ts
@@ -336,11 +336,11 @@ export function create(patch: Partial<Request> = {}) {
 }
 
 export function getById(id: string): Promise<Request | null> {
-  return db.get(type, id);
+  return db.findOne<Request>(type, { _id: id });
 }
 
 export function getByParentId(parentId: string) {
-  return db.getWhere<Request>(type, { parentId: parentId });
+  return db.findOne<Request>(type, { parentId: parentId });
 }
 
 export function findByParentId(parentId: string) {

--- a/packages/insomnia/src/models/response.ts
+++ b/packages/insomnia/src/models/response.ts
@@ -3,7 +3,7 @@ import type { Readable } from 'node:stream';
 import zlib from 'node:zlib';
 
 import type { RequestTestResult } from '../../../insomnia-scripting-environment/src/objects';
-import { database as db, type Query } from '../common/database';
+import { database as db } from '../common/database';
 import type { ResponseTimelineEntry } from '../main/network/libcurl-promise';
 import * as requestOperations from '../models/helpers/request-operations';
 import { deserializeNDJSON } from '../utils/ndjson';
@@ -137,22 +137,21 @@ export function remove(response: Response) {
   return db.remove(response);
 }
 
-async function _findRecentForRequest(requestId: string, environmentId: string | null, limit: number) {
-  const query: Query<Response> = {
-    parentId: requestId,
-  };
-
+export async function getLatestForRequestId(
+  requestId: string,
+  environmentId: string | null,
+): Promise<Response | undefined> {
   // Filter responses by environment if setting is enabled
-  const settings = await models.settings.get();
-  if (environmentId && settings?.filterResponsesByEnv) {
-    query.environmentId = environmentId;
-  }
+  const shouldFilter = (await models.settings.get()).filterResponsesByEnv;
 
-  return db.findMostRecentlyModified<Response>(type, query, limit);
-}
-
-export async function getLatestForRequest(requestId: string, environmentId: string | null) {
-  const responses = await _findRecentForRequest(requestId, environmentId, 1);
+  const responses = await db.findMostRecentlyModified<Response>(
+    type,
+    {
+      parentId: requestId,
+      ...(shouldFilter ? { environmentId } : {}),
+    },
+    1,
+  );
   return responses[0];
 }
 

--- a/packages/insomnia/src/models/response.ts
+++ b/packages/insomnia/src/models/response.ts
@@ -144,15 +144,15 @@ export async function getLatestForRequestId(
   // Filter responses by environment if setting is enabled
   const shouldFilter = (await models.settings.get()).filterResponsesByEnv;
 
-  const responses = await db.findMostRecentlyModified<Response>(
+  const response = await db.findOne<Response>(
     type,
     {
       parentId: requestId,
       ...(shouldFilter ? { environmentId } : {}),
     },
-    1,
+    { modified: -1 },
   );
-  return responses[0];
+  return response;
 }
 
 export async function create(patch: Partial<Response> = {}, maxResponses = 20): Promise<Response> {
@@ -175,7 +175,10 @@ export async function create(patch: Partial<Response> = {}, maxResponses = 20): 
   };
 
   // Delete all other responses before creating the new one
-  const allResponses = await db.findMostRecentlyModified<Response>(type, query, Math.max(1, maxResponses));
+  const responsesToShow = Math.max(1, maxResponses);
+
+  const allResponses = await db.find<Response>(type, query, { modified: -1 }, responsesToShow);
+
   const recentIds = allResponses.map(r => r._id);
   // Remove all that were in the last query, except the first `maxResponses` IDs
   await db.removeWhere(type, {

--- a/packages/insomnia/src/models/response.ts
+++ b/packages/insomnia/src/models/response.ts
@@ -153,8 +153,7 @@ async function _findRecentForRequest(requestId: string, environmentId: string | 
 
 export async function getLatestForRequest(requestId: string, environmentId: string | null) {
   const responses = await _findRecentForRequest(requestId, environmentId, 1);
-  const response = responses[0] as Response | null | undefined;
-  return response || null;
+  return responses[0];
 }
 
 export async function create(patch: Partial<Response> = {}, maxResponses = 20): Promise<Response> {

--- a/packages/insomnia/src/models/response.ts
+++ b/packages/insomnia/src/models/response.ts
@@ -97,20 +97,6 @@ export function migrate(doc: Response) {
     throw e;
   }
 }
-
-export function hookDatabaseInit(consoleLog: typeof console.log = console.log) {
-  consoleLog('[db] Init responses DB');
-}
-
-export function hookRemove(doc: Response, consoleLog: typeof console.log = console.log) {
-  fs.unlink(doc.bodyPath, () => {
-    consoleLog(`[response] Delete body ${doc.bodyPath}`);
-  });
-  fs.unlink(doc.timelinePath, () => {
-    consoleLog(`[response] Delete timeline ${doc.timelinePath}`);
-  });
-}
-
 export function getById(id: string) {
   return db.get<Response>(type, id);
 }
@@ -135,13 +121,19 @@ export async function removeForRequest(parentId: string, environmentId?: string 
   if (environmentId !== undefined && settings.filterResponsesByEnv) {
     query.environmentId = environmentId;
   }
-
+  const toDelete = await db.find<Response>(type, query);
+  for (const doc of toDelete) {
+    fs.promises.unlink(doc.bodyPath);
+    fs.promises.unlink(doc.timelinePath);
+  }
   // Also delete legacy responses here or else the user will be confused as to
   // why some responses are still showing in the UI.
   await db.removeWhere(type, query);
 }
 
 export function remove(response: Response) {
+  fs.promises.unlink(response.bodyPath);
+  fs.promises.unlink(response.timelinePath);
   return db.remove(response);
 }
 

--- a/packages/insomnia/src/models/response.ts
+++ b/packages/insomnia/src/models/response.ts
@@ -98,7 +98,7 @@ export function migrate(doc: Response) {
   }
 }
 export function getById(id: string) {
-  return db.get<Response>(type, id);
+  return db.findOne<Response>(type, { _id: id });
 }
 
 export function findByParentId(parentId: string) {

--- a/packages/insomnia/src/models/response.ts
+++ b/packages/insomnia/src/models/response.ts
@@ -190,12 +190,6 @@ export async function create(patch: Partial<Response> = {}, maxResponses = 20): 
   return db.docCreate(type, patch);
 }
 
-export function getLatestByParentId(parentId: string) {
-  return db.getMostRecentlyModified<Response>(type, {
-    parentId,
-  });
-}
-
 export const getBodyStream = (
   response?: { bodyPath?: string; bodyCompression?: Compression },
   readFailureValue?: string,

--- a/packages/insomnia/src/models/response.ts
+++ b/packages/insomnia/src/models/response.ts
@@ -106,7 +106,7 @@ export function findByParentId(parentId: string) {
 }
 
 export async function all() {
-  return db.all<Response>(type);
+  return db.find<Response>(type);
 }
 
 export async function removeForRequest(parentId: string, environmentId?: string | null) {

--- a/packages/insomnia/src/models/runner-test-result.ts
+++ b/packages/insomnia/src/models/runner-test-result.ts
@@ -73,10 +73,6 @@ export function getByParentId(parentId: string) {
   return db.findOne<RunnerTestResult>(type, { parentId });
 }
 
-export function getLatestByParentId(parentId: string) {
-  return db.getMostRecentlyModified<RunnerTestResult>(type, { parentId });
-}
-
 export function getById(_id: string) {
   return db.findOne<RunnerTestResult>(type, {
     _id,

--- a/packages/insomnia/src/models/runner-test-result.ts
+++ b/packages/insomnia/src/models/runner-test-result.ts
@@ -70,7 +70,7 @@ export function update(testResult: RunnerTestResult, patch: Partial<RunnerTestRe
 }
 
 export function getByParentId(parentId: string) {
-  return db.getWhere<RunnerTestResult>(type, { parentId });
+  return db.findOne<RunnerTestResult>(type, { parentId });
 }
 
 export function getLatestByParentId(parentId: string) {
@@ -78,7 +78,7 @@ export function getLatestByParentId(parentId: string) {
 }
 
 export function getById(_id: string) {
-  return db.getWhere<RunnerTestResult>(type, {
+  return db.findOne<RunnerTestResult>(type, {
     _id,
   });
 }

--- a/packages/insomnia/src/models/runner-test-result.ts
+++ b/packages/insomnia/src/models/runner-test-result.ts
@@ -84,7 +84,7 @@ export function getById(_id: string) {
 }
 
 export function all() {
-  return db.all<RunnerTestResult>(type);
+  return db.find<RunnerTestResult>(type);
 }
 
 export function remove(item: RunnerTestResult) {

--- a/packages/insomnia/src/models/settings.ts
+++ b/packages/insomnia/src/models/settings.ts
@@ -116,18 +116,16 @@ export async function patch(settingsPatch: Partial<Settings>) {
 }
 
 export async function getOrCreate() {
-  const results = (await db.find<Settings>(type)) || [];
+  const result = await db.findOne<Settings>(type);
 
-  if (results.length === 0) {
+  if (!result) {
     return await create();
   }
-  return results[0];
+  return result;
 }
 
 export async function get() {
-  const results = (await db.find<Settings>(type)) || [];
-
-  return results[0];
+  return getOrCreate();
 }
 
 /**

--- a/packages/insomnia/src/models/settings.ts
+++ b/packages/insomnia/src/models/settings.ts
@@ -90,7 +90,7 @@ export function migrate(doc: Settings) {
 }
 
 export async function all() {
-  let settingsList = await db.all<Settings>(type);
+  let settingsList = await db.find<Settings>(type);
 
   if (settingsList?.length === 0) {
     settingsList = [await getOrCreate()];
@@ -116,7 +116,7 @@ export async function patch(settingsPatch: Partial<Settings>) {
 }
 
 export async function getOrCreate() {
-  const results = (await db.all<Settings>(type)) || [];
+  const results = (await db.find<Settings>(type)) || [];
 
   if (results.length === 0) {
     return await create();
@@ -125,7 +125,7 @@ export async function getOrCreate() {
 }
 
 export async function get() {
-  const results = (await db.all<Settings>(type)) || [];
+  const results = (await db.find<Settings>(type)) || [];
 
   return results[0];
 }

--- a/packages/insomnia/src/models/socket-io-payload.ts
+++ b/packages/insomnia/src/models/socket-io-payload.ts
@@ -69,8 +69,8 @@ export async function duplicate(request: SocketIOPayload, patch: Partial<SocketI
   });
 }
 
-export const getById = (_id: string) => database.getWhere<SocketIOPayload>(type, { _id });
-export const getByParentId = (parentId: string) => database.getWhere<SocketIOPayload>(type, { parentId });
+export const getById = (_id: string) => database.findOne<SocketIOPayload>(type, { _id });
+export const getByParentId = (parentId: string) => database.findOne<SocketIOPayload>(type, { parentId });
 
 export async function updateOrCreateByParentId(parentId: string, patch: Partial<SocketIOPayload>) {
   const requestPayload = await getByParentId(parentId);
@@ -92,4 +92,4 @@ export async function getOrCreateByParentId(parentId: string) {
   return doc || create({ parentId });
 }
 
-export const all = () => database.all<SocketIOPayload>(type);
+export const all = () => database.find<SocketIOPayload>(type);

--- a/packages/insomnia/src/models/socket-io-request.ts
+++ b/packages/insomnia/src/models/socket-io-request.ts
@@ -63,7 +63,7 @@ export const create = (patch: Partial<SocketIORequest> = {}) => {
   return database.docCreate<SocketIORequest>(type, patch);
 };
 
-export const getById = (_id: string) => database.getWhere<SocketIORequest>(type, { _id });
+export const getById = (_id: string) => database.findOne<SocketIORequest>(type, { _id });
 
 export const migrate = (doc: SocketIORequest) => doc;
 

--- a/packages/insomnia/src/models/socket-io-response.ts
+++ b/packages/insomnia/src/models/socket-io-response.ts
@@ -60,7 +60,7 @@ export function findByParentId(parentId: string) {
 }
 
 export async function all() {
-  return db.all<SocketIOResponse>(type);
+  return db.find<SocketIOResponse>(type);
 }
 
 export async function removeForRequest(parentId: string, environmentId?: string | null) {

--- a/packages/insomnia/src/models/socket-io-response.ts
+++ b/packages/insomnia/src/models/socket-io-response.ts
@@ -51,20 +51,6 @@ export function update(doc: SocketIOResponse, patch: Partial<SocketIOResponse>) 
   return db.docUpdate(doc, patch);
 }
 
-export function hookDatabaseInit(consoleLog: typeof console.log = console.log) {
-  consoleLog('[db] Init SocketIO-responses DB');
-}
-
-export function hookRemove(doc: SocketIOResponse, consoleLog: typeof console.log = console.log) {
-  fs.unlink(doc.eventLogPath, () => {
-    consoleLog(`[response] Delete body ${doc.eventLogPath}`);
-  });
-
-  fs.unlink(doc.timelinePath, () => {
-    consoleLog(`[response] Delete timeline ${doc.timelinePath}`);
-  });
-}
-
 export function getById(id: string) {
   return db.get<SocketIOResponse>(type, id);
 }
@@ -89,13 +75,19 @@ export async function removeForRequest(parentId: string, environmentId?: string 
   if (environmentId !== undefined && settings.filterResponsesByEnv) {
     query.environmentId = environmentId;
   }
-
+  const toDelete = await db.find<SocketIOResponse>(type, query);
+  for (const doc of toDelete) {
+    fs.promises.unlink(doc.eventLogPath);
+    fs.promises.unlink(doc.timelinePath);
+  }
   // Also delete legacy responses here or else the user will be confused as to
   // why some responses are still showing in the UI.
   await db.removeWhere(type, query);
 }
 
 export function remove(response: SocketIOResponse) {
+  fs.promises.unlink(response.eventLogPath);
+  fs.promises.unlink(response.timelinePath);
   return db.remove(response);
 }
 

--- a/packages/insomnia/src/models/socket-io-response.ts
+++ b/packages/insomnia/src/models/socket-io-response.ts
@@ -142,9 +142,3 @@ export async function getLatestForRequest(requestId: string, environmentId: stri
   const response = responses[0] as SocketIOResponse | null | undefined;
   return response || null;
 }
-
-export function getLatestByParentId(parentId: string) {
-  return db.getMostRecentlyModified<SocketIOResponse>(type, {
-    parentId,
-  });
-}

--- a/packages/insomnia/src/models/socket-io-response.ts
+++ b/packages/insomnia/src/models/socket-io-response.ts
@@ -111,7 +111,7 @@ export async function create(patch: Partial<SocketIOResponse> = {}, maxResponses
   }
 
   // Delete all other responses before creating the new one
-  const allResponses = await db.findMostRecentlyModified<SocketIOResponse>(type, query, Math.max(1, maxResponses));
+  const allResponses = await db.find<SocketIOResponse>(type, query, { modified: -1 }, Math.max(1, maxResponses));
   const recentIds = allResponses.map(r => r._id);
   // Remove all that were in the last query, except the first `maxResponses` IDs
   await db.removeWhere(type, {
@@ -129,14 +129,13 @@ export async function getLatestForRequestId(requestId: string, environmentId: st
 
   const shouldFilter = (await models.settings.get()).filterResponsesByEnv;
 
-  const responses = await db.findMostRecentlyModified<SocketIOResponse>(
+  const response = await db.findOne<SocketIOResponse>(
     type,
     {
       parentId: requestId,
       ...(shouldFilter ? { environmentId } : {}),
     },
-    1,
+    { modified: -1 },
   );
-  const response = responses[0] as SocketIOResponse | null | undefined;
-  return response || null;
+  return response;
 }

--- a/packages/insomnia/src/models/socket-io-response.ts
+++ b/packages/insomnia/src/models/socket-io-response.ts
@@ -52,7 +52,7 @@ export function update(doc: SocketIOResponse, patch: Partial<SocketIOResponse>) 
 }
 
 export function getById(id: string) {
-  return db.get<SocketIOResponse>(type, id);
+  return db.findOne<SocketIOResponse>(type, { _id: id });
 }
 
 export function findByParentId(parentId: string) {

--- a/packages/insomnia/src/models/socket-io-response.ts
+++ b/packages/insomnia/src/models/socket-io-response.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 
-import { database as db, type Query } from '../common/database';
+import { database as db } from '../common/database';
 import * as requestOperations from './helpers/request-operations';
 import type { BaseModel } from './index';
 import * as models from './index';
@@ -124,21 +124,19 @@ export async function create(patch: Partial<SocketIOResponse> = {}, maxResponses
   return db.docCreate(type, patch);
 }
 
-async function _findRecentForRequest(requestId: string, environmentId: string | null, limit: number) {
-  const query: Query<SocketIOResponse> = {
-    parentId: requestId,
-  };
-
+export async function getLatestForRequestId(requestId: string, environmentId: string | null) {
   // Filter responses by environment if setting is enabled
-  if ((await models.settings.get()).filterResponsesByEnv) {
-    query.environmentId = environmentId;
-  }
 
-  return db.findMostRecentlyModified<SocketIOResponse>(type, query, limit);
-}
+  const shouldFilter = (await models.settings.get()).filterResponsesByEnv;
 
-export async function getLatestForRequest(requestId: string, environmentId: string | null) {
-  const responses = await _findRecentForRequest(requestId, environmentId, 1);
+  const responses = await db.findMostRecentlyModified<SocketIOResponse>(
+    type,
+    {
+      parentId: requestId,
+      ...(shouldFilter ? { environmentId } : {}),
+    },
+    1,
+  );
   const response = responses[0] as SocketIOResponse | null | undefined;
   return response || null;
 }

--- a/packages/insomnia/src/models/stats.ts
+++ b/packages/insomnia/src/models/stats.ts
@@ -70,7 +70,7 @@ export async function get() {
 }
 
 export function all() {
-  return db.all<Stats>(type) || [];
+  return db.find<Stats>(type) || [];
 }
 
 export async function incrementRequestStats({ createdRequests, deletedRequests, executedRequests }: Partial<Stats>) {

--- a/packages/insomnia/src/models/stats.ts
+++ b/packages/insomnia/src/models/stats.ts
@@ -61,12 +61,12 @@ export async function update(patch: Partial<Stats>) {
 }
 
 export async function get() {
-  const results = (await db.find<Stats>(type)) || [];
+  const result = await db.findOne<Stats>(type);
 
-  if (results.length === 0) {
+  if (!result) {
     return create();
   }
-  return results[0];
+  return result;
 }
 
 export function all() {

--- a/packages/insomnia/src/models/stats.ts
+++ b/packages/insomnia/src/models/stats.ts
@@ -61,7 +61,7 @@ export async function update(patch: Partial<Stats>) {
 }
 
 export async function get() {
-  const results = (await db.all<Stats>(type)) || [];
+  const results = (await db.find<Stats>(type)) || [];
 
   if (results.length === 0) {
     return create();

--- a/packages/insomnia/src/models/unit-test-result.ts
+++ b/packages/insomnia/src/models/unit-test-result.ts
@@ -44,7 +44,7 @@ export function update(unitTest: UnitTestResult, patch: Partial<UnitTestResult>)
 }
 
 export function getByParentId(parentId: string) {
-  return db.getWhere<UnitTestResult>(type, { parentId });
+  return db.findOne<UnitTestResult>(type, { parentId });
 }
 
 export function getLatestByParentId(parentId: string) {
@@ -52,7 +52,7 @@ export function getLatestByParentId(parentId: string) {
 }
 
 export function getById(_id: string) {
-  return db.getWhere<UnitTestResult>(type, {
+  return db.findOne<UnitTestResult>(type, {
     _id,
   });
 }

--- a/packages/insomnia/src/models/unit-test-result.ts
+++ b/packages/insomnia/src/models/unit-test-result.ts
@@ -58,5 +58,5 @@ export function getById(_id: string) {
 }
 
 export function all() {
-  return db.all<UnitTestResult>(type);
+  return db.find<UnitTestResult>(type);
 }

--- a/packages/insomnia/src/models/unit-test-result.ts
+++ b/packages/insomnia/src/models/unit-test-result.ts
@@ -47,10 +47,6 @@ export function getByParentId(parentId: string) {
   return db.findOne<UnitTestResult>(type, { parentId });
 }
 
-export function getLatestByParentId(parentId: string) {
-  return db.getMostRecentlyModified<UnitTestResult>(type, { parentId });
-}
-
 export function getById(_id: string) {
   return db.findOne<UnitTestResult>(type, {
     _id,

--- a/packages/insomnia/src/models/unit-test-suite.ts
+++ b/packages/insomnia/src/models/unit-test-suite.ts
@@ -57,5 +57,5 @@ export function findByParentId(parentId: string) {
 export const getById = (_id: string) => db.getWhere<UnitTestSuite>(type, { _id });
 
 export function all() {
-  return db.all<UnitTestSuite>(type);
+  return db.find<UnitTestSuite>(type);
 }

--- a/packages/insomnia/src/models/unit-test-suite.ts
+++ b/packages/insomnia/src/models/unit-test-suite.ts
@@ -47,14 +47,14 @@ export function remove(unitTestSuite: UnitTestSuite) {
 }
 
 export function getByParentId(parentId: string) {
-  return db.getWhere<UnitTestSuite>(type, { parentId });
+  return db.findOne<UnitTestSuite>(type, { parentId });
 }
 
 export function findByParentId(parentId: string) {
   return db.find<UnitTestSuite>(type, { parentId });
 }
 
-export const getById = (_id: string) => db.getWhere<UnitTestSuite>(type, { _id });
+export const getById = (_id: string) => db.findOne<UnitTestSuite>(type, { _id });
 
 export function all() {
   return db.find<UnitTestSuite>(type);

--- a/packages/insomnia/src/models/unit-test.ts
+++ b/packages/insomnia/src/models/unit-test.ts
@@ -51,7 +51,7 @@ export function update(unitTest: UnitTest, patch: Partial<UnitTest> = {}) {
 }
 
 export function getByParentId(parentId: string) {
-  return db.getWhere<UnitTest>(type, { parentId });
+  return db.findOne<UnitTest>(type, { parentId });
 }
 
 export function all() {

--- a/packages/insomnia/src/models/unit-test.ts
+++ b/packages/insomnia/src/models/unit-test.ts
@@ -55,5 +55,5 @@ export function getByParentId(parentId: string) {
 }
 
 export function all() {
-  return db.all<UnitTest>(type);
+  return db.find<UnitTest>(type);
 }

--- a/packages/insomnia/src/models/user-session.ts
+++ b/packages/insomnia/src/models/user-session.ts
@@ -72,16 +72,14 @@ export async function patch(patch: Partial<UserSession>) {
 }
 
 export async function getOrCreate() {
-  const results = (await db.find<UserSession>(type)) || [];
+  const result = await db.findOne<UserSession>(type);
 
-  if (results.length === 0) {
+  if (!result) {
     return await create();
   }
-  return results[0];
+  return result;
 }
 
 export async function get() {
-  const results = (await db.find<UserSession>(type)) || [];
-
-  return results[0];
+  return getOrCreate();
 }

--- a/packages/insomnia/src/models/user-session.ts
+++ b/packages/insomnia/src/models/user-session.ts
@@ -46,7 +46,7 @@ export function migrate(doc: UserSession) {
 }
 
 export async function all() {
-  let userList = await db.all<UserSession>(type);
+  let userList = await db.find<UserSession>(type);
 
   if (userList?.length === 0) {
     userList = [await getOrCreate()];
@@ -72,7 +72,7 @@ export async function patch(patch: Partial<UserSession>) {
 }
 
 export async function getOrCreate() {
-  const results = (await db.all<UserSession>(type)) || [];
+  const results = (await db.find<UserSession>(type)) || [];
 
   if (results.length === 0) {
     return await create();
@@ -81,7 +81,7 @@ export async function getOrCreate() {
 }
 
 export async function get() {
-  const results = (await db.all<UserSession>(type)) || [];
+  const results = (await db.find<UserSession>(type)) || [];
 
   return results[0];
 }

--- a/packages/insomnia/src/models/websocket-payload.ts
+++ b/packages/insomnia/src/models/websocket-payload.ts
@@ -58,7 +58,7 @@ export async function duplicate(request: WebSocketPayload, patch: Partial<WebSoc
   });
 }
 
-export const getById = (_id: string) => database.getWhere<WebSocketPayload>(type, { _id });
-export const getByParentId = (parentId: string) => database.getWhere<WebSocketPayload>(type, { parentId });
+export const getById = (_id: string) => database.findOne<WebSocketPayload>(type, { _id });
+export const getByParentId = (parentId: string) => database.findOne<WebSocketPayload>(type, { parentId });
 
-export const all = () => database.all<WebSocketPayload>(type);
+export const all = () => database.find<WebSocketPayload>(type);

--- a/packages/insomnia/src/models/websocket-request.ts
+++ b/packages/insomnia/src/models/websocket-request.ts
@@ -97,8 +97,8 @@ export async function duplicate(request: WebSocketRequest, patch: Partial<WebSoc
   });
 }
 
-export const getById = (_id: string) => database.getWhere<WebSocketRequest>(type, { _id });
+export const getById = (_id: string) => database.findOne<WebSocketRequest>(type, { _id });
 
 export const findByParentId = (parentId: string) => database.find<WebSocketRequest>(type, { parentId });
 
-export const all = () => database.all<WebSocketRequest>(type);
+export const all = () => database.find<WebSocketRequest>(type);

--- a/packages/insomnia/src/models/websocket-response.ts
+++ b/packages/insomnia/src/models/websocket-response.ts
@@ -63,7 +63,7 @@ export function migrate(doc: WebSocketResponse) {
 }
 
 export function getById(id: string) {
-  return db.get<WebSocketResponse>(type, id);
+  return db.findOne<WebSocketResponse>(type, { _id: id });
 }
 
 export function findByParentId(parentId: string) {

--- a/packages/insomnia/src/models/websocket-response.ts
+++ b/packages/insomnia/src/models/websocket-response.ts
@@ -122,7 +122,10 @@ export async function create(patch: Partial<WebSocketResponse> = {}, maxResponse
   }
 
   // Delete all other responses before creating the new one
-  const allResponses = await db.findMostRecentlyModified<WebSocketResponse>(type, query, Math.max(1, maxResponses));
+  const responsesToShow = Math.max(1, maxResponses);
+
+  const allResponses = await db.find<WebSocketResponse>(type, query, { modified: -1 }, responsesToShow);
+
   const recentIds = allResponses.map(r => r._id);
   // Remove all that were in the last query, except the first `maxResponses` IDs
   await db.removeWhere(type, {
@@ -140,14 +143,13 @@ export async function getLatestForRequestId(requestId: string, environmentId: st
 
   const shouldFilter = (await models.settings.get()).filterResponsesByEnv;
 
-  const responses = await db.findMostRecentlyModified<WebSocketResponse>(
+  const response = await db.findOne<WebSocketResponse>(
     type,
     {
       parentId: requestId,
       ...(shouldFilter ? { environmentId } : {}),
     },
-    1,
+    { modified: -1 },
   );
-  const response = responses[0] as WebSocketResponse | null | undefined;
-  return response || null;
+  return response;
 }

--- a/packages/insomnia/src/models/websocket-response.ts
+++ b/packages/insomnia/src/models/websocket-response.ts
@@ -71,7 +71,7 @@ export function findByParentId(parentId: string) {
 }
 
 export async function all() {
-  return db.all<WebSocketResponse>(type);
+  return db.find<WebSocketResponse>(type);
 }
 
 export async function removeForRequest(parentId: string, environmentId?: string | null) {

--- a/packages/insomnia/src/models/websocket-response.ts
+++ b/packages/insomnia/src/models/websocket-response.ts
@@ -153,9 +153,3 @@ export async function getLatestForRequest(requestId: string, environmentId: stri
   const response = responses[0] as WebSocketResponse | null | undefined;
   return response || null;
 }
-
-export function getLatestByParentId(parentId: string) {
-  return db.getMostRecentlyModified<WebSocketResponse>(type, {
-    parentId,
-  });
-}

--- a/packages/insomnia/src/models/websocket-response.ts
+++ b/packages/insomnia/src/models/websocket-response.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 
-import { database as db, type Query } from '../common/database';
+import { database as db } from '../common/database';
 import * as requestOperations from './helpers/request-operations';
 import type { BaseModel } from './index';
 import * as models from './index';
@@ -135,21 +135,19 @@ export async function create(patch: Partial<WebSocketResponse> = {}, maxResponse
   return db.docCreate(type, patch);
 }
 
-async function _findRecentForRequest(requestId: string, environmentId: string | null, limit: number) {
-  const query: Query<WebSocketResponse> = {
-    parentId: requestId,
-  };
-
+export async function getLatestForRequestId(requestId: string, environmentId: string | null) {
   // Filter responses by environment if setting is enabled
-  if ((await models.settings.get()).filterResponsesByEnv) {
-    query.environmentId = environmentId;
-  }
 
-  return db.findMostRecentlyModified<WebSocketResponse>(type, query, limit);
-}
+  const shouldFilter = (await models.settings.get()).filterResponsesByEnv;
 
-export async function getLatestForRequest(requestId: string, environmentId: string | null) {
-  const responses = await _findRecentForRequest(requestId, environmentId, 1);
+  const responses = await db.findMostRecentlyModified<WebSocketResponse>(
+    type,
+    {
+      parentId: requestId,
+      ...(shouldFilter ? { environmentId } : {}),
+    },
+    1,
+  );
   const response = responses[0] as WebSocketResponse | null | undefined;
   return response || null;
 }

--- a/packages/insomnia/src/models/websocket-response.ts
+++ b/packages/insomnia/src/models/websocket-response.ts
@@ -62,20 +62,6 @@ export function migrate(doc: WebSocketResponse) {
   return doc;
 }
 
-export function hookDatabaseInit(consoleLog: typeof console.log = console.log) {
-  consoleLog('[db] Init websocket-responses DB');
-}
-
-export function hookRemove(doc: WebSocketResponse, consoleLog: typeof console.log = console.log) {
-  fs.unlink(doc.eventLogPath, () => {
-    consoleLog(`[response] Delete body ${doc.eventLogPath}`);
-  });
-
-  fs.unlink(doc.timelinePath, () => {
-    consoleLog(`[response] Delete timeline ${doc.timelinePath}`);
-  });
-}
-
 export function getById(id: string) {
   return db.get<WebSocketResponse>(type, id);
 }
@@ -100,13 +86,19 @@ export async function removeForRequest(parentId: string, environmentId?: string 
   if (environmentId !== undefined && settings.filterResponsesByEnv) {
     query.environmentId = environmentId;
   }
-
+  const toDelete = await db.find<WebSocketResponse>(type, query);
+  for (const doc of toDelete) {
+    fs.promises.unlink(doc.eventLogPath);
+    fs.promises.unlink(doc.timelinePath);
+  }
   // Also delete legacy responses here or else the user will be confused as to
   // why some responses are still showing in the UI.
   await db.removeWhere(type, query);
 }
 
 export function remove(response: WebSocketResponse) {
+  fs.promises.unlink(response.eventLogPath);
+  fs.promises.unlink(response.timelinePath);
   return db.remove(response);
 }
 

--- a/packages/insomnia/src/models/workspace-meta.ts
+++ b/packages/insomnia/src/models/workspace-meta.ts
@@ -59,16 +59,15 @@ export function update(workspaceMeta: WorkspaceMeta, patch: Partial<WorkspaceMet
 
 export async function updateByParentId(parentId: string, patch: Partial<WorkspaceMeta> = {}) {
   const meta = await getByParentId(parentId);
-  // @ts-expect-error -- TSCONVERSION appears to be a genuine error not previously caught by Flow
-  return db.docUpdate<WorkspaceMeta>(meta, patch);
+  return meta && db.docUpdate<WorkspaceMeta>(meta, patch);
 }
 
 export async function getByParentId(parentId: string) {
-  return db.getWhere<WorkspaceMeta>(type, { parentId });
+  return db.findOne<WorkspaceMeta>(type, { parentId });
 }
 
 export async function getByGitRepositoryId(gitRepositoryId: string) {
-  return db.getWhere<WorkspaceMeta>(type, { gitRepositoryId });
+  return db.findOne<WorkspaceMeta>(type, { gitRepositoryId });
 }
 
 export async function getOrCreateByParentId(parentId: string) {

--- a/packages/insomnia/src/models/workspace-meta.ts
+++ b/packages/insomnia/src/models/workspace-meta.ts
@@ -77,5 +77,5 @@ export async function getOrCreateByParentId(parentId: string) {
 }
 
 export function all() {
-  return db.all<WorkspaceMeta>(type);
+  return db.find<WorkspaceMeta>(type);
 }

--- a/packages/insomnia/src/models/workspace.ts
+++ b/packages/insomnia/src/models/workspace.ts
@@ -60,7 +60,7 @@ export function migrate(doc: Workspace) {
 }
 
 export function getById(id?: string) {
-  return db.get<Workspace>(type, id);
+  return db.findOne<Workspace>(type, { _id: id });
 }
 
 export function findByParentId(parentId: string) {

--- a/packages/insomnia/src/models/workspace.ts
+++ b/packages/insomnia/src/models/workspace.ts
@@ -73,7 +73,7 @@ export async function create(patch: Partial<Workspace> = {}) {
 }
 
 export async function all() {
-  return await db.all<Workspace>(type);
+  return await db.find<Workspace>(type);
 }
 
 export function count() {

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -812,7 +812,7 @@ export interface sendCurlAndWriteTimelineResponse extends ResponsePatch {
 export async function sendCurlAndWriteTimeline(
   renderedRequest: RenderedRequest,
   clientCertificates: ClientCertificate[],
-  caCert: CaCertificate | null,
+  caCert: CaCertificate | undefined,
   settings: Settings,
   timelinePath: string,
   responseId: string,

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -51,7 +51,7 @@ export const getOAuth2Token = async (
   requestId: string,
   authentication: AuthTypeOAuth2,
   forceRefresh = false,
-): Promise<OAuth2Token | null> => {
+): Promise<OAuth2Token | undefined> => {
   try {
     const { oAuth2Token, closestAuthId } = await getExistingAccessTokenAndRefreshIfExpired(
       requestId,
@@ -251,7 +251,7 @@ async function getExistingAccessTokenAndRefreshIfExpired(
   requestId: string,
   authentication: AuthTypeOAuth2,
   forceRefresh: boolean,
-): Promise<{ oAuth2Token: OAuth2Token | null; closestAuthId: string }> {
+): Promise<{ oAuth2Token: OAuth2Token | undefined; closestAuthId: string }> {
   const activeRequest = await models.request.getById(requestId);
   const requestGroups = (
     await db.withAncestors<Request | RequestGroup>(activeRequest, [models.requestGroup.type])
@@ -262,9 +262,9 @@ async function getExistingAccessTokenAndRefreshIfExpired(
   const isRequestAuthEnabled =
     getAuthObjectOrNull(activeRequest?.authentication) && isAuthEnabled(activeRequest?.authentication);
   const closestAuthId = isRequestAuthEnabled ? requestId : closestFolderAuth?._id || requestId;
-  const token: OAuth2Token | null = await models.oAuth2Token.getByParentId(closestAuthId);
+  const token = await models.oAuth2Token.getByParentId(closestAuthId);
   if (!token) {
-    return { oAuth2Token: null, closestAuthId };
+    return { oAuth2Token: undefined, closestAuthId };
   }
   const expiresAt = token.expiresAt || Infinity;
   const isExpired = Date.now() > expiresAt;
@@ -275,7 +275,7 @@ async function getExistingAccessTokenAndRefreshIfExpired(
   // token is expired
 
   if (!token.refreshToken) {
-    return { oAuth2Token: null, closestAuthId };
+    return { oAuth2Token: undefined, closestAuthId };
   }
 
   let params = [
@@ -305,7 +305,7 @@ async function getExistingAccessTokenAndRefreshIfExpired(
     // brand new refresh and access tokens.
     const old = await models.oAuth2Token.getOrCreateByParentId(closestAuthId);
     models.oAuth2Token.update(old, transformNewAccessTokenToOauthModel({ access_token: null }));
-    return { oAuth2Token: null, closestAuthId };
+    return { oAuth2Token: undefined, closestAuthId };
   }
   const isSuccessful = statusCode >= 200 && statusCode < 300;
   const hasBodyAndIsError = bodyBuffer && statusCode === 400;
@@ -328,7 +328,7 @@ async function getExistingAccessTokenAndRefreshIfExpired(
   invariant(bodyBuffer, `[oauth2] No body returned from ${authentication.accessTokenUrl}`);
   const data = tryToParse(bodyBuffer.toString());
   if (!data) {
-    return { oAuth2Token: null, closestAuthId };
+    return { oAuth2Token: undefined, closestAuthId };
   }
   const old = await models.oAuth2Token.getOrCreateByParentId(closestAuthId);
   const oAuth2Token = await models.oAuth2Token.update(

--- a/packages/insomnia/src/plugins/context/__tests__/request.test.ts
+++ b/packages/insomnia/src/plugins/context/__tests__/request.test.ts
@@ -17,7 +17,7 @@ const CONTEXT = {
 
 describe('init()', () => {
   beforeEach(async () => {
-    await db.init(models.types(), { inMemoryOnly: true }, true, () => {});
+    await db.init({ inMemoryOnly: true }, true, () => {});
 
     await models.workspace.create({
       _id: 'wrk_1',
@@ -98,7 +98,7 @@ describe('init()', () => {
 
 describe('request.*', () => {
   beforeEach(async () => {
-    await db.init(models.types(), { inMemoryOnly: true }, true, () => {});
+    await db.init({ inMemoryOnly: true }, true, () => {});
 
     await models.workspace.create({
       _id: 'wrk_1',

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -401,7 +401,7 @@ export function getPluginCommonContext({
           },
         },
         response: {
-          getLatestForRequestId: models.response.getLatestForRequest,
+          getLatestForRequestId: models.response.getLatestForRequestId,
           getBodyBuffer: models.response.getBodyBuffer,
         },
         settings: {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -149,7 +149,7 @@ export interface ProjectLoaderData {
   mockServersCount: number;
   projectsCount: number;
   activeProject?: Project;
-  activeProjectGitRepository?: GitRepository | null;
+  activeProjectGitRepository?: GitRepository;
   projects: (Project & { gitRepository?: GitRepository })[];
   learningFeaturePromise?: Promise<LearningFeature>;
   remoteFilesPromise?: Promise<InsomniaFile[]>;
@@ -949,7 +949,7 @@ const Component = () => {
                   {isGitProject(activeProject) && (
                     <GitProjectSyncDropdown
                       key={activeProjectGitRepository?._id}
-                      gitRepository={activeProjectGitRepository || null}
+                      gitRepository={activeProjectGitRepository}
                     />
                   )}
                   {isLocalProject(activeProject) && !isGitProject(activeProject) && <LocalProjectBar />}

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.connect.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.connect.tsx
@@ -3,7 +3,6 @@ import { useCallback } from 'react';
 import { href, useFetcher } from 'react-router';
 
 import type { ChangeBufferEvent } from '~/common/database';
-import { database } from '~/common/database';
 import type { CookieJar } from '~/models/cookie-jar';
 import * as requestOperations from '~/models/helpers/request-operations';
 import type { RequestAuthentication, RequestHeader } from '~/models/request';
@@ -93,11 +92,13 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
   }
   // HACK: even more elaborate hack to get the request to update
   return new Promise(resolve => {
-    database.onChange(async (changes: ChangeBufferEvent[]) => {
+    const unsubscribe = window.main.on('db.changes', async (_, changes: ChangeBufferEvent[]) => {
       for (const change of changes) {
         const [event, doc] = change;
         if (isRequestMeta(doc) && doc.parentId === requestId && event === 'update') {
           resolve(null);
+          unsubscribe();
+          return;
         }
       }
     });

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.response.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.response.delete.tsx
@@ -25,7 +25,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
     const res = await models.webSocketResponse.getById(responseId);
     invariant(res, 'Response not found');
     await models.webSocketResponse.remove(res);
-    const response = await models.webSocketResponse.getLatestForRequest(requestId, workspaceMeta.activeEnvironmentId);
+    const response = await models.webSocketResponse.getLatestForRequestId(requestId, workspaceMeta.activeEnvironmentId);
     if (response?.requestVersionId) {
       await models.requestVersion.restore(response.requestVersionId);
     }
@@ -34,7 +34,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
     const res = await models.socketIOResponse.getById(responseId);
     invariant(res, 'Response not found');
     await models.socketIOResponse.remove(res);
-    const response = await models.socketIOResponse.getLatestForRequest(requestId, workspaceMeta.activeEnvironmentId);
+    const response = await models.socketIOResponse.getLatestForRequestId(requestId, workspaceMeta.activeEnvironmentId);
     if (response?.requestVersionId) {
       await models.requestVersion.restore(response.requestVersionId);
     }
@@ -43,7 +43,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
     const res = await models.response.getById(responseId);
     invariant(res, 'Response not found');
     await models.response.remove(res);
-    const response = await models.response.getLatestForRequest(requestId, workspaceMeta.activeEnvironmentId);
+    const response = await models.response.getLatestForRequestId(requestId, workspaceMeta.activeEnvironmentId);
     if (response?.requestVersionId) {
       await models.requestVersion.restore(response.requestVersionId);
     }
@@ -54,13 +54,10 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
 }
 
 export function useRequestResponseDeleteActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const {
-    submit: fetcherSubmit,
-    ...fetcherRest
-  } = useFetcher<typeof clientAction>(args);
+  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
 
-  const submit = useCallback((
-    {
+  const submit = useCallback(
+    ({
       organizationId,
       projectId,
       workspaceId,
@@ -72,21 +69,25 @@ export function useRequestResponseDeleteActionFetcher(args?: Parameters<typeof u
       workspaceId: string;
       requestId: string;
       responseId: string;
-    }
-  ) => {
-    const url = href('/organization/:organizationId/project/:projectId/workspace/:workspaceId/debug/request/:requestId/response/delete', {
-      organizationId,
-      projectId,
-      workspaceId,
-      requestId,
-    });
+    }) => {
+      const url = href(
+        '/organization/:organizationId/project/:projectId/workspace/:workspaceId/debug/request/:requestId/response/delete',
+        {
+          organizationId,
+          projectId,
+          workspaceId,
+          requestId,
+        },
+      );
 
-    return fetcherSubmit(JSON.stringify({ responseId }), {
-      action: url,
-      method: 'POST',
-      encType: 'application/json',
-    });
-  }, [fetcherSubmit]);
+      return fetcherSubmit(JSON.stringify({ responseId }), {
+        action: url,
+        method: 'POST',
+        encType: 'application/json',
+      });
+    },
+    [fetcherSubmit],
+  );
 
   return {
     ...fetcherRest,

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx
@@ -94,7 +94,7 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
 
   const activeResponse = activeRequestMeta.activeResponseId
     ? await models[responseModelName].getById(activeRequestMeta.activeResponseId)
-    : await models[responseModelName].getLatestForRequest(requestId, activeWorkspaceMeta.activeEnvironmentId);
+    : await models[responseModelName].getLatestForRequestId(requestId, activeWorkspaceMeta.activeEnvironmentId);
   const allResponses = (await models[responseModelName].findByParentId(requestId)) as (
     | Response
     | WebSocketResponse

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.tsx
@@ -33,7 +33,7 @@ export interface WebSocketRequestLoaderData {
 export interface SocketIORequestLoaderData {
   activeRequest: SocketIORequest;
   activeRequestMeta: RequestMeta;
-  activeResponse: null;
+  activeResponse: SocketIOResponse;
   responses: SocketIOResponse[];
   requestVersions: RequestVersion[];
   requestPayload: SocketIOPayload;

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -40,7 +40,7 @@ import {
 } from 'react-router';
 
 import { DEFAULT_SIDEBAR_SIZE, getProductName, SORT_ORDERS, type SortOrder, sortOrderName } from '~/common/constants';
-import { type ChangeBufferEvent, database as db } from '~/common/database';
+import { type ChangeBufferEvent } from '~/common/database';
 import { generateId, isNotNullOrUndefined } from '~/common/misc';
 import type { PlatformKeyCombinations } from '~/common/settings';
 import type { GrpcMethodInfo } from '~/main/ipc/grpc';
@@ -274,7 +274,7 @@ const Debug = () => {
   const patchGroup = useRequestGroupPatcher();
   const patchRequestMeta = useRequestMetaPatcher();
   useEffect(() => {
-    db.onChange(async (changes: ChangeBufferEvent[]) => {
+    const unsubscribe = window.main.on('db.changes', async (_, changes: ChangeBufferEvent[]) => {
       for (const change of changes) {
         const [event, doc] = change;
         if (isGrpcRequest(doc) && event === 'insert') {
@@ -282,6 +282,9 @@ const Debug = () => {
         }
       }
     });
+    return () => {
+      unsubscribe();
+    };
   }, []);
 
   const { settings } = useRootLoaderData()!;

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.checkout.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.checkout.tsx
@@ -22,6 +22,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
 
   try {
     const delta = await vcs.checkout(syncItems, branch);
+    // This is to synchronize the local database with the branch changes
     await database.batchModifyDocs(delta as Operation);
     delete remoteCompareCache[workspaceId];
   } catch (err) {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.create.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.create.tsx
@@ -24,6 +24,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
     await vcs.fork(branchName);
     // Checkout new branch
     const delta = await vcs.checkout(syncItems, branchName);
+    // This is to synchronize the local database with the branch changes
     await database.batchModifyDocs(delta as Operation);
     delete remoteCompareCache[workspaceId];
   } catch (err) {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.merge.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.merge.tsx
@@ -27,6 +27,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
     throw err;
   }
   try {
+    // This is to synchronize the local database with the branch changes
     await database.batchModifyDocs(delta as Operation);
     delete remoteCompareCache[workspaceId];
   } catch (err) {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.fetch.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.fetch.tsx
@@ -30,6 +30,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
       projectId,
     });
 
+    // This is to synchronize the local database with the branch changes
     await database.batchModifyDocs(delta);
   } catch (err) {
     await vcs.checkout([], currentBranch);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.pull.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.pull.tsx
@@ -30,7 +30,7 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
       event: SegmentEvent.vcsAction,
       properties: vcsSegmentEventProperties('remote', 'pull'),
     });
-
+    // This is to synchronize the local database with the branch changes
     await database.batchModifyDocs(delta);
     delete remoteCompareCache[workspaceId];
   } catch (err) {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.restore.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.restore.tsx
@@ -19,6 +19,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
     const vcs = VCSInstance();
     const { syncItems } = await getSyncItems({ workspaceId });
     const delta = await vcs.rollback(id, syncItems);
+    // This is to synchronize the local database with the branch changes
     await database.batchModifyDocs(delta as unknown as Operation);
     delete remoteCompareCache[workspaceId];
   } catch (err) {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.rollback.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.rollback.tsx
@@ -15,6 +15,7 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
     const vcs = VCSInstance();
     const { syncItems } = await getSyncItems({ workspaceId });
     const delta = await vcs.rollbackToLatest(syncItems);
+    // This is to synchronize the local database with the branch changes
     await database.batchModifyDocs(delta as unknown as Operation);
     delete remoteCompareCache[workspaceId];
   } catch (err) {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId.tsx
@@ -57,8 +57,11 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   // TODO: use the same request for try mock rather than creating lots of child requests
   const reqIds = (await models.request.findByParentId(mockRouteId)).map(r => r._id);
 
-  const responses = await db.findMostRecentlyModified<Response>(models.response.type, { parentId: { $in: reqIds } });
-  const activeResponse = responses?.[0];
+  const activeResponse = await db.findOne<Response>(
+    models.response.type,
+    { parentId: { $in: reqIds } },
+    { modified: -1 },
+  );
   if (activeResponse && 'bodyPath' in activeResponse) {
     // read the body if its smaller than the limit add it to the activeResponse
     const length = Math.max(activeResponse.bytesContent, activeResponse.bytesRead);
@@ -72,7 +75,7 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   return {
     mockServer,
     mockRoute,
-    activeResponse: responses?.[0],
+    activeResponse,
   };
 }
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId._index.tsx
@@ -8,10 +8,13 @@ import type { Route } from './+types/organization.$organizationId.project.$proje
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   const { organizationId, projectId, workspaceId, testSuiteId } = params;
 
-  const testResults = await database.findMostRecentlyModified<UnitTestResult>('UnitTestResult', {
-    parentId: workspaceId,
-  });
-  const testResult = testResults[0];
+  const testResult = await database.findOne<UnitTestResult>(
+    'UnitTestResult',
+    {
+      parentId: workspaceId,
+    },
+    { modified: -1 },
+  );
   if (testResult) {
     return redirect(
       href(

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId._index.tsx
@@ -1,14 +1,17 @@
 import { href, redirect } from 'react-router';
 
-import * as models from '~/models';
+import { database } from '~/common/database';
+import type { UnitTestResult } from '~/models/unit-test-result';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId._index';
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   const { organizationId, projectId, workspaceId, testSuiteId } = params;
 
-  const testResult = await models.unitTestResult.getLatestByParentId(workspaceId);
-
+  const testResults = await database.findMostRecentlyModified<UnitTestResult>('UnitTestResult', {
+    parentId: workspaceId,
+  });
+  const testResult = testResults[0];
   if (testResult) {
     return redirect(
       href(

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test-result.$testResultId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test-result.$testResultId.tsx
@@ -12,7 +12,7 @@ import type { Route } from './+types/organization.$organizationId.project.$proje
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   const { testResultId } = params;
 
-  const testResult = await database.getWhere<UnitTestResult>(models.unitTestResult.type, {
+  const testResult = await database.findOne<UnitTestResult>(models.unitTestResult.type, {
     _id: testResultId,
   });
   invariant(testResult, 'Test Result not found');

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test-result._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test-result._index.tsx
@@ -1,13 +1,17 @@
 import { href, redirect } from 'react-router';
 
-import * as models from '~/models';
+import { database } from '~/common/database';
+import type { UnitTestResult } from '~/models/unit-test-result';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test-result._index';
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   const { organizationId, projectId, workspaceId, testSuiteId } = params;
 
-  const testResult = await models.unitTestResult.getLatestByParentId(workspaceId);
+  const testResults = await database.findMostRecentlyModified<UnitTestResult>('UnitTestResult', {
+    parentId: workspaceId,
+  });
+  const testResult = testResults[0];
   if (testResult) {
     return redirect(
       href(

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test-result._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test-result._index.tsx
@@ -8,10 +8,13 @@ import type { Route } from './+types/organization.$organizationId.project.$proje
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   const { organizationId, projectId, workspaceId, testSuiteId } = params;
 
-  const testResults = await database.findMostRecentlyModified<UnitTestResult>('UnitTestResult', {
-    parentId: workspaceId,
-  });
-  const testResult = testResults[0];
+  const testResult = await database.findOne<UnitTestResult>(
+    'UnitTestResult',
+    {
+      parentId: workspaceId,
+    },
+    { modified: -1 },
+  );
   if (testResult) {
     return redirect(
       href(

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.delete.tsx
@@ -12,7 +12,7 @@ import type { Route } from './+types/organization.$organizationId.project.$proje
 export async function clientAction({ params }: Route.ClientActionArgs) {
   const { testId } = params;
 
-  const unitTest = await database.getWhere<UnitTest>(models.unitTest.type, {
+  const unitTest = await database.findOne<UnitTest>(models.unitTest.type, {
     _id: testId,
   });
   invariant(unitTest, 'Test not found');

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.run.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.run.tsx
@@ -14,7 +14,7 @@ import type { Route } from './+types/organization.$organizationId.project.$proje
 export async function clientAction({ params }: Route.ClientActionArgs) {
   const { organizationId, projectId, workspaceId, testSuiteId, testId } = params;
 
-  const unitTest = await database.getWhere<UnitTest>(models.unitTest.type, {
+  const unitTest = await database.findOne<UnitTest>(models.unitTest.type, {
     _id: testId,
   });
   invariant(unitTest, 'Test not found');

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.update.tsx
@@ -12,7 +12,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   const { testId } = params;
   const data = (await request.json()) as Partial<UnitTest>;
 
-  const unitTest = await database.getWhere<UnitTest>(models.unitTest.type, {
+  const unitTest = await database.findOne<UnitTest>(models.unitTest.type, {
     _id: testId,
   });
   invariant(unitTest, 'Test not found');

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.tsx
@@ -324,7 +324,7 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   const workspaceEntities = await database.getWithDescendants(workspace, [models.request.type]);
   const requests: Request[] = workspaceEntities.filter(isRequest);
 
-  const unitTestSuite = await database.getWhere<UnitTestSuite>(models.unitTestSuite.type, {
+  const unitTestSuite = await database.findOne<UnitTestSuite>(models.unitTestSuite.type, {
     _id: testSuiteId,
   });
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.update.tsx
@@ -13,7 +13,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
 
   const data = (await request.json()) as Partial<UnitTestSuite>;
 
-  const unitTestSuite = await database.getWhere<UnitTestSuite>(models.unitTestSuite.type, {
+  const unitTestSuite = await database.findOne<UnitTestSuite>(models.unitTestSuite.type, {
     _id: testSuiteId,
   });
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx
@@ -119,11 +119,11 @@ export async function clientLoader({ params, request }: Route.ClientLoaderArgs) 
   });
 
   const activeEnvironment =
-    (await database.getWhere<Environment>(models.environment.type, {
+    (await database.findOne<Environment>(models.environment.type, {
       _id: activeWorkspaceMeta.activeEnvironmentId,
     })) || baseEnvironment;
 
-  const activeGlobalEnvironment = await database.getWhere<Environment>(models.environment.type, {
+  const activeGlobalEnvironment = await database.findOne<Environment>(models.environment.type, {
     _id: activeWorkspaceMeta.activeGlobalEnvironmentId,
   });
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.delete.tsx
@@ -54,13 +54,14 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   const { organizationId, projectId } = params;
 
   const project = await models.project.getById(projectId);
-
+  invariant(project, 'Project not found');
   const formData = await request.formData();
 
   const workspaceId = formData.get('workspaceId');
   invariant(typeof workspaceId === 'string', 'Workspace ID is required');
 
   const workspace = await models.workspace.getById(workspaceId);
+  invariant(workspace, 'Workspace not found');
 
   const msgObj = await deleteWorkspace(workspace, project);
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project._index.tsx
@@ -148,7 +148,7 @@ export interface ProjectLoaderData {
   mockServersCount: number;
   projectsCount: number;
   activeProject?: Project;
-  activeProjectGitRepository?: GitRepository | null;
+  activeProjectGitRepository?: GitRepository;
   projects: (Project & { gitRepository?: GitRepository })[];
   learningFeaturePromise?: Promise<LearningFeature>;
   remoteFilesPromise?: Promise<InsomniaFile[]>;
@@ -954,7 +954,7 @@ const Component = () => {
                   {isGitProject(activeProject) && (
                     <GitProjectSyncDropdown
                       key={activeProjectGitRepository?._id}
-                      gitRepository={activeProjectGitRepository || null}
+                      gitRepository={activeProjectGitRepository}
                     />
                   )}
                   {isLocalProject(activeProject) && !isGitProject(activeProject) && <LocalProjectBar />}

--- a/packages/insomnia/src/routes/organization.sync-organizations-and-projects.tsx
+++ b/packages/insomnia/src/routes/organization.sync-organizations-and-projects.tsx
@@ -53,7 +53,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
 
     // When user switch to a new organization, there is no project in db cache, we need to redirect to the first project after sync project
     if (!projectId && asyncTaskList.includes(AsyncTask.SyncProjects)) {
-      const firstProject = await database.getWhere<Project>(project.type, { parentId: organizationId });
+      const firstProject = await database.findOne<Project>(project.type, { parentId: organizationId });
       if (firstProject?._id) {
         return redirect(
           href('/organization/:organizationId/project/:projectId', {

--- a/packages/insomnia/src/sync/git/__tests__/ne-db-client.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/ne-db-client.test.ts
@@ -121,7 +121,7 @@ describe('NeDBClient', () => {
   describe('writeFile()', () => {
     it('should ignore files not in GIT_INSOMNIA_DIR directory', async () => {
       // Arrange
-      const upsertSpy = vi.spyOn(db, 'upsert');
+      const updateSpy = vi.spyOn(db, 'update');
       const workspaceId = 'wrk_1';
       const neDbClient = new NeDBClient(workspaceId, 'proj_1');
       const env = {
@@ -133,16 +133,16 @@ describe('NeDBClient', () => {
       // Act
       await neDbClient.writeFile(filePath, YAML.stringify(env));
       // Assert
-      expect(upsertSpy).not.toBeCalled();
+      expect(updateSpy).not.toBeCalled();
       // Cleanup
-      upsertSpy.mockRestore();
+      updateSpy.mockRestore();
     });
 
     it('should write files in GIT_INSOMNIA_DIR directory to db', async () => {
       // Arrange
       const workspaceId = 'wrk_1';
       const neDbClient = new NeDBClient(workspaceId, 'proj_1');
-      const upsertSpy = vi.spyOn(db, 'upsert');
+      const updateSpy = vi.spyOn(db, 'update');
       const env = {
         _id: 'env_1',
         type: models.environment.type,
@@ -152,10 +152,10 @@ describe('NeDBClient', () => {
       // Act
       await neDbClient.writeFile(filePath, YAML.stringify(env));
       // Assert
-      expect(upsertSpy).toHaveBeenCalledTimes(1);
-      expect(upsertSpy).toHaveBeenCalledWith(env, true);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      expect(updateSpy).toHaveBeenCalledWith(env, true);
       // Cleanup
-      upsertSpy.mockRestore();
+      updateSpy.mockRestore();
     });
 
     it('should set workspace parentId to the project', async () => {
@@ -163,7 +163,7 @@ describe('NeDBClient', () => {
       const workspaceId = 'wrk_1';
       const projectId = `${models.project.prefix}_1`;
       const neDbClient = new NeDBClient(workspaceId, projectId);
-      const upsertSpy = vi.spyOn(db, 'upsert');
+      const updateSpy = vi.spyOn(db, 'update');
 
       workspaceBuilder._id(workspaceId).scope('design').certificates(null);
 
@@ -177,11 +177,11 @@ describe('NeDBClient', () => {
       await neDbClient.writeFile(filePath, YAML.stringify(workspaceInFile));
 
       // Assert
-      expect(upsertSpy).toHaveBeenCalledTimes(1);
-      expect(upsertSpy).toHaveBeenCalledWith(workspaceInDb, true);
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      expect(updateSpy).toHaveBeenCalledWith(workspaceInDb, true);
 
       // Cleanup
-      upsertSpy.mockRestore();
+      updateSpy.mockRestore();
     });
 
     it('should throw error if id does not match', async () => {

--- a/packages/insomnia/src/sync/git/__tests__/ne-db-client.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/ne-db-client.test.ts
@@ -20,7 +20,7 @@ describe('NeDBClient', () => {
   beforeEach(async () => {
     workspaceBuilder.reset();
     setupDateMocks();
-    await db.init(models.types(), { inMemoryOnly: true }, true, () => {});
+    await db.init({ inMemoryOnly: true }, true, () => {});
     // Create some sample models
     await models.project.create({
       _id: 'proj_1',

--- a/packages/insomnia/src/sync/git/ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/ne-db-client.ts
@@ -3,12 +3,10 @@ import path from 'node:path';
 import type { PromiseFsClient } from 'isomorphic-git';
 import YAML from 'yaml';
 
-import { invariant } from '~/utils/invariant';
-
 import { database as db } from '../../common/database';
 import type { BaseModel } from '../../models';
 import * as models from '../../models';
-import { isWorkspace, type Workspace } from '../../models/workspace';
+import { isWorkspace } from '../../models/workspace';
 import { resetKeys } from '../ignore-keys';
 import { GIT_INSOMNIA_DIR_NAME } from './git-vcs';
 import parseGitPath from './parse-git-path';

--- a/packages/insomnia/src/sync/git/ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/ne-db-client.ts
@@ -170,7 +170,7 @@ export class NeDBClient {
       ];
     } else if (type !== null && id === null) {
       const workspace = await db.findOne(models.workspace.type, { _id: this._workspaceId });
-      const children = workspace ? await db.getWithDescendants(workspace, [type] as models.ModelTypes) : [];
+      const children = workspace ? await db.getWithDescendants(workspace, [type]) : [];
       docs = children.filter(d => d.type === type && !d.isPrivate);
     } else {
       throw this._errMissing(filePath);

--- a/packages/insomnia/src/sync/git/ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/ne-db-client.ts
@@ -3,10 +3,12 @@ import path from 'node:path';
 import type { PromiseFsClient } from 'isomorphic-git';
 import YAML from 'yaml';
 
+import { invariant } from '~/utils/invariant';
+
 import { database as db } from '../../common/database';
 import type { BaseModel } from '../../models';
 import * as models from '../../models';
-import { isWorkspace } from '../../models/workspace';
+import { isWorkspace, type Workspace } from '../../models/workspace';
 import { resetKeys } from '../ignore-keys';
 import { GIT_INSOMNIA_DIR_NAME } from './git-vcs';
 import parseGitPath from './parse-git-path';

--- a/packages/insomnia/src/sync/git/ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/ne-db-client.ts
@@ -119,7 +119,7 @@ export class NeDBClient {
       doc.parentId = this._projectId;
     }
 
-    await db.upsert(doc, true);
+    await db.update(doc, true);
   }
 
   async unlink(filePath: string) {

--- a/packages/insomnia/src/sync/git/ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/ne-db-client.ts
@@ -53,7 +53,7 @@ export class NeDBClient {
       throw this._errMissing(filePath);
     }
 
-    const doc = await db.get(type, id);
+    const doc = await db.findOne(type, { _id: id });
 
     if (!doc || doc.isPrivate) {
       throw this._errMissing(filePath);
@@ -128,7 +128,7 @@ export class NeDBClient {
       throw new Error(`Cannot unlink file ${filePath}`);
     }
 
-    const doc = await db.get(type, id);
+    const doc = await db.findOne(type, { _id: id });
 
     if (!doc) {
       return;
@@ -169,8 +169,7 @@ export class NeDBClient {
         models.socketIORequest.type,
       ];
     } else if (type !== null && id === null) {
-      const workspace = await db.get(models.workspace.type, this._workspaceId);
-
+      const workspace = await db.findOne(models.workspace.type, { _id: this._workspaceId });
       const children = workspace ? await db.getWithDescendants(workspace, [type] as models.ModelTypes) : [];
       docs = children.filter(d => d.type === type && !d.isPrivate);
     } else {

--- a/packages/insomnia/src/sync/git/parse-git-path.ts
+++ b/packages/insomnia/src/sync/git/parse-git-path.ts
@@ -1,5 +1,7 @@
 import path from 'node:path';
 
+import { type AllTypes, isValidType } from '~/models';
+
 import { GIT_CLONE_DIR } from './git-vcs';
 
 // The win32 separator is a single backslash (\), but we have to escape both the JS string and RegExp.
@@ -9,7 +11,7 @@ const _cloneDirRegExp = new RegExp(`^${GIT_CLONE_DIR}${pathSep}`);
 
 interface GitPathSegments {
   root: string | null;
-  type: string | null;
+  type: AllTypes | null;
   id: string | null;
 }
 
@@ -23,7 +25,7 @@ const parseGitPath = (filePath: string): GitPathSegments => {
   const id = typeof idRaw === 'string' ? idRaw.replace(/\.(json|yml)$/, '') : idRaw;
   return {
     root: root || null,
-    type: type || null,
+    type: isValidType(type) ? type : null,
     id: id || null,
   };
 };

--- a/packages/insomnia/src/sync/git/project-ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/project-ne-db-client.ts
@@ -94,6 +94,7 @@ export class GitProjectNeDBClient {
       const originDocs = await database.getWithDescendants(workspace);
       // If the workspace already exists, we need to remove any documents that are not in the new data
       const deletedDocs = originDocs.filter(originDoc => !dataToImport.some(doc => doc._id === originDoc._id));
+      // TODO: this could be done with a removeMany
       await database.batchModifyDocs({
         remove: deletedDocs,
       });

--- a/packages/insomnia/src/sync/git/project-ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/project-ne-db-client.ts
@@ -114,7 +114,7 @@ export class GitProjectNeDBClient {
         await models.workspaceMeta.update(workspaceMeta, { gitFilePath: filePath });
       }
 
-      await db.upsert(doc, true);
+      await db.update(doc, true);
     }
 
     await db.flushChanges(bufferId);

--- a/packages/insomnia/src/sync/git/project-ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/project-ne-db-client.ts
@@ -128,7 +128,7 @@ export class GitProjectNeDBClient {
       throw this._errMissing(filePath);
     }
 
-    const doc = await db.get(models.workspace.type, workspaceId);
+    const doc = await db.findOne(models.workspace.type, { _id: workspaceId });
 
     if (!doc) {
       return;

--- a/packages/insomnia/src/sync/store/drivers/file-system-driver.ts
+++ b/packages/insomnia/src/sync/store/drivers/file-system-driver.ts
@@ -33,13 +33,13 @@ export default class FileSystemDriver implements BaseDriver {
   }
 
   async setItem(key: string, value: Buffer) {
-    console.log(`[FileSystemDriver] Writing to ${key}`);
+    console.debug(`[FileSystemDriver] Writing to ${key}`);
     const finalPath = await this._getKeyPath(key);
     // Temp path contains randomness to avoid race-condition collisions. This
     // doesn't actually avoid race conditions but at least it won't fail.
 
     const tmpPath = `${finalPath}.${crypto.randomUUID()}.tmp`;
-    console.log(`[FileSystemDriver] Writing to ${tmpPath} then renaming to ${finalPath}`);
+    console.debug(`[FileSystemDriver] Writing to ${tmpPath} then renaming to ${finalPath}`);
     // This method implements atomic writes by first writing to a temporary
     // file (non-atomic) then renaming the file to the final value (atomic)
     try {

--- a/packages/insomnia/src/sync/store/index.ts
+++ b/packages/insomnia/src/sync/store/index.ts
@@ -56,7 +56,7 @@ export default class Store {
       // Without the `await` here, the catch won't get called
       value = await this._deserialize(ext, rawValue);
     } catch (err) {
-      console.log('[sync] Failed to deserialize', rawValue.toString('base64'));
+      console.debug('[sync] Failed to deserialize', rawValue.toString('base64'));
       throw new Error(`Failed to deserialize key=${key} err=${err}`);
     }
 

--- a/packages/insomnia/src/sync/vcs/migrate-projects-into-organization.ts
+++ b/packages/insomnia/src/sync/vcs/migrate-projects-into-organization.ts
@@ -27,7 +27,7 @@ export const shouldMigrateProjectUnderOrganization = async () => {
     }),
   ]);
 
-  return localProjectCount > 0 || legacyRemoteProjectCount > 0;
+  return (localProjectCount ?? 0) > 0 || (legacyRemoteProjectCount ?? 0) > 0;
 };
 
 export const migrateProjectsIntoOrganization = async ({

--- a/packages/insomnia/src/sync/vcs/migrate-projects-into-organization.ts
+++ b/packages/insomnia/src/sync/vcs/migrate-projects-into-organization.ts
@@ -27,7 +27,7 @@ export const shouldMigrateProjectUnderOrganization = async () => {
     }),
   ]);
 
-  return (localProjectCount ?? 0) > 0 || (legacyRemoteProjectCount ?? 0) > 0;
+  return localProjectCount > 0 || legacyRemoteProjectCount > 0;
 };
 
 export const migrateProjectsIntoOrganization = async ({

--- a/packages/insomnia/src/sync/vcs/pull-backend-project.ts
+++ b/packages/insomnia/src/sync/vcs/pull-backend-project.ts
@@ -35,7 +35,7 @@ export const pullBackendProject = async ({ vcs, backendProject, remoteProject }:
       scope: 'collection',
     });
 
-    await database.upsert(workspace);
+    await database.update(workspace);
 
     return { project: remoteProject, workspaceId: workspace._id };
   }
@@ -59,7 +59,7 @@ export const pullBackendProject = async ({ vcs, backendProject, remoteProject }:
     }
     const allModelType = models.types();
     if (allModelType.includes(doc.type)) {
-      await database.upsert(doc);
+      await database.update(doc);
     }
   }
 

--- a/packages/insomnia/src/sync/vcs/vcs.ts
+++ b/packages/insomnia/src/sync/vcs/vcs.ts
@@ -85,7 +85,7 @@ export class VCS {
 
   async setBackendProject(backendProject: BackendProject) {
     this._backendProject = backendProject;
-    console.log(`[sync] Activated project ${backendProject.id}`);
+    console.debug(`[sync] Activated project ${backendProject.id}`);
     // Store it because it might not be yet
     await this._storeBackendProject(backendProject);
   }

--- a/packages/insomnia/src/templating/base-extension-worker.ts
+++ b/packages/insomnia/src/templating/base-extension-worker.ts
@@ -34,7 +34,11 @@ export const fetchFromTemplateWorkerDatabase = async (path: PluginToMainAPIPaths
     method: 'post',
     body: JSON.stringify(body),
   });
-  const result = await resp.json();
+  let result;
+  try {
+    // We expect this to throw if a db call returns undefined
+    result = await resp.json();
+  } catch {}
   if (!resp.ok) {
     throw new Error(result?.error || JSON.stringify(result));
   }
@@ -180,7 +184,9 @@ export default class BaseExtension {
       renderPurpose,
       util: {
         readFile: async (path: string, encoding?: string) => {
-          const allowed = renderContext?.getSettings().dataFolders.some((folder: string) => folder !== '' && path.startsWith(folder));
+          const allowed = renderContext
+            ?.getSettings()
+            .dataFolders.some((folder: string) => folder !== '' && path.startsWith(folder));
           if (!allowed) {
             throw `Insomnia cannot access the file ‘${path}’. You can adjust this in Preferences → Security.`;
           }

--- a/packages/insomnia/src/templating/base-extension.ts
+++ b/packages/insomnia/src/templating/base-extension.ts
@@ -120,11 +120,13 @@ export default class BaseExtension {
           };
         },
         readFile: async (path: string, encoding = 'utf8') => {
-          const allowed = renderContext?.getSettings().dataFolders.some((folder: string) => folder !== '' && path.startsWith(folder));
+          const allowed = renderContext
+            ?.getSettings()
+            .dataFolders.some((folder: string) => folder !== '' && path.startsWith(folder));
           if (!allowed) {
             throw `Insomnia cannot access the file ‘${path}’. You can adjust this in Preferences → Security.`;
           }
-                    
+
           const content = await fs.promises.readFile(path);
           return encoding === 'utf8' ? content.toString(encoding) : content;
         },
@@ -163,7 +165,7 @@ export default class BaseExtension {
             },
           },
           response: {
-            getLatestForRequestId: models.response.getLatestForRequest,
+            getLatestForRequestId: models.response.getLatestForRequestId,
             getBodyBuffer: models.response.getBodyBuffer,
           },
           settings: {

--- a/packages/insomnia/src/templating/types.ts
+++ b/packages/insomnia/src/templating/types.ts
@@ -266,18 +266,18 @@ export interface PluginTemplateTagContext {
     openInBrowser?: (url: string) => void;
     models: {
       request: {
-        getById: (id: string) => Promise<Request | null>;
+        getById: (id: string) => Promise<Request | undefined>;
         getAncestors: (request: Request) => Promise<(Request | RequestGroup | Workspace)[]>;
       };
       cloudCredential: {
-        getById: (id: string) => Promise<CloudProviderCredential | null>;
+        getById: (id: string) => Promise<CloudProviderCredential | undefined>;
         update: (
           originCredential: CloudProviderCredential,
           patch: Partial<CloudProviderCredential>,
         ) => Promise<CloudProviderCredential>;
       };
-      workspace: { getById: (id: string) => Promise<Workspace | null> };
-      oAuth2Token: { getByRequestId: (id: string) => Promise<OAuth2Token | null> };
+      workspace: { getById: (id: string) => Promise<Workspace | undefined> };
+      oAuth2Token: { getByRequestId: (id: string) => Promise<OAuth2Token | undefined> };
       cookieJar: { getOrCreateForParentId: (parentId: string) => Promise<CookieJar> };
       response: {
         getLatestForRequestId: typeof getLatestForRequest;

--- a/packages/insomnia/src/templating/types.ts
+++ b/packages/insomnia/src/templating/types.ts
@@ -8,8 +8,7 @@ import type { OAuth2Token } from '../models/o-auth-2-token';
 import type { Project } from '../models/project';
 import type { Request } from '../models/request';
 import type { RequestGroup } from '../models/request-group';
-import type { Response } from '../models/response';
-import type { getBodyBuffer, getLatestForRequest } from '../models/response';
+import type { getBodyBuffer, getLatestForRequestId, Response } from '../models/response';
 import type { get as getSettings } from '../models/settings';
 import type { SocketIORequest } from '../models/socket-io-request';
 import type { WebSocketRequest } from '../models/websocket-request';
@@ -280,7 +279,7 @@ export interface PluginTemplateTagContext {
       oAuth2Token: { getByRequestId: (id: string) => Promise<OAuth2Token | undefined> };
       cookieJar: { getOrCreateForParentId: (parentId: string) => Promise<CookieJar> };
       response: {
-        getLatestForRequestId: typeof getLatestForRequest;
+        getLatestForRequestId: typeof getLatestForRequestId;
         getBodyBuffer: typeof getBodyBuffer;
       };
       settings: {

--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -36,7 +36,7 @@ import { GitProjectRepositorySettingsModal } from '../modals/git-repository-sett
 import { SyncMergeModal } from '../modals/sync-merge-modal';
 import { showToast } from '../toast-notification';
 interface Props {
-  gitRepository: GitRepository | null;
+  gitRepository?: GitRepository;
 }
 
 export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository }) => {

--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -374,7 +374,7 @@ const renderAccessTokenExpiry = (token?: Pick<OAuth2Token, 'accessToken' | 'expi
 };
 
 const OAuth2TokenInput: FC<{
-  token: OAuth2Token | null;
+  token?: OAuth2Token;
   label: string;
   property: keyof Pick<OAuth2Token, 'accessToken' | 'refreshToken' | 'identityToken'>;
 }> = ({ token, label, property }) => {
@@ -413,7 +413,7 @@ const OAuth2TokenInput: FC<{
   );
 };
 
-const OAuth2Error: FC<{ token: OAuth2Token | null }> = ({ token }) => {
+const OAuth2Error: FC<{ token?: OAuth2Token }> = ({ token }) => {
   const debug = () => {
     if (!token || !token.xResponseId) {
       return;
@@ -459,7 +459,7 @@ const OAuth2Tokens: FC = () => {
   const reqData = useRequestLoaderData() as RequestLoaderData;
   const groupData = useRequestGroupLoaderData() as RequestGroupLoaderData;
   const { authentication, _id } = reqData?.activeRequest || groupData.activeRequestGroup;
-  const [token, setToken] = useState<OAuth2Token | null>(null);
+  const [token, setToken] = useState<OAuth2Token | undefined>();
   useEffect(() => {
     const fn = async () => {
       const token = await models.oAuth2Token.getByParentId(_id);
@@ -490,7 +490,7 @@ const OAuth2Tokens: FC = () => {
             disabled={!token}
             onClick={() => {
               if (token) {
-                setToken(null);
+                setToken(undefined);
                 models.oAuth2Token.remove(token);
               }
             }}
@@ -513,7 +513,7 @@ const OAuth2Tokens: FC = () => {
             } catch (err) {
               // Clear existing tokens if there's an error
               if (token) {
-                setToken(null);
+                setToken(undefined);
                 models.oAuth2Token.remove(token);
               }
               setError(err.message);

--- a/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/body/graph-ql-editor.tsx
@@ -133,7 +133,7 @@ const fetchGraphQLSchemaForRequest = async ({
       operationName: 'IntrospectionQuery',
     });
 
-    const introspectionRequest = await db.upsert(
+    const introspectionRequest = await db.update(
       Object.assign({}, req, {
         _id: req._id + '.graphql',
         settingMaxTimelineDataSize: 5000,

--- a/packages/insomnia/src/ui/components/editors/mock-response-extractor.tsx
+++ b/packages/insomnia/src/ui/components/editors/mock-response-extractor.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { Button } from 'react-aria-components';
 import { useNavigate, useParams } from 'react-router';
 
+import { isSocketIOResponse } from '~/models/socket-io-response';
 import { useOrganizationLoaderData } from '~/routes/organization';
 import { useRequestLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId';
 import {
@@ -13,7 +14,7 @@ import {
 import { useMockRouteNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.new';
 
 import { getContentTypeName, getMimeTypeFromContentType } from '../../../common/constants';
-import type { ResponseHeader } from '../../../models/response';
+import { type ResponseHeader } from '../../../models/response';
 import { useWorkspaceLoaderData } from '../../../routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { invariant } from '../../../utils/invariant';
 import { HelpTooltip } from '../help-tooltip';
@@ -68,6 +69,31 @@ If you want to create a self-hosted mock server route from a request response in
     canOnlyChooseExistingMockServer ? mockServerAndRoutes[0]._id : '',
   );
   const [selectedMockRoute, setSelectedMockRoute] = useState('');
+  if (tipPreventingUserFromCreatingMockRoute) {
+    return (
+      <div className="flex h-full flex-col justify-center px-32">
+        <div className="flex place-content-center pb-8 text-9xl text-[--hl-md]">
+          <Icon icon="cube" />
+        </div>
+        <div className="flex place-content-center whitespace-pre-line pb-2">
+          {tipPreventingUserFromCreatingMockRoute}
+        </div>
+      </div>
+    );
+  }
+  if (activeResponse && isSocketIOResponse(activeResponse) && !('contentType' in activeResponse)) {
+    return (
+      <div className="flex h-full flex-col justify-center px-32">
+        <div className="flex place-content-center pb-8 text-9xl text-[--hl-md]">
+          <Icon icon="cube" />
+        </div>
+        <div className="flex place-content-center whitespace-pre-line pb-2">
+          You can't create a mock server route from a Socket.IO response
+        </div>
+      </div>
+    );
+  }
+
   const maybeMimeType = activeResponse && getMimeTypeFromContentType(activeResponse.contentType);
   const mimeType = maybeMimeType && isInMockContentTypeList(maybeMimeType) ? maybeMimeType : 'text/plain';
   return (
@@ -75,190 +101,182 @@ If you want to create a self-hosted mock server route from a request response in
       <div className="flex place-content-center pb-8 text-9xl text-[--hl-md]">
         <Icon icon="cube" />
       </div>
-      {tipPreventingUserFromCreatingMockRoute ? (
-        <div className="flex place-content-center whitespace-pre-line pb-2">
-          {tipPreventingUserFromCreatingMockRoute}
-        </div>
-      ) : (
-        <>
-          <div className="flex place-content-center pb-2">
-            Transform this
-            {activeResponse?.contentType
-              ? getContentTypeName(activeResponse?.contentType) === 'Other'
-                ? ''
-                : ` ${getContentTypeName(activeResponse?.contentType)}`
-              : ''}{' '}
-            response to a new mock route or overwrite an existing one.
-          </div>
-          <form
-            onSubmit={async e => {
-              e.preventDefault();
-              if (selectedMockServer && selectedMockRoute) {
-                if (activeResponse && 'bodyPath' in activeResponse) {
-                  // TODO: move this out of the renderer, and upsert mock
-                  const body = await fs.readFile(activeResponse.bodyPath);
+      <div className="flex place-content-center pb-2">
+        Transform this
+        {activeResponse?.contentType
+          ? getContentTypeName(activeResponse?.contentType) === 'Other'
+            ? ''
+            : ` ${getContentTypeName(activeResponse?.contentType)}`
+          : ''}{' '}
+        response to a new mock route or overwrite an existing one.
+      </div>
+      <form
+        onSubmit={async e => {
+          e.preventDefault();
+          if (selectedMockServer && selectedMockRoute) {
+            if (activeResponse && 'bodyPath' in activeResponse) {
+              // TODO: move this out of the renderer, and upsert mock
+              const body = await fs.readFile(activeResponse.bodyPath);
 
-                  patchMockRoute(selectedMockRoute, {
+              patchMockRoute(selectedMockRoute, {
+                body: body.toString(),
+                mimeType,
+                statusCode: activeResponse.statusCode,
+                headers: activeResponse.headers,
+              });
+            }
+            return;
+          }
+          let path = '/new-route';
+          try {
+            path = activeResponse ? new URL(activeResponse.url).pathname : '/new-route';
+          } catch (e) {
+            console.log(e);
+          }
+          // Create new mock server and route
+          if (!selectedMockServer) {
+            showModal(PromptModal, {
+              title: 'Create Mock Route',
+              defaultValue: path,
+              label: 'Name',
+              onComplete: async name => {
+                invariant(activeResponse, 'Active response must be defined');
+                const body = 'bodyPath' in activeResponse ? await fs.readFile(activeResponse.bodyPath) : '';
+                // auth mechanism is too sensitive to allow content length checks
+                const headersWithoutContentLength: ResponseHeader[] = activeResponse.headers.filter(
+                  h => h.name.toLowerCase() !== 'content-length',
+                );
+
+                createMockRouteFetcher.submit({
+                  organizationId,
+                  projectId,
+                  workspaceId,
+                  patch: {
+                    name: name,
                     body: body.toString(),
                     mimeType,
                     statusCode: activeResponse.statusCode,
-                    headers: activeResponse.headers,
+                    headers: headersWithoutContentLength,
+                    mockServerName: activeWorkspace.name,
+                  },
+                });
+              },
+            });
+            return;
+          }
+          // Create new mock route
+          if (!selectedMockRoute) {
+            showModal(PromptModal, {
+              title: 'Create Mock Route',
+              defaultValue: path,
+              label: 'Name',
+              onComplete: async name => {
+                invariant(activeResponse, 'Active response must be defined');
+                const body = 'bodyPath' in activeResponse ? await fs.readFile(activeResponse.bodyPath) : '';
+                const hasRouteInServer = mockServerAndRoutes
+                  .find(s => s._id === selectedMockServer)
+                  ?.routes.find(r => r.name === name && r.method.toUpperCase() === 'GET');
+                if (hasRouteInServer) {
+                  showModal(AlertModal, {
+                    title: 'Error',
+                    message: `Path "${name}" and method must be unique. Please enter a different name.`,
                   });
+                  return;
                 }
-                return;
-              }
-              let path = '/new-route';
-              try {
-                path = activeResponse ? new URL(activeResponse.url).pathname : '/new-route';
-              } catch (e) {
-                console.log(e);
-              }
-              // Create new mock server and route
-              if (!selectedMockServer) {
-                showModal(PromptModal, {
-                  title: 'Create Mock Route',
-                  defaultValue: path,
-                  label: 'Name',
-                  onComplete: async name => {
-                    invariant(activeResponse, 'Active response must be defined');
-                    const body = 'bodyPath' in activeResponse ? await fs.readFile(activeResponse.bodyPath) : '';
-                    // auth mechanism is too sensitive to allow content length checks
-                    const headersWithoutContentLength: ResponseHeader[] = activeResponse.headers.filter(
-                      h => h.name.toLowerCase() !== 'content-length',
-                    );
-
-                    createMockRouteFetcher.submit({
-                      organizationId,
-                      projectId,
-                      workspaceId,
-                      patch: {
-                        name: name,
-                        body: body.toString(),
-                        mimeType,
-                        statusCode: activeResponse.statusCode,
-                        headers: headersWithoutContentLength,
-                        mockServerName: activeWorkspace.name,
-                      },
-                    });
+                // auth mechanism is too sensitive to allow content length checks
+                const headersWithoutContentLength: ResponseHeader[] = activeResponse.headers.filter(
+                  h => h.name.toLowerCase() !== 'content-length',
+                );
+                createMockRouteFetcher.submit({
+                  organizationId,
+                  projectId,
+                  workspaceId,
+                  patch: {
+                    name: name,
+                    parentId: selectedMockServer,
+                    body: body.toString(),
+                    mimeType,
+                    statusCode: activeResponse.statusCode,
+                    headers: headersWithoutContentLength,
                   },
                 });
-                return;
-              }
-              // Create new mock route
-              if (!selectedMockRoute) {
-                showModal(PromptModal, {
-                  title: 'Create Mock Route',
-                  defaultValue: path,
-                  label: 'Name',
-                  onComplete: async name => {
-                    invariant(activeResponse, 'Active response must be defined');
-                    const body = 'bodyPath' in activeResponse ? await fs.readFile(activeResponse.bodyPath) : '';
-                    const hasRouteInServer = mockServerAndRoutes
-                      .find(s => s._id === selectedMockServer)
-                      ?.routes.find(r => r.name === name && r.method.toUpperCase() === 'GET');
-                    if (hasRouteInServer) {
-                      showModal(AlertModal, {
-                        title: 'Error',
-                        message: `Path "${name}" and method must be unique. Please enter a different name.`,
-                      });
-                      return;
-                    }
-                    // auth mechanism is too sensitive to allow content length checks
-                    const headersWithoutContentLength: ResponseHeader[] = activeResponse.headers.filter(
-                      h => h.name.toLowerCase() !== 'content-length',
-                    );
-                    createMockRouteFetcher.submit({
-                      organizationId,
-                      projectId,
-                      workspaceId,
-                      patch: {
-                        name: name,
-                        parentId: selectedMockServer,
-                        body: body.toString(),
-                        mimeType,
-                        statusCode: activeResponse.statusCode,
-                        headers: headersWithoutContentLength,
-                      },
-                    });
-                  },
-                });
-              }
-            }}
-          >
-            <div className="form-row">
-              <div className="form-control form-control--outlined">
-                <label>
-                  Choose Mock Server
-                  <HelpTooltip position="top" className="space-left">
-                    Select from created mock servers to add the route to
-                  </HelpTooltip>
-                  <select
-                    value={selectedMockServer}
-                    onChange={event => {
-                      const selected = event.currentTarget.value;
-                      setSelectedMockServer(selected);
-                      setSelectedMockRoute('');
-                    }}
-                  >
-                    {!canOnlyChooseExistingMockServer && <option value="">-- Create new --</option>}
-                    {mockServerAndRoutes.map(w => (
-                      <option key={w._id} value={w._id}>
-                        {w.name}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-              </div>
-            </div>
-            <div className="form-row">
-              <div className="form-control form-control--outlined">
-                <label>
-                  Choose Mock Route
-                  <HelpTooltip position="top" className="space-left">
-                    Select from created mock routes to overwrite with this response
-                  </HelpTooltip>
-                  <select
-                    value={selectedMockRoute}
-                    onChange={event => {
-                      const selected = event.currentTarget.value;
-                      setSelectedMockRoute(selected);
-                    }}
-                  >
-                    <option value="">-- Create new --</option>
-                    {mockServerAndRoutes
-                      .find(s => s._id === selectedMockServer)
-                      ?.routes.map(w => (
-                        <option key={w._id} value={w._id}>
-                          {w.name}
-                        </option>
-                      ))}
-                  </select>
-                </label>
-              </div>
-            </div>
-            <div className="mt-2 flex">
-              <Button
-                type="submit"
-                className="mr-2 rounded-sm border border-solid border-[--hl-md] bg-[rgba(var(--color-surprise-rgb),var(--tw-bg-opacity))] bg-opacity-100 px-3 py-2 text-[--color-font-surprise] transition-colors hover:bg-opacity-90 hover:no-underline focus:ring-[--hl-md] aria-pressed:bg-opacity-80"
-              >
-                {selectedMockRoute ? 'Overwrite' : 'Create'}
-              </Button>
-              <Button
-                isDisabled={!selectedMockServer || !selectedMockRoute}
-                onPress={() => {
-                  const mockWorkspaceId = mockServerAndRoutes.find(s => s._id === selectedMockServer)?.parentId;
-                  navigate(
-                    `/organization/${organizationId}/project/${projectId}/workspace/${mockWorkspaceId}/mock-server/mock-route/${selectedMockRoute}`,
-                  );
+              },
+            });
+          }
+        }}
+      >
+        <div className="form-row">
+          <div className="form-control form-control--outlined">
+            <label>
+              Choose Mock Server
+              <HelpTooltip position="top" className="space-left">
+                Select from created mock servers to add the route to
+              </HelpTooltip>
+              <select
+                value={selectedMockServer}
+                onChange={event => {
+                  const selected = event.currentTarget.value;
+                  setSelectedMockServer(selected);
+                  setSelectedMockRoute('');
                 }}
-                className="flex items-center justify-center gap-2 rounded-sm bg-[--hl-xxs] px-3 py-2 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
               >
-                Go to mock
-              </Button>
-            </div>
-          </form>
-        </>
-      )}
+                {!canOnlyChooseExistingMockServer && <option value="">-- Create new --</option>}
+                {mockServerAndRoutes.map(w => (
+                  <option key={w._id} value={w._id}>
+                    {w.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </div>
+        <div className="form-row">
+          <div className="form-control form-control--outlined">
+            <label>
+              Choose Mock Route
+              <HelpTooltip position="top" className="space-left">
+                Select from created mock routes to overwrite with this response
+              </HelpTooltip>
+              <select
+                value={selectedMockRoute}
+                onChange={event => {
+                  const selected = event.currentTarget.value;
+                  setSelectedMockRoute(selected);
+                }}
+              >
+                <option value="">-- Create new --</option>
+                {mockServerAndRoutes
+                  .find(s => s._id === selectedMockServer)
+                  ?.routes.map(w => (
+                    <option key={w._id} value={w._id}>
+                      {w.name}
+                    </option>
+                  ))}
+              </select>
+            </label>
+          </div>
+        </div>
+        <div className="mt-2 flex">
+          <Button
+            type="submit"
+            className="mr-2 rounded-sm border border-solid border-[--hl-md] bg-[rgba(var(--color-surprise-rgb),var(--tw-bg-opacity))] bg-opacity-100 px-3 py-2 text-[--color-font-surprise] transition-colors hover:bg-opacity-90 hover:no-underline focus:ring-[--hl-md] aria-pressed:bg-opacity-80"
+          >
+            {selectedMockRoute ? 'Overwrite' : 'Create'}
+          </Button>
+          <Button
+            isDisabled={!selectedMockServer || !selectedMockRoute}
+            onPress={() => {
+              const mockWorkspaceId = mockServerAndRoutes.find(s => s._id === selectedMockServer)?.parentId;
+              navigate(
+                `/organization/${organizationId}/project/${projectId}/workspace/${mockWorkspaceId}/mock-server/mock-route/${selectedMockRoute}`,
+              );
+            }}
+            className="flex items-center justify-center gap-2 rounded-sm bg-[--hl-xxs] px-3 py-2 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+          >
+            Go to mock
+          </Button>
+        </div>
+      </form>
     </div>
   );
 };

--- a/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
@@ -590,7 +590,7 @@ export const RequestScriptEditor: FC<Props> = ({ className, defaultValue, onChan
       clientCertificates: [],
       cookies: new CookieObject({
         _id: '',
-        type: '',
+        type: 'CookieJar',
         parentId: '',
         modified: 0,
         created: 0,

--- a/packages/insomnia/src/ui/components/modals/__tests__/import-export.test.ts
+++ b/packages/insomnia/src/ui/components/modals/__tests__/import-export.test.ts
@@ -109,7 +109,7 @@ describe('exportWorkspacesHAR() and exportRequestsHAR()', () => {
   });
 
   it('exports all workspaces as an HTTP Archive', async () => {
-    await db.init(models.types(), { inMemoryOnly: true }, true, () => {});
+    await db.init({ inMemoryOnly: true }, true, () => {});
 
     const wrk1 = await models.workspace.create({
       _id: 'wrk_1',

--- a/packages/insomnia/src/ui/components/modals/proto-files-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/proto-files-modal.tsx
@@ -122,7 +122,7 @@ export const ProtoFilesModal: FC<Props> = ({ defaultId, onHide, onSave }) => {
   }, [workspaceId]);
 
   useEffect(() => {
-    db.onChange(async (changes: ChangeBufferEvent[]) => {
+    const unsubscribe = window.main.on('db.changes', async (_, changes: ChangeBufferEvent[]) => {
       for (const change of changes) {
         const [, doc] = change;
         if (isProtoFile(doc) || isProtoDirectory(doc)) {
@@ -130,6 +130,9 @@ export const ProtoFilesModal: FC<Props> = ({ defaultId, onHide, onSave }) => {
         }
       }
     });
+    return () => {
+      unsubscribe();
+    };
   }, [workspaceId]);
 
   const handleAddDirectory = async () => {

--- a/packages/insomnia/src/ui/components/modals/proto-files-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/proto-files-modal.tsx
@@ -137,7 +137,7 @@ export const ProtoFilesModal: FC<Props> = ({ defaultId, onHide, onSave }) => {
 
   const handleAddDirectory = async () => {
     let rollback = false;
-    let createdIds: string[];
+    let createdIds: string[] = [];
     const bufferId = await db.bufferChangesIndefinitely();
     const filePath = await tryToSelectFolderPath();
     if (!filePath) {
@@ -202,10 +202,22 @@ export const ProtoFilesModal: FC<Props> = ({ defaultId, onHide, onSave }) => {
       await db.flushChanges(bufferId, rollback);
 
       if (rollback) {
-        // @ts-expect-error -- TSCONVERSION
-        await models.protoDirectory.batchRemoveIds(createdIds);
-        // @ts-expect-error -- TSCONVERSION
-        await models.protoFile.batchRemoveIds(createdIds);
+        const dirs = await db.find('ProtoDirectory', {
+          _id: {
+            $in: createdIds,
+          },
+        });
+        for (const dir of dirs) {
+          await db.unsafeRemove(dir);
+        }
+        const files = await db.find('ProtoFile', {
+          _id: {
+            $in: createdIds,
+          },
+        });
+        for (const file of files) {
+          await db.unsafeRemove(file);
+        }
       }
     }
   };

--- a/packages/insomnia/src/ui/components/tabs/tab-list.tsx
+++ b/packages/insomnia/src/ui/components/tabs/tab-list.tsx
@@ -213,7 +213,7 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
 
   useEffect(() => {
     // sync tabList with database
-    const callback = async (changes: ChangeBufferEvent[]) => {
+    const unsubscribe = window.main.on('db.changes', async (_, changes: ChangeBufferEvent[]) => {
       for (const change of changes) {
         const changeType = change[0];
         const doc = change[1];
@@ -226,11 +226,10 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
           }
         }
       }
-    };
-    database.onChange(callback);
+    });
 
     return () => {
-      database.offChange(callback);
+      unsubscribe();
     };
   }, [handleDelete, handleUpdate]);
 

--- a/packages/insomnia/src/ui/hooks/use-vcs-version.ts
+++ b/packages/insomnia/src/ui/hooks/use-vcs-version.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
 
-import { type ChangeBufferEvent, database } from '../../common/database';
+import { type ChangeBufferEvent } from '../../common/database';
 import type { BaseModel } from '../../models';
 import { useProjectIndexLoaderData } from '../../routes/organization.$organizationId.project.$projectId._index';
 import { useWorkspaceLoaderData } from '../../routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
@@ -14,7 +14,14 @@ export function useActiveRequestSyncVCSVersion() {
   useEffect(() => {
     const isRequestUpdatedFromSync = (changes: ChangeBufferEvent<BaseModel>[]) =>
       changes.find(([, doc, fromSync]) => requestId === doc._id && fromSync);
-    database.onChange(changes => isRequestUpdatedFromSync(changes) && setVersion(v => v + 1));
+    const unsubscribe = window.main.on('db.changes', async (_, changes) => {
+      if (isRequestUpdatedFromSync(changes)) {
+        setVersion(v => v + 1);
+      }
+    });
+    return () => {
+      unsubscribe();
+    };
   }, [requestId]);
 
   return version;
@@ -29,7 +36,14 @@ export function useActiveApiSpecSyncVCSVersion() {
   useEffect(() => {
     const isRequestUpdatedFromSync = (changes: ChangeBufferEvent<BaseModel>[]) =>
       changes.find(([, doc, fromSync]) => workspaceData?.activeApiSpec?._id === doc._id && fromSync);
-    database.onChange(changes => isRequestUpdatedFromSync(changes) && setVersion(v => v + 1));
+    const unsubscribe = window.main.on('db.changes', async (_, changes) => {
+      if (isRequestUpdatedFromSync(changes)) {
+        setVersion(v => v + 1);
+      }
+    });
+    return () => {
+      unsubscribe();
+    };
   }, [workspaceData?.activeApiSpec?._id]);
 
   return version;

--- a/packages/insomnia/src/ui/rendererListeners.ts
+++ b/packages/insomnia/src/ui/rendererListeners.ts
@@ -26,13 +26,15 @@ if (isDevelopment()) {
       value: options[0].value,
       options,
       onDone: async (type: string | null) => {
-        if (type) {
-          const bufferId = await database.bufferChanges();
-          console.log(`[developer] clearing all "${type}" entities`);
-          const allEntities = await database.find(type);
-          await database.batchModifyDocs({ remove: allEntities });
-          database.flushChanges(bufferId);
+        if (!type || !models.isValidType(type)) {
+          console.error(`[developer] invalid model type: ${type}`);
+          return;
         }
+        const bufferId = await database.bufferChanges();
+        console.log(`[developer] clearing all "${type}" entities`);
+        const allEntities = await database.find(type);
+        await database.batchModifyDocs({ remove: allEntities });
+        database.flushChanges(bufferId);
       },
     });
   });

--- a/packages/insomnia/src/ui/rendererListeners.ts
+++ b/packages/insomnia/src/ui/rendererListeners.ts
@@ -33,6 +33,7 @@ if (isDevelopment()) {
         const bufferId = await database.bufferChanges();
         console.log(`[developer] clearing all "${type}" entities`);
         const allEntities = await database.find(type);
+        // TODO: this could be done with a removeMany
         await database.batchModifyDocs({ remove: allEntities });
         database.flushChanges(bufferId);
       },
@@ -55,6 +56,7 @@ if (isDevelopment()) {
             .map(async type => {
               console.log(`[developer] clearing all "${type}" entities`);
               const allEntities = await database.find(type);
+              // TODO: this could be done with a removeMany
               await database.batchModifyDocs({ remove: allEntities });
             });
           await Promise.all(promises);

--- a/packages/insomnia/src/ui/rendererListeners.ts
+++ b/packages/insomnia/src/ui/rendererListeners.ts
@@ -29,7 +29,7 @@ if (isDevelopment()) {
         if (type) {
           const bufferId = await database.bufferChanges();
           console.log(`[developer] clearing all "${type}" entities`);
-          const allEntities = await database.all(type);
+          const allEntities = await database.find(type);
           await database.batchModifyDocs({ remove: allEntities });
           database.flushChanges(bufferId);
         }
@@ -52,7 +52,7 @@ if (isDevelopment()) {
             .reverse()
             .map(async type => {
               console.log(`[developer] clearing all "${type}" entities`);
-              const allEntities = await database.all(type);
+              const allEntities = await database.find(type);
               await database.batchModifyDocs({ remove: allEntities });
             });
           await Promise.all(promises);

--- a/packages/insomnia/src/utils/router.ts
+++ b/packages/insomnia/src/utils/router.ts
@@ -70,7 +70,7 @@ export const getInitialRouteForOrganization = async ({
     }
   }
   // 2. if no history, redirect to the first project
-  const firstProject = await database.getWhere<Project>(models.project.type, { parentId: organizationId });
+  const firstProject = await database.findOne<Project>(models.project.type, { parentId: organizationId });
 
   if (firstProject?._id) {
     return href(`/organization/:organizationId/project/:projectId`, {


### PR DESCRIPTION
motivation: lots of work in the pipeline will need to be able to make db changes from differnt processes and race conditions may emerge, this effort is to simplify the db object down to its minimum in order to better debug issue when they occur.

objective: simplify db layer without any changes in behaviour

ideas of stuff to prune away:

- [x] unused hooks
- [x] _empty
- [x] all
- [x] get
- [x] getWhere
- [x] getMostRecent
- [x] string union db type
- [x] use async methods
- [x] move change listener
- [x] remove upsert function and make update always upsert

risks
- making change to batch modify and withDescendent could break remote sync in unpredicatable ways.
- removing db functions could break plugins, but we have an explicit plugin api now in the worker template db which can be used.
- making changes to initModel could also break remote sync because we can't guarentee there isnt old versions of our data in the branch.

ideas
- we might want to consider making withAncestors and withDescendents less powerful since they can be very slow. An idea would be to fit their specific purpose, eg get request groups and workspace. Which is 9 out of 10 use cases.
- we could use a versioning mechanism or something clever to skip migrations, that way we can move migration out of the hot path into only init and remote sync phases
- we should split batch modify for remote sync and batchmodify to other things as they have very different concerns.
- after initModel and migrations are added to remote sync upsert and db.init there is no need to initModel in find
- add a domain model to optimise withDescents and with ancestors so they dont need to recurse over every model everytime

future work
- merge batchmodify and remote sync and simplify
- remove initModel from queries after remote sync is done
- merge models into database to give a database.request.getById like api. casing issues. self reference
- domain model
- consider how to split init phases to eliminate the self referencing functions.
- add a way to init via import file or nedb objects
- maybe add aliases for removed methods if we find there is plugin usage.
- move change listeners to the ipc bridge instead of the insert update delete functions.
- get rid of fromSync hack and replace with a watcher like git sync does, with last commit and snapshot hash to trigger reloads instead.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
