### PR TITLE
fix: Adjust Hashicorp vault config form with help tooltip

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
@@ -83,7 +83,7 @@ test.describe('Check vault used in environment', () => {
     await page.getByTestId('dataFolders').fill(getFixturePath('vault-collection.yaml'));
     await page.getByTestId('dataFolders-btn').click();
     await page.locator('.app').press('Escape');
-    
+
     // import requests
     const requestColText = await loadFixture('vault-collection.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), requestColText);
@@ -208,6 +208,9 @@ test.describe('Check vault used in environment', () => {
     await page.getByTestId('underlay').click();
     // activate request
     await page.getByTestId('legacy-invalid-vault').getByLabel('GET legacy-invalid-vault', { exact: true }).click();
+    await expect
+      .soft(page.getByLabel('Insomnia Tabs').getByText('legacy-invalid-vault', { exact: true }))
+      .toBeVisible();
     await page.getByRole('button', { name: 'Send' }).click(); // Expect to see error message
     await expect.soft(page.getByText('Unexpected Request Failure')).toBeVisible();
     await expect.soft(page.getByText('Error: vault is a reserved')).toBeVisible();

--- a/packages/insomnia/src/ui/components/templating/external-vault/hashicorp-vault-form.tsx
+++ b/packages/insomnia/src/ui/components/templating/external-vault/hashicorp-vault-form.tsx
@@ -46,18 +46,6 @@ export const HashiCorpVaultForm = (props: HashiCorpVaultFormProps) => {
 
   return (
     <>
-      <div className="form-row">
-        <div className="form-control">
-          <label>
-            Secret Name:
-            <input
-              name="secretName"
-              defaultValue={secretName}
-              onChange={e => handleOnChange('secretName', e.target.value)}
-            />
-          </label>
-        </div>
-      </div>
       {credentialType === HashiCorpCredentialType.onPrem && (
         <>
           <div className="form-row">
@@ -95,11 +83,23 @@ export const HashiCorpVaultForm = (props: HashiCorpVaultFormProps) => {
           <div className="form-row">
             <div className="form-control">
               <label>
-                Secret Engine Path:
+                Secret Engine Name:
                 <input
                   name="secretEnginePath"
                   defaultValue={secretEnginePath}
                   onChange={e => handleOnChange('secretEnginePath', e.target.value)}
+                />
+              </label>
+            </div>
+          </div>
+          <div className="form-row">
+            <div className="form-control">
+              <label>
+                Secret Path:
+                <input
+                  name="secretName"
+                  defaultValue={secretName}
+                  onChange={e => handleOnChange('secretName', e.target.value)}
                 />
               </label>
             </div>

--- a/packages/insomnia/src/ui/components/templating/external-vault/hashicorp-vault-form.tsx
+++ b/packages/insomnia/src/ui/components/templating/external-vault/hashicorp-vault-form.tsx
@@ -83,7 +83,10 @@ export const HashiCorpVaultForm = (props: HashiCorpVaultFormProps) => {
           <div className="form-row">
             <div className="form-control">
               <label>
-                Secret Engine Name:
+                Secret Mount Path:
+                <HelpTooltip className="space-left">
+                  The path where the secrets engine is mounted. It is displayed as the engine name in the UI.
+                </HelpTooltip>
                 <input
                   name="secretEnginePath"
                   defaultValue={secretEnginePath}
@@ -96,6 +99,7 @@ export const HashiCorpVaultForm = (props: HashiCorpVaultFormProps) => {
             <div className="form-control">
               <label>
                 Secret Path:
+                <HelpTooltip className="space-left">The path of the secret to read</HelpTooltip>
                 <input
                   name="secretName"
                   defaultValue={secretName}


### PR DESCRIPTION
**Changes:**
Current Hashicorp vault config form bring some misleading to customer.
Adjust the config form position to keep align with the order showed in Hashicorp vault server UI.

Closes [INS-1195](https://konghq.atlassian.net/browse/INS-1195)

[INS-1195]: https://konghq.atlassian.net/browse/INS-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ