### PR TITLE
[INS-1234] Finesse experience of loading remote branches when creatin…

### DIFF
--- a/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
@@ -1,5 +1,6 @@
-import React, { useDeferredValue, useEffect } from 'react';
+import React, { useDeferredValue } from 'react';
 import { Button, ComboBox, Input, Label, ListBox, ListBoxItem, Popover } from 'react-aria-components';
+import * as reactUse from 'react-use';
 import { z } from 'zod/v4';
 
 import type { GitCredentials } from '~/models/git-repository';
@@ -29,37 +30,42 @@ export const GitRemoteBranchSelect = ({
       ('oauth2format' in credentials || (credentials.username && 'password' in credentials && credentials.password)),
   );
 
-  useEffect(() => {
-    if (!areEssentialInputsAvailable) {
-      return;
-    }
+  // Debounce calling submit
+  reactUse.useDebounce(
+    () => {
+      if (!areEssentialInputsAvailable) {
+        return;
+      }
 
-    // There's no need to fetch branches automatically if they've already been loaded. The user has the
-    // option to manually trigger a reload via the GUI.
-    if (remoteBranchesFetcher.data?.branches?.length) {
-      return;
-    }
+      // There's no need to fetch branches automatically if they've already been loaded. The user has the
+      // option to manually trigger a reload via the GUI.
+      if (remoteBranchesFetcher.data?.branches?.length) {
+        return;
+      }
 
-    // Automatic fetching of branches can return errors in some legitimate cases, like if the user is
-    // typing the URL or their credentials very slowly. Disable the progressive enhancement of
-    // automatically populating branches in this case and let the user manually fetch branches when
-    // they're ready.
-    //
-    // Note: This also removes the need to explicitly show branch fetch errors in the GUI when we're
-    // fetching *automatically*.
-    //
-    // @TODO Show errors in GUI if a manually triggered fetch errors out.
-    if (remoteBranchesFetcher.data?.errors?.length) {
-      return;
-    }
+      // Automatic fetching of branches can return errors in some legitimate cases, like if the user is
+      // typing the URL or their credentials very slowly. Disable the progressive enhancement of
+      // automatically populating branches in this case and let the user manually fetch branches when
+      // they're ready.
+      //
+      // Note: This also removes the need to explicitly show branch fetch errors in the GUI when we're
+      // fetching *automatically*.
+      //
+      // @TODO Show errors in GUI if a manually triggered fetch errors out.
+      if (remoteBranchesFetcher.data?.errors?.length) {
+        return;
+      }
 
-    if (!isLoadingRemoteBranches) {
-      remoteBranchesFetcher.submit({
-        uri,
-        credentials,
-      });
-    }
-  }, [uri, credentials, areEssentialInputsAvailable, isLoadingRemoteBranches, remoteBranchesFetcher]);
+      if (!isLoadingRemoteBranches) {
+        remoteBranchesFetcher.submit({
+          uri,
+          credentials,
+        });
+      }
+    },
+    300,
+    [uri, credentials, areEssentialInputsAvailable, isLoadingRemoteBranches, remoteBranchesFetcher],
+  );
 
   // The re-fetch button is enabled in case of errors so user can manually recover when possible
   const isRefetchButtonDisabled =

--- a/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
@@ -1,6 +1,5 @@
 import React, { useDeferredValue, useEffect } from 'react';
 import { Button, ComboBox, Input, Label, ListBox, ListBoxItem, Popover } from 'react-aria-components';
-import { useParams } from 'react-router';
 
 import type { GitCredentials } from '~/models/git-repository';
 import { useGitRemoteBranchesActionFetcher } from '~/routes/git.remote-branches';
@@ -18,22 +17,42 @@ export const GitRemoteBranchSelect = ({
 }) => {
   const uri = useDeferredValue(url);
   const remoteBranchesFetcher = useGitRemoteBranchesActionFetcher({ key: `branch-select:${uri}` });
-  const { organizationId } = useParams() as { organizationId: string };
-
+  const remoteBranches = remoteBranchesFetcher.data?.branches || [];
   const isLoadingRemoteBranches = remoteBranchesFetcher.state !== 'idle';
+  const isComboboxDisabled = remoteBranches.length === 0 || isLoadingRemoteBranches || !url || isDisabled;
+  const essentialInputsAvailable = uri && ('oauth2format' in credentials || (credentials.username && 'password' in credentials && credentials.password));
 
   useEffect(() => {
-    if (uri && remoteBranchesFetcher.state === 'idle' && !remoteBranchesFetcher.data) {
+    if (!essentialInputsAvailable) {
+      return;
+    }
+
+    // There's no need to fetch branches automatically if they've already been loaded. The user has the
+    // option to manually trigger a reload via the GUI.
+    if (remoteBranchesFetcher.data?.branches?.length) {
+      return;
+    }
+
+    // Automatic fetching of branches can return errors in some legitimate cases, like if the user is
+    // typing the URL or their credentials very slowly. Disable the progressive enhancement of
+    // automatically populating branches in this case and let the user manually fetch branches when
+    // they're ready.
+    //
+    // Note: This also removes the need to explicitly show branch fetch errors in the GUI when we're
+    // fetching *automatically*.
+    //
+    // @TODO Show errors in GUI if a manually triggered fetch errors out.
+    if (remoteBranchesFetcher.data?.errors?.length) {
+      return;
+    }
+
+    if (!isLoadingRemoteBranches) {
       remoteBranchesFetcher.submit({
         uri,
         credentials,
       });
     }
-  }, [organizationId, remoteBranchesFetcher, uri, credentials]);
-
-  const remoteBranches = remoteBranchesFetcher.data?.branches || [];
-
-  const isComboboxDisabled = remoteBranches.length === 0 || isLoadingRemoteBranches || !url || isDisabled;
+  }, [uri, credentials, essentialInputsAvailable, isLoadingRemoteBranches, remoteBranchesFetcher]);
 
   return (
     <Label className="flex flex-col">
@@ -87,11 +106,11 @@ export const GitRemoteBranchSelect = ({
         </ComboBox>
         <Button
           type="button"
-          isDisabled={isComboboxDisabled}
+          isDisabled={!remoteBranchesFetcher.data?.errors?.length && (!essentialInputsAvailable || isLoadingRemoteBranches)} // Button is enabled in case of errors so user can manually recover when possible
           className="m-2 flex aspect-square size-[--line-height-xs] items-center justify-center gap-2 truncate rounded-sm border border-solid border-[--hl-sm] p-2 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] disabled:opacity-30 aria-pressed:bg-[--hl-sm]"
           aria-label="Refresh repositories"
           onPress={() => {
-            if (uri && remoteBranchesFetcher.state === 'idle') {
+            if (uri && !isLoadingRemoteBranches) {
               remoteBranchesFetcher.submit({
                 uri,
                 credentials,

--- a/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
@@ -1,10 +1,13 @@
 import React, { useDeferredValue, useEffect } from 'react';
 import { Button, ComboBox, Input, Label, ListBox, ListBoxItem, Popover } from 'react-aria-components';
+import { z } from 'zod/v4';
 
 import type { GitCredentials } from '~/models/git-repository';
 import { useGitRemoteBranchesActionFetcher } from '~/routes/git.remote-branches';
 
 import { Icon } from '../icon';
+
+const GitRemoteURISchema = z.url().endsWith('.git');
 
 export const GitRemoteBranchSelect = ({
   url,
@@ -19,11 +22,15 @@ export const GitRemoteBranchSelect = ({
   const remoteBranchesFetcher = useGitRemoteBranchesActionFetcher({ key: `branch-select:${uri}` });
   const remoteBranches = remoteBranchesFetcher.data?.branches || [];
   const isLoadingRemoteBranches = remoteBranchesFetcher.state !== 'idle';
-  const isComboboxDisabled = remoteBranches.length === 0 || isLoadingRemoteBranches || !url || isDisabled;
-  const essentialInputsAvailable = uri && ('oauth2format' in credentials || (credentials.username && 'password' in credentials && credentials.password));
+  const isComboboxDisabled = remoteBranches.length === 0 || isLoadingRemoteBranches || !uri || isDisabled;
+  const areEssentialInputsAvailable = Boolean(
+    uri &&
+      GitRemoteURISchema.safeParse(uri).success &&
+      ('oauth2format' in credentials || (credentials.username && 'password' in credentials && credentials.password)),
+  );
 
   useEffect(() => {
-    if (!essentialInputsAvailable) {
+    if (!areEssentialInputsAvailable) {
       return;
     }
 
@@ -52,7 +59,11 @@ export const GitRemoteBranchSelect = ({
         credentials,
       });
     }
-  }, [uri, credentials, essentialInputsAvailable, isLoadingRemoteBranches, remoteBranchesFetcher]);
+  }, [uri, credentials, areEssentialInputsAvailable, isLoadingRemoteBranches, remoteBranchesFetcher]);
+
+  // The re-fetch button is enabled in case of errors so user can manually recover when possible
+  const isRefetchButtonDisabled =
+    !remoteBranchesFetcher.data?.errors?.length && (!areEssentialInputsAvailable || isLoadingRemoteBranches);
 
   return (
     <Label className="flex flex-col">
@@ -106,7 +117,7 @@ export const GitRemoteBranchSelect = ({
         </ComboBox>
         <Button
           type="button"
-          isDisabled={!remoteBranchesFetcher.data?.errors?.length && (!essentialInputsAvailable || isLoadingRemoteBranches)} // Button is enabled in case of errors so user can manually recover when possible
+          isDisabled={isRefetchButtonDisabled}
           className="m-2 flex aspect-square size-[--line-height-xs] items-center justify-center gap-2 truncate rounded-sm border border-solid border-[--hl-sm] p-2 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] disabled:opacity-30 aria-pressed:bg-[--hl-sm]"
           aria-label="Refresh repositories"
           onPress={() => {


### PR DESCRIPTION
This PR addresses UX issues in the Create a new project modal, especially evident when configuring access to a repository using the "Git" tab rather than using the Github/Gitlab tabs.

| Behavior | Example |
|:--|---|
| It now loads branches associated with a repository regardless of the order in which the URL, username, and password fields are filled out. Previously it would only work as expected if the credentials were filled in before the URL. | ![Kapture 2025-08-21 at 19 42 41](https://github.com/user-attachments/assets/310bf63d-a5ca-4b0d-a3ae-5ad8697cb401) |
| It keeps the "Refresh" button enabled in case of an error, so it can be used as an escape hatch to manually retry fetching branches. | <img width="636" height="537" alt="image" src="https://github.com/user-attachments/assets/71fee1fc-4fda-4ca8-b2ae-56a70581ae69" /> |

Other than UX, it also avoids sending API requests which are obviously malformed by waiting until the URL and credentials are both available.

Changes were tested by creating new projects by connecting to Github, Gitlab, using a PAT for Github, and a PAT for Gitlab.