### PR TITLE
chore(ts): exclude dist dir

### DIFF
--- a/packages/insomnia/tsconfig.json
+++ b/packages/insomnia/tsconfig.json
@@ -54,6 +54,7 @@
     "assets",
     "bin",
     "build",
+    "dist",
     "config",
     "node_modules",
     "src/coverage",


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
<img width="453" height="127" alt="image" src="https://github.com/user-attachments/assets/6e8c820c-d570-4975-bb98-93719514924a" />

Fix this warning when we have local build resource in `/dist`
