### PR TITLE
fix: error when delete workspace

### DIFF
--- a/packages/insomnia/src/ui/context/app/insomnia-event-stream-context.tsx
+++ b/packages/insomnia/src/ui/context/app/insomnia-event-stream-context.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, type FC, type PropsWithChildren, useContext, useEffect, useState } from 'react';
-import { useParams, useRevalidator } from 'react-router';
+import { useFetchers, useParams, useRevalidator } from 'react-router';
 import * as reactUse from 'react-use';
 
 import { CDN_INVALIDATION_TTL } from '~/common/constants';
@@ -152,6 +152,9 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
   }, [organizationId, remoteId, userSession.id, workspaceId]);
 
   const { revalidate } = useRevalidator();
+  const inflightFetchers = useFetchers();
+  const ifInSubmission = inflightFetchers.some(f => f.formMethod === 'POST');
+  const latestInSubmission = reactUse.useLatest(ifInSubmission);
 
   useEffect(() => {
     const sessionId = userSession.id;
@@ -211,7 +214,9 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
               // we don't need to revalidate if the user is in workspace page
               !latestWorkspaceId.current
             ) {
-              revalidate();
+              if (!latestInSubmission.current) {
+                revalidate();
+              }
             } else if (event.type === 'VaultKeyChanged') {
               const accountId = userSession.accountId;
               const organizations = JSON.parse(
@@ -236,7 +241,9 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
                 });
               } else if (event.type === 'FileChanged' && !latestWorkspaceId.current) {
                 // FileChanged could be a new file has been added, we need to revalidate the workspace list
-                revalidate();
+                if (!latestInSubmission.current) {
+                  revalidate();
+                }
               }
             }
           } catch (e) {
@@ -265,6 +272,7 @@ export const InsomniaEventStreamProvider: FC<PropsWithChildren> = ({ children })
     syncStorageRulesSubmit,
     userSession.accountId,
     userSession.id,
+    latestInSubmission,
   ]);
 
   return (


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

close [INS-1251](https://github.com/Kong/insomnia/pull/9060#issue-3355043309)

[INS-1251]: https://konghq.atlassian.net/browse/INS-1251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

When an action in React Router returns a redirect, if revalidate is triggered during the execution of that action, the redirect is lost. As a result, the redirect does not take effect, and no subsequent revalidation runs after the action completes. This can lead to inconsistent application state and unexpected UI behavior.
<img width="570" height="137" alt="image" src="https://github.com/user-attachments/assets/d2c88dea-4979-4815-b308-943e577e8a3e" />


https://github.com/remix-run/react-router/blob/a1a9f680f8337aee48e6610e7ab2f5ff8e63aa59/packages/react-router/lib/router/router.ts#L2445-L2448