### PR TITLE
fix: update tab after moving request-[INS-1169]

### DIFF
--- a/packages/insomnia/src/ui/components/tabs/tab-list.tsx
+++ b/packages/insomnia/src/ui/components/tabs/tab-list.tsx
@@ -12,6 +12,9 @@ import {
 } from 'react-aria-components';
 import { useParams } from 'react-router';
 
+import { isGrpcRequest } from '~/models/grpc-request';
+import { isSocketIORequest } from '~/models/socket-io-request';
+import { isWebSocketRequest } from '~/models/websocket-request';
 import { useRequestNewActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
 
 import { type ChangeBufferEvent, type ChangeType, database } from '../../../common/database';
@@ -177,7 +180,7 @@ export const OrganizationTabList = ({ showActiveStatus = true, currentPage = '' 
       if (patchObj.parentId && !patchObj.metaSortKey && (patchObj.parentId as string).startsWith('wrk_')) {
         const workspace = await models.workspace.getById(patchObj.parentId);
         if (workspace) {
-          if (isRequest(doc)) {
+          if (isRequest(doc) || isWebSocketRequest(doc) || isGrpcRequest(doc) || isSocketIORequest(doc)) {
             updateTabById?.(doc._id, {
               workspaceId: workspace._id,
               workspaceName: workspace.name,


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
Update tab when moving grpc/websocket/socketio request