### PR TITLE
feat(Maintain localStorage data): Keep localStorage saved data after migrating from the file:// protocol

### DIFF
--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -195,6 +195,7 @@ async function _unsetSessionData() {
   });
 }
 
+// TODO: v12 remove this function and getLocalStorageDataFromFileOrigin from main
 export async function migrateFromLocalStorage() {
   if (!window.localStorage.getItem('file-origin-localStorage-migrated')) {
     console.log('[migration] Migrating localStorage data from file origin');

--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -196,6 +196,22 @@ async function _unsetSessionData() {
 }
 
 export async function migrateFromLocalStorage() {
+  if (!window.localStorage.getItem('file-origin-localStorage-migrated')) {
+    console.log('[migration] Migrating localStorage data from file origin');
+    try {
+      const localStorageData = await window.main.getLocalStorageDataFromFileOrigin();
+      if (localStorageData) {
+        for (const [key, value] of Object.entries(localStorageData)) {
+          if (key && value) {
+            localStorage.setItem(key, value);
+          }
+        }
+        localStorage.setItem('file-origin-localStorage-migrated', 'true');
+      }
+    } catch (error) {
+      console.error('[migration] Failed to migrate localStorage data:', error);
+    }
+  }
   const sessionId = window.localStorage.getItem('currentSessionId');
 
   if (!sessionId) {

--- a/packages/insomnia/src/entry.client.tsx
+++ b/packages/insomnia/src/entry.client.tsx
@@ -23,6 +23,11 @@ import { getInitialEntry } from './utils/router';
 
 initializeSentry();
 
+await database.initClient();
+await initPlugins();
+
+await migrateFromLocalStorage();
+
 try {
   window.showAlert = options => showModal(AlertModal, options);
   window.showPrompt = options =>
@@ -47,11 +52,6 @@ try {
 } catch (e) {
   console.log('[onboarding] Failed to parse session data', e);
 }
-
-await database.initClient();
-await initPlugins();
-
-await migrateFromLocalStorage();
 
 // Check if there is a Session provided by an env variable and use this
 const insomniaSession = getInsomniaSession();

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -175,6 +175,7 @@ const main: Window['main'] = {
   },
   extractJsonFileFromPostmanDataDumpArchive: archivePath =>
     ipcRenderer.invoke('extractJsonFileFromPostmanDataDumpArchive', archivePath),
+  getLocalStorageDataFromFileOrigin: () => ipcRenderer.invoke('getLocalStorageDataFromFileOrigin'),
 };
 
 ipcRenderer.on('hidden-browser-window-response-listener', event => {

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -89,7 +89,8 @@ export type HandleChannels =
   | 'git.getGitHubRepository'
   | 'git.initSignInToGitLab'
   | 'git.completeSignInToGitLab'
-  | 'git.signOutOfGitLab';
+  | 'git.signOutOfGitLab'
+  | 'getLocalStorageDataFromFileOrigin';
 
 export const ipcMainHandle = (
   channel: HandleChannels,

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -103,6 +103,7 @@ export interface RendererToMainBridgeAPI {
   completeExecutionStep: (options: { requestId: string }) => void;
   updateLatestStepName: (options: { requestId: string; stepName: string }) => void;
   extractJsonFileFromPostmanDataDumpArchive: (archivePath: string) => Promise<any>;
+  getLocalStorageDataFromFileOrigin: () => Promise<Record<string, any>>;
 }
 
 export function registerMainHandlers() {
@@ -273,4 +274,45 @@ export function registerMainHandlers() {
   });
 
   ipcMainHandle('extractJsonFileFromPostmanDataDumpArchive', extractPostmanDataDumpHandler);
+
+  ipcMainHandle('getLocalStorageDataFromFileOrigin', async () => {
+    const tmpDir = app.getPath('userData');
+    const tmpHTMLFile = path.join(tmpDir, 'file.html');
+    // Create a temporary HTML file to load the file:// origin
+    await fs.promises.writeFile(tmpHTMLFile, '<html><body></body></html>', { encoding: 'utf8' });
+
+    // Create a hidden BrowserWindow to load the file:// origin
+    // This is necessary to access the localStorage of the file:// origin
+    // and retrieve the data.
+    const fileOriginWindow = new BrowserWindow({
+      show: false,
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        sandbox: true,
+      },
+    });
+
+    fileOriginWindow.loadURL(`file:${tmpHTMLFile}`);
+
+    return new Promise<Record<string, any>>((resolve, reject) => {
+      fileOriginWindow.webContents.on('did-finish-load', async () => {
+        const localStorageData = await fileOriginWindow.webContents.executeJavaScript(
+          'JSON.stringify(localStorage)',
+          true,
+        );
+        // Close the hidden window after retrieving localStorage data
+        fileOriginWindow.close();
+        // Clean up the temporary file
+        fs.unlinkSync(tmpHTMLFile);
+        resolve(JSON.parse(localStorageData));
+      });
+      fileOriginWindow.webContents.on('did-fail-load', () => {
+        // Close the hidden window and clean up the temporary file on failure
+        fileOriginWindow.close();
+        tmpHTMLFile && fs.unlinkSync(tmpHTMLFile);
+        reject(new Error('Failed to load file:// origin to get localStorage data'));
+      });
+    });
+  });
 }

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -301,6 +301,9 @@ export function registerMainHandlers() {
           'JSON.stringify(localStorage)',
           true,
         );
+
+        // Clear the localStorage of the file:// origin
+        await fileOriginWindow.webContents.executeJavaScript('localStorage.clear();', true);
         // Close the hidden window after retrieving localStorage data
         fileOriginWindow.close();
         // Clean up the temporary file


### PR DESCRIPTION
# Overview

We recently migrated from the `file://` protocol to using a custom handler to serve the index.html and other associated assets for the app.
This migration creates an issue where data stored in localStorage are now not available in the new origin.

## Impact:
- Users will see again the v11 onboarding even if they have seen it before.
- Stored filters will be lost (e.g. a filter on the files for the project view)

## Alternatives considered:

| Approach | Outcome |
|----------|---------|
| Keep using `file://` protocol | ❌ **Not recommended** - [Goes against Electron security recommendations](https://www.electronjs.org/docs/latest/tutorial/security#18-avoid-usage-of-the-file-protocol-and-prefer-usage-of-custom-protocols) and is the main reason for changing this implementation |
| Access localStorage data directly from LevelDB | ❌ **Not ideal** - Requires implementing a database adapter, adds complexity, and may break with Chromium updates to storage format |
| Use Electron's native APIs | ❌ **Not possible** - No native Electron API exists to access localStorage for specific origins ([confirmed limitation](https://github.com/electron/electron/issues/9110)) |

## Approach of this PR
- We expose a new function from the main process. This creates a new window targeting a temporary html file and uses the `file://` protocol and retrieves the localStorage data.
- We then copy that data to the new origin and set a flag that this migration should not be run again.
- We also clear the localStorage of the file protocol to make sure that even if the migration re-runs there will not be side-effects.

## Next steps
- LocalStorage is used for volatile state so we need to make sure it's okay for it to be cleared between versions.
- This migration logic will be removed on the upcoming v12 major release