### PR TITLE
fix: sendRequest doesnt return error in some cases - INS-1262

### DIFF
--- a/packages/insomnia-scripting-environment/src/objects/send-request.ts
+++ b/packages/insomnia-scripting-environment/src/objects/send-request.ts
@@ -188,23 +188,23 @@ function requestToCurlOptions(req: string | Request | RequestOptions, settings: 
       settings,
       certificates: finalReq.certificate
         ? [
-          {
-            host: finalReq.certificate?.name || '',
-            passphrase: finalReq.certificate?.passphrase || '',
-            cert: finalReq.certificate?.cert?.src || '',
-            key: finalReq.certificate?.key?.src || '',
-            pfx: finalReq.certificate?.pfx?.src || '',
-            // unused fields because they are not persisted
-            disabled: false,
-            isPrivate: false,
-            _id: '',
-            type: '',
-            parentId: '',
-            modified: 0,
-            created: 0,
-            name: '',
-          },
-        ]
+            {
+              host: finalReq.certificate?.name || '',
+              passphrase: finalReq.certificate?.passphrase || '',
+              cert: finalReq.certificate?.cert?.src || '',
+              key: finalReq.certificate?.key?.src || '',
+              pfx: finalReq.certificate?.pfx?.src || '',
+              // unused fields because they are not persisted
+              disabled: false,
+              isPrivate: false,
+              _id: '',
+              type: '',
+              parentId: '',
+              modified: 0,
+              created: 0,
+              name: '',
+            },
+          ]
         : [],
       caCertficatePath: null, // the request in pre-request script doesn't support customizing ca yet
       socketPath: undefined,

--- a/packages/insomnia-scripting-environment/src/objects/send-request.ts
+++ b/packages/insomnia-scripting-environment/src/objects/send-request.ts
@@ -15,11 +15,11 @@ export async function sendRequest(
   cb: (error?: string, response?: Response) => void,
   settings: Settings,
 ): Promise<Response | undefined> {
-  return new Promise<Response | undefined>(async resolve => {
+  return new Promise<Response | undefined>(async (resolve, reject) => {
     // TODO(george): enable cascading cancellation later as current solution just adds complexity
-    const requestOptions = requestToCurlOptions(request, settings);
-
     try {
+      const requestOptions = requestToCurlOptions(request, settings);
+
       const nodejsCurlRequest =
         process.type === 'renderer'
           ? window.bridge.curlRequest
@@ -30,20 +30,32 @@ export async function sendRequest(
           return curlOutputToResponse(output, request);
         })
         .then((transformedOutput: Response) => {
-          cb(undefined, transformedOutput);
+          if (cb) {
+            cb(undefined, transformedOutput);
+          }
           resolve(transformedOutput);
         })
         .catch((e: string | undefined) => {
-          cb(e, undefined);
-          resolve(undefined);
+          if (cb) {
+            cb(e, undefined);
+          } else {
+            reject(e);
+          }
         });
     } catch (err: any) {
       if (err.name === 'AbortError') {
-        cb(`Request was cancelled: ${err.message}`, undefined);
+        if (cb) {
+          cb(`Request was cancelled: ${err.message}`, undefined);
+        } else {
+          reject(err);
+        }
       } else {
-        cb(`Something went wrong: ${err.message}`, undefined);
+        if (cb) {
+          cb(`Something went wrong: ${err.message}`, undefined);
+        } else {
+          reject(err);
+        }
       }
-      resolve(undefined);
     }
   });
 }
@@ -107,7 +119,8 @@ function requestToCurlOptions(req: string | Request | RequestOptions, settings: 
           break;
         }
         default: {
-          throw new Error(`unknown body mode: ${finalReq.body.mode}`);
+          // it could be empty body and which is valid
+          mimeType = 'text/plain';
         }
       }
     }
@@ -175,23 +188,23 @@ function requestToCurlOptions(req: string | Request | RequestOptions, settings: 
       settings,
       certificates: finalReq.certificate
         ? [
-            {
-              host: finalReq.certificate?.name || '',
-              passphrase: finalReq.certificate?.passphrase || '',
-              cert: finalReq.certificate?.cert?.src || '',
-              key: finalReq.certificate?.key?.src || '',
-              pfx: finalReq.certificate?.pfx?.src || '',
-              // unused fields because they are not persisted
-              disabled: false,
-              isPrivate: false,
-              _id: '',
-              type: '',
-              parentId: '',
-              modified: 0,
-              created: 0,
-              name: '',
-            },
-          ]
+          {
+            host: finalReq.certificate?.name || '',
+            passphrase: finalReq.certificate?.passphrase || '',
+            cert: finalReq.certificate?.cert?.src || '',
+            key: finalReq.certificate?.key?.src || '',
+            pfx: finalReq.certificate?.pfx?.src || '',
+            // unused fields because they are not persisted
+            disabled: false,
+            isPrivate: false,
+            _id: '',
+            type: '',
+            parentId: '',
+            modified: 0,
+            created: 0,
+            name: '',
+          },
+        ]
         : [],
       caCertficatePath: null, // the request in pre-request script doesn't support customizing ca yet
       socketPath: undefined,

--- a/packages/insomnia-scripting-environment/src/objects/send-request.ts
+++ b/packages/insomnia-scripting-environment/src/objects/send-request.ts
@@ -15,46 +15,27 @@ export async function sendRequest(
   cb: (error?: string, response?: Response) => void,
   settings: Settings,
 ): Promise<Response | undefined> {
-  return new Promise<Response | undefined>(async (resolve, reject) => {
-    // TODO(george): enable cascading cancellation later as current solution just adds complexity
+  return new Promise(async (resolve, reject) => {
     try {
       const requestOptions = requestToCurlOptions(request, settings);
-
       const nodejsCurlRequest =
         process.type === 'renderer'
           ? window.bridge.curlRequest
           : (await import('insomnia/src/main/network/libcurl-promise')).curlRequest;
-      nodejsCurlRequest(requestOptions)
-        .then((result: any) => {
-          const output = result as CurlRequestOutput;
-          return curlOutputToResponse(output, request);
-        })
-        .then((transformedOutput: Response) => {
-          if (cb) {
-            cb(undefined, transformedOutput);
-          }
-          resolve(transformedOutput);
-        })
-        .catch((e: string | undefined) => {
-          if (cb) {
-            cb(e, undefined);
-          } else {
-            reject(e);
-          }
-        });
-    } catch (err: any) {
-      if (err.name === 'AbortError') {
-        if (cb) {
-          cb(`Request was cancelled: ${err.message}`, undefined);
-        } else {
-          reject(err);
-        }
+
+      const output = (await nodejsCurlRequest(requestOptions)) as CurlRequestOutput;
+      const transformedOutput = await curlOutputToResponse(output, request);
+
+      if (cb) {
+        cb(undefined, transformedOutput);
+      }
+      return resolve(transformedOutput);
+    } catch (e) {
+      if (cb) {
+        cb(e, undefined);
+        resolve(undefined);
       } else {
-        if (cb) {
-          cb(`Something went wrong: ${err.message}`, undefined);
-        } else {
-          reject(err);
-        }
+        reject(e);
       }
     }
   });
@@ -119,7 +100,7 @@ function requestToCurlOptions(req: string | Request | RequestOptions, settings: 
           break;
         }
         default: {
-          // it could be empty body and which is valid
+          // the body could be empty and which is valid
           mimeType = 'text/plain';
         }
       }


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Changes
- [x] Return error when there's error in sendRequest
- [x] `requestToCurlOptions` always returns request body mime type as the body could be empty

Tested cases from: #9031 #8897
