### PR TITLE
[INS-1143] Point See What's New app update notification link to the official changelog page

### DIFF
--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -332,7 +332,7 @@ async function _trackStats() {
     console.log('[main] App update detected', currentVersion, lastVersion);
     const notification: ToastNotification = {
       key: `updated-${currentVersion}`,
-      url: 'https://github.com/Kong/insomnia/releases',
+      url: 'https://insomnia.rest/changelog',
       cta: "See What's New",
       message: `Updated to ${currentVersion}`,
     };


### PR DESCRIPTION
The changelog on the website is updated with specifically crafted release notes now and it makes sense to take users there directly.

There is a gap in the experience for users installing a beta build since the website only include notes for GA releases. This gap will be addressed separately by adding messaging & a link to the Changelog page on the website.