### PR TITLE
bump: @kong/insomnia-plugin-external-vault

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3941,9 +3941,9 @@
       "license": "MIT"
     },
     "node_modules/@kong/insomnia-plugin-external-vault": {
-      "version": "0.1.0-alpha.2",
-      "resolved": "https://npm.pkg.github.com/download/@kong/insomnia-plugin-external-vault/0.1.0-alpha.2/721fa22512bfc714085c4fed4c9ed097ba4cb23a",
-      "integrity": "sha512-YxD5r67lSTaMo6MJAOnT2g31EtGhumZ8e47Sx6VFIlPPQHcvntCZv1oCz1WLWAUiHtScn99725Lt0fx8fmDgNg==",
+      "version": "0.1.0-alpha.3",
+      "resolved": "https://npm.pkg.github.com/download/@kong/insomnia-plugin-external-vault/0.1.0-alpha.3/ac387ade735e35617f88a64e0ecba9ee0a318102",
+      "integrity": "sha512-BEYPReGpzbBP70nG6QMDl1J5AWfmsp6je7clOe4DR0Ut+dTT+x+yH7BHwcM0c3D0MSlNlMHT4Lxs6oT4ZQY9Hg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -27898,7 +27898,7 @@
         "@getinsomnia/node-libcurl": "3.0.0",
         "@grpc/grpc-js": "^1.13.3",
         "@grpc/proto-loader": "^0.7.13",
-        "@kong/insomnia-plugin-external-vault": "^0.1.0-alpha.2",
+        "@kong/insomnia-plugin-external-vault": "^0.1.0-alpha.3",
         "@seald-io/nedb": "^4.1.1",
         "@segment/analytics-node": "2.2.1",
         "apiconnect-wsdl": "2.0.36",
@@ -28050,14 +28050,14 @@
         "zod": "^3.25.75"
       },
       "optionalDependencies": {
-        "@kong/insomnia-plugin-external-vault": "^0.1.0-alpha.2"
+        "@kong/insomnia-plugin-external-vault": "^0.1.0-alpha.3"
       }
     },
     "packages/insomnia-inso": {
       "version": "11.5.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@kong/insomnia-plugin-external-vault": "^0.1.0-alpha.2",
+        "@kong/insomnia-plugin-external-vault": "^0.1.0-alpha.3",
         "@seald-io/nedb": "^4.1.1",
         "@stoplight/spectral-core": "^1.20.0",
         "@stoplight/spectral-formats": "^1.8.2",
@@ -28082,7 +28082,7 @@
         "shellwords": "^1.0.1"
       },
       "optionalDependencies": {
-        "@kong/insomnia-plugin-external-vault": "^0.1.0-alpha.2"
+        "@kong/insomnia-plugin-external-vault": "^0.1.0-alpha.3"
       }
     },
     "packages/insomnia-inso/node_modules/@esbuild/aix-ppc64": {

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -65,6 +65,6 @@
     "yaml": "^2.7.1"
   },
   "optionalDependencies": {
-    "@kong/insomnia-plugin-external-vault": "^0.1.0-alpha.2"
+    "@kong/insomnia-plugin-external-vault": "^0.1.0-alpha.3"
   }
 }

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -199,7 +199,7 @@
     "zod": "^3.25.75"
   },
   "optionalDependencies": {
-    "@kong/insomnia-plugin-external-vault": "^0.1.0-alpha.2"
+    "@kong/insomnia-plugin-external-vault": "^0.1.0-alpha.3"
   },
   "dev": {
     "dev-server-port": 3334


### PR DESCRIPTION

Update `@kong/insomnia-plugin-external-vault` to version `0.1.0-alpha.3`.