### PR TITLE
[INS-1189] Redirect to organization page if project is not found.

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.tsx
@@ -1,4 +1,4 @@
-import { useRouteLoaderData } from 'react-router';
+import { href, redirect, useRouteLoaderData } from 'react-router';
 
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
@@ -6,11 +6,14 @@ import { invariant } from '~/utils/invariant';
 import type { Route } from './+types/organization.$organizationId.project.$projectId';
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
-  const { projectId } = params;
+  const { organizationId, projectId } = params;
   invariant(projectId, 'Project ID is required');
 
   const project = await models.project.getById(projectId);
-  invariant(project, `Project was not found ${projectId}`);
+
+  if (!project) {
+    return redirect(href('/organization/:organizationId', { organizationId }));
+  }
 
   return {
     activeProject: project,


### PR DESCRIPTION
# Overview:

Currently when deleting a project there is a race condition where the project is deleted but some items inside the project e.g. (workspace,request) are not based on the way our database handles deleting related objects.
This leads to some items requesting the project loader data which ends up throwing an error.

This PR fixes the issue where the loader is called with a projectId for a deleted project by redirecting to the parent organization.

## Next steps:
- [ ] Investigate deleting everything under a project when the project is deleted.
- [ ] We are already working on removing using `database` logic from inside the UI which will eliminate this class of issues.