### PR TITLE
fix: Commit modal fixes and uncommitted modal improvement [INS-1282] 

### DIFF
--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -97,6 +97,8 @@ export const GitProjectStagingModal: FC<{
   const commitFetcher = useGitProjectCommitActionFetcher();
 
   const [message, setMessage] = useState('');
+  // Add this state at the top of your component
+  const [committingAction, setCommittingAction] = useState<'commit' | 'commit-push' | null>(null);
 
   function diffChanges({ path, staged }: { path: string; staged: boolean }) {
     diffChangesFetcher.load({
@@ -228,6 +230,8 @@ export const GitProjectStagingModal: FC<{
                         const message = formData.get('message')?.toString() || '';
                         const push = Boolean(formData.get('push') === 'true');
 
+                        setCommittingAction(push ? 'commit-push' : 'commit');
+
                         commitFetcher.submit({
                           projectId,
                           message,
@@ -253,7 +257,6 @@ export const GitProjectStagingModal: FC<{
                           <Button
                             type="submit"
                             isDisabled={isCommitting || changes.staged.length === 0}
-                            formAction={`/organization/${organizationId}/project/${projectId}/git/commit`}
                             className="flex h-8 flex-1 items-center justify-center gap-2 rounded-sm bg-[--hl-xxs] px-4 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
                           >
                             {canCommitAndPull ? (
@@ -297,26 +300,28 @@ export const GitProjectStagingModal: FC<{
                         <div className="flex flex-shrink-0 items-center justify-stretch gap-2">
                           <Button
                             type="submit"
-                            isDisabled={isCommitting || changes.staged.length === 0}
-                            formAction={`/organization/${organizationId}/project/${projectId}/git/commit`}
+                            isDisabled={(committingAction === 'commit' && isCommitting) || changes.staged.length === 0}
                             className="flex h-8 flex-1 items-center justify-center gap-2 rounded-sm bg-[--hl-xxs] px-4 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
                           >
                             <Icon
-                              icon={isCommitting ? 'spinner' : 'check'}
-                              className={`w-5 ${isCommitting ? 'animate-spin' : ''}`}
+                              icon={committingAction === 'commit' && isCommitting ? 'spinner' : 'check'}
+                              className={`w-5 ${committingAction === 'commit' && isCommitting ? 'animate-spin' : ''}`}
                             />{' '}
                             Commit
                           </Button>
 
                           <Button
                             type="submit"
-                            isDisabled={isCommitting || changes.staged.length === 0}
-                            formAction={`/organization/${organizationId}/project/${projectId}/git/commit-and-push`}
+                            isDisabled={
+                              (committingAction === 'commit-push' && isCommitting) || changes.staged.length === 0
+                            }
+                            name="push"
+                            value="true"
                             className="flex h-8 flex-1 items-center justify-center gap-2 rounded-sm bg-[--hl-xxs] px-4 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
                           >
                             <Icon
-                              icon={isCommitting ? 'spinner' : 'cloud-arrow-up'}
-                              className={`w-5 ${isCommitting ? 'animate-spin' : ''}`}
+                              icon={committingAction === 'commit-push' && isCommitting ? 'spinner' : 'cloud-arrow-up'}
+                              className={`w-5 ${committingAction === 'commit-push' && isCommitting ? 'animate-spin' : ''}`}
                             />{' '}
                             Commit and push
                           </Button>

--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -173,7 +173,6 @@ export const GitProjectStagingModal: FC<{
   }, [commitFetcher.data, hasNoCommitErrors]);
 
   // These used only when the mode is commitAndPull
-  const canCommit = changes.staged.length > 0 && changes.unstaged.length > 0;
   const canCommitAndPull = changes.staged.length > 0 && changes.unstaged.length === 0;
 
   return (
@@ -250,53 +249,49 @@ export const GitProjectStagingModal: FC<{
                         />
                       </TextField>
                       {mode === StagingModalModes.commitAndPull ? (
-                        <div className="flex flex-col gap-2">
-                          <div className="flex items-center gap-2">
-                            <Button
-                              type="submit"
-                              isDisabled={isCommitting || !canCommit}
-                              formAction={`/organization/${organizationId}/project/${projectId}/git/commit`}
-                              className="flex h-8 flex-1 items-center justify-center gap-2 rounded-sm bg-[--hl-xxs] px-4 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+                        <div className="flex items-center gap-2">
+                          <Button
+                            type="submit"
+                            isDisabled={isCommitting || changes.staged.length === 0}
+                            formAction={`/organization/${organizationId}/project/${projectId}/git/commit`}
+                            className="flex h-8 flex-1 items-center justify-center gap-2 rounded-sm bg-[--hl-xxs] px-4 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+                          >
+                            {canCommitAndPull ? (
+                              <>
+                                <Icon
+                                  icon={isCommitting ? 'spinner' : 'cloud-arrow-down'}
+                                  className={`w-5 ${isCommitting ? 'animate-spin' : ''}`}
+                                />
+                                Commit and pull
+                              </>
+                            ) : (
+                              <>
+                                <Icon
+                                  icon={isCommitting ? 'spinner' : 'check'}
+                                  className={`w-5 ${isCommitting ? 'animate-spin' : ''}`}
+                                />
+                                Commit
+                              </>
+                            )}
+                          </Button>
+                          <Button
+                            type="button"
+                            isDisabled={isCommitting}
+                            className="flex h-8 flex-1 items-center justify-center gap-2 rounded-sm bg-[--hl-xxs] px-4 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+                            onPress={() => {
+                              setShowConfirmDiscardAndPullModal(true);
+                            }}
+                          >
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 24 24"
+                              fill="currentColor"
+                              className="size-4"
                             >
-                              <Icon
-                                icon={isCommitting && canCommit ? 'spinner' : 'check'}
-                                className={`w-5 ${isCommitting && canCommit ? 'animate-spin' : ''}`}
-                              />
-                              Commit
-                            </Button>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <Button
-                              type="submit"
-                              isDisabled={isCommitting || !canCommitAndPull}
-                              formAction={`/organization/${organizationId}/project/${projectId}/git/commit`}
-                              className="flex h-8 flex-1 items-center justify-center gap-2 rounded-sm bg-[--hl-xxs] px-4 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
-                            >
-                              <Icon
-                                icon={isCommitting && canCommitAndPull ? 'spinner' : 'cloud-arrow-down'}
-                                className={`w-5 ${isCommitting && canCommitAndPull ? 'animate-spin' : ''}`}
-                              />
-                              Commit and pull
-                            </Button>
-                            <Button
-                              type="button"
-                              isDisabled={isCommitting}
-                              className="flex h-8 flex-1 items-center justify-center gap-2 rounded-sm bg-[--hl-xxs] px-4 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
-                              onPress={() => {
-                                setShowConfirmDiscardAndPullModal(true);
-                              }}
-                            >
-                              <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                viewBox="0 0 24 24"
-                                fill="currentColor"
-                                className="size-4"
-                              >
-                                <path d="M5.828 7l2.536 2.535L6.95 10.95 2 6l4.95-4.95 1.414 1.415L5.828 5H13a8 8 0 110 16H4v-2h9a6 6 0 000-12H5.828z" />
-                              </svg>
-                              Discard and pull
-                            </Button>
-                          </div>
+                              <path d="M5.828 7l2.536 2.535L6.95 10.95 2 6l4.95-4.95 1.414 1.415L5.828 5H13a8 8 0 110 16H4v-2h9a6 6 0 000-12H5.828z" />
+                            </svg>
+                            Discard and pull
+                          </Button>
                         </div>
                       ) : (
                         <div className="flex flex-shrink-0 items-center justify-stretch gap-2">


### PR DESCRIPTION
### Improvements
- When a single file is selected for commit, show a Commit button.
- When all changed files are selected, or when committing multiple files together, show a Commit & Pull button.
<img width="1218" height="653" alt="Screenshot 2025-08-28 at 18 48 30" src="https://github.com/user-attachments/assets/84853e3f-21ff-4d6c-851c-229f544ecd8b" />
<img width="1217" height="653" alt="Screenshot 2025-08-28 at 18 47 13" src="https://github.com/user-attachments/assets/a124d58b-590c-4ab6-ae29-e6de6ca5fd78" />


### Fixes
- [x]  Fixed the Commit and Push action in the commit modal.
- [x]  Added separate loading states for Commit and Commit & Push buttons.