### PR TITLE
fix: Improve error handling and success notifications for Git push operation [INS-1140]

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -125,26 +125,36 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository }) => {
   }, [gitStatusFetcher, projectId, shouldFetchGitRepoStatus]);
 
   useEffect(() => {
-    const errors = [...(gitPushFetcher.data?.errors ?? [])];
+    const data = gitPushFetcher.data;
+    if (!data) return;
+
+    const errors = data.errors ?? [];
+
     if (errors.length > 0) {
-      setPushCount(prevCount => prevCount + 1);
+      setPushCount(prev => prev + 1);
 
-      const hasPullError = errors.includes(GitVCSOperationErrors.RequiredPullRemoteChangesError);
-
-      if (hasPullError) {
-        !prevHadPullError.current && !isGitPullRequiredModalOpen && !isPulling && setIsGitPullRequiredModalOpen(true);
-      } else {
-        showToast({
-          icon,
-          title: `Push failed`,
-          status: 'error',
-        });
-        setOperationError(errors.join('\n'));
+      if (errors.includes(GitVCSOperationErrors.RequiredPullRemoteChangesError)) {
+        if (!prevHadPullError.current && !isGitPullRequiredModalOpen && !isPulling) {
+          setIsGitPullRequiredModalOpen(true);
+        }
+        return;
       }
-    } else if (gitPushFetcher.data && 'success' in gitPushFetcher.data && gitPushFetcher.data.success && !isPulling) {
+
+      // Other errors
       showToast({
         icon,
-        title: `Push completed`,
+        title: 'Push failed',
+        status: 'error',
+      });
+      setOperationError(errors.join('\n'));
+      return;
+    }
+
+    // Success
+    if ('success' in data && data.success && !isPulling) {
+      showToast({
+        icon,
+        title: 'Push completed',
         status: 'success',
       });
     }
@@ -648,7 +658,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository }) => {
             fetchStatus();
           }}
           onClose={() => {
-            prevHadPullError.current = true;
+            prevHadPullError.current = false;
 
             setIsGitStagingModalOpen(false);
             setStagingMode(StagingModalModes.default);
@@ -681,7 +691,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository }) => {
             fetchStatus();
           }}
           onClose={() => {
-            prevHadPullError.current = true;
+            prevHadPullError.current = false;
             setIsGitPullRequiredModalOpen(false);
           }}
         />

--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -136,9 +136,12 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository }) => {
       if (errors.includes(GitVCSOperationErrors.RequiredPullRemoteChangesError)) {
         if (!prevHadPullError.current && !isGitPullRequiredModalOpen && !isPulling) {
           setIsGitPullRequiredModalOpen(true);
+          prevHadPullError.current = false;
         }
         return;
       }
+
+      prevHadPullError.current = false;
 
       // Other errors
       showToast({


### PR DESCRIPTION
If a push is rejected then it just fails silently. I.e. it displays the "Push started" toast and then nothing else.

Closes INS-1140