### PR TITLE
chore: fix all playwright warnings and cut CI time by 10%

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -57,11 +57,11 @@ export default tseslint.config(
     rules: {
       ...playwright.configs['flat/recommended'].rules,
       'playwright/expect-expect': 'off',
-      'playwright/valid-title': 'off', //TODO: avoid using looping e2e tests
       'playwright/require-soft-assertions': 'error',
       'playwright/prefer-native-locators': 'error',
       'playwright/prefer-to-be': 'error',
       'playwright/prefer-to-contain': 'error',
+      'playwright/no-wait-for-timeout': 'error',
     },
   },
   {

--- a/packages/insomnia-smoke-test/tests/critical/backup.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/backup.test.ts
@@ -7,23 +7,13 @@ import { test } from '../../playwright/test';
 
 test('can backup data on new version available', async ({ app, page }) => {
   const dataPath = await app.evaluate(async ({ app }) => app.getPath('userData'));
-  let foundBackups = false;
-  // retry 5 times
-  for (let i = 0; i < 5; i++) {
-    console.log('Retry', i);
-    if (fs.existsSync(path.join(dataPath, 'backups'))) {
-      console.log('Backups exists!');
-      const rootBackupsFolder = fs.readdirSync(path.join(dataPath, 'backups'));
-      const backupDir = fs.readdirSync(path.join(dataPath, 'backups', rootBackupsFolder[0]));
-      const hasFilesInsideBackup = backupDir.length > 0;
-      const hasProjectDbFile = backupDir.includes('insomnia.Project.db');
-      foundBackups = hasFilesInsideBackup && hasProjectDbFile;
-      break;
-    } else {
-      console.log('backups not found. Waiting 5 seconds...');
-      await page.waitForTimeout(5000);
-    }
-  }
-
-  expect.soft(foundBackups).toBe(true);
+  await page.getByRole('button', { name: 'Create request collection' }).click();
+  await page.getByRole('button', { name: 'Send' }).click();
+  await page.getByText('Error: URL using bad/illegal').click();
+  const rootBackupsFolder = fs.readdirSync(path.join(dataPath, 'backups'));
+  const backupDir = fs.readdirSync(path.join(dataPath, 'backups', rootBackupsFolder[0]));
+  const hasFilesInsideBackup = backupDir.length > 0;
+  const hasProjectDbFile = backupDir.includes('insomnia.Project.db');
+  expect.soft(hasFilesInsideBackup).toBe(true);
+  expect.soft(hasProjectDbFile).toBe(true);
 });

--- a/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
@@ -32,7 +32,6 @@ test.describe('after-response script features tests', () => {
     await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
 
     // verify response
-    await page.waitForSelector('[data-testid="response-status-tag"]:visible');
     await expect.soft(statusTag).toContainText('200 OK');
 
     // verify
@@ -78,7 +77,6 @@ test.describe('after-response script features tests', () => {
     await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
 
     // verify response
-    await page.waitForSelector('[data-testid="response-status-tag"]:visible');
     await expect.soft(statusTag1).toContainText('200 OK');
 
     // verify persisted environment

--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
@@ -78,7 +78,7 @@ test.describe('Check vault used in environment', () => {
     },
   });
 
-  test('test global private sub environment to store vaults', async ({ page, app }) => {
+  test('global private sub environment to store vaults', async ({ page, app }) => {
     await page.getByTestId('settings-button').click();
     await page.getByTestId('dataFolders').fill(getFixturePath('vault-collection.yaml'));
     await page.getByTestId('dataFolders-btn').click();

--- a/packages/insomnia-smoke-test/tests/smoke/mock.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/mock.test.ts
@@ -1,6 +1,7 @@
 import { test } from '../../playwright/test';
 
-// @TODO - Bring this back once the stage server is up and running
+// @TODO - Bring this back once the stage server is back up and running and remove the ignore line below
+// eslint-disable-next-line playwright/no-skipped-test
 test.skip('can make a mock route: WARNING: THIS TEST DEPENDS ON mock-stage.insomnia.run to be up', async ({ page }) => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
 

--- a/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
@@ -144,11 +144,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await expect.soft(responseBody).toContainText('"sub": "fresh"');
 
   // Reset the OAuth 2 session from Preferences
-  if (process.platform === 'darwin') {
-    await page.keyboard.press('Meta+,');
-  } else {
-    await page.keyboard.press('Control+,');
-  }
+  await page.getByTestId('settings-button').click();
   await page.locator('button:has-text("Clear OAuth 2 session")').click();
   await page.keyboard.press('Escape');
 
@@ -177,11 +173,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await expect.soft(responseBody).toContainText('"sub": "admin"');
 
   // Reset the OAuth 2 session from Preferences
-  if (process.platform === 'darwin') {
-    await page.keyboard.press('Meta+,');
-  } else {
-    await page.keyboard.press('Control+,');
-  }
+  await page.getByTestId('settings-button').click();
   await page.locator('button:has-text("Clear OAuth 2 session")').click();
   await page.keyboard.press('Escape');
 
@@ -194,11 +186,7 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await expect.soft(responseBody).toContainText('"clientId": "client_credentials"');
 
   // Reset the OAuth 2 session from Preferences
-  if (process.platform === 'darwin') {
-    await page.keyboard.press('Meta+,');
-  } else {
-    await page.keyboard.press('Control+,');
-  }
+  await page.getByTestId('settings-button').click();
   await page.locator('button:has-text("Clear OAuth 2 session")').click();
   await page.keyboard.press('Escape');
 

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -250,8 +250,8 @@ test.describe('pre-request features tests', () => {
 
     // enter script
     await page.getByRole('tab', { name: 'Scripts' }).click();
-    const preRequestScriptEditor = page.getByTestId('CodeEditor').getByRole('textbox');
-    await preRequestScriptEditor.fill(`
+    const editor = page.getByTestId('CodeEditor').getByRole('textbox');
+    await editor.fill(`
           const rawReq = {
               url: 'http://127.0.0.1:4010/echo',
               method: 'POST',
@@ -634,56 +634,40 @@ test.describe('unhappy paths', () => {
     await page.getByLabel('Pre-request Scripts').click();
   });
 
-  const testCases = [
-    {
-      name: 'custom error is returned',
-      preReqScript: `
-            throw Error('my custom error');
-            `,
-      context: {
-        insomnia: {},
-      },
-      expectedResult: {
-        message: 'my custom error',
-      },
-    },
-    {
-      name: 'syntax error',
-      preReqScript: `
-            insomnia.INVALID_FIELD.set('', '')
-            `,
-      context: {
-        insomnia: {},
-      },
-      expectedResult: {
-        message: "Cannot read properties of undefined (reading 'set')",
-      },
-    },
-  ];
+  test('custom errors are returned', async ({ page }) => {
+    await page.getByLabel('Request Collection').getByTestId('echo pre-request script result').press('Enter');
 
-  for (const tc of testCases) {
-    test(tc.name, async ({ page }) => {
-      const responsePane = page.getByTestId('response-pane');
+    // set request body
+    await page.getByRole('tab', { name: 'Body' }).click();
+    await page.getByRole('button', { name: 'Body' }).click();
+    await page.getByRole('option', { name: 'JSON' }).click();
 
-      await page.getByLabel('Request Collection').getByTestId('echo pre-request script result').press('Enter');
+    // enter script
+    await page.getByRole('tab', { name: 'Scripts' }).click();
+    const editor = page.getByTestId('CodeEditor').getByRole('textbox');
+    await editor.fill(`throw Error('my custom error');`);
 
-      // set request body
-      await page.getByRole('tab', { name: 'Body' }).click();
-      await page.getByRole('button', { name: 'Body' }).click();
-      await page.getByRole('option', { name: 'JSON' }).click();
+    await page.getByRole('tab', { name: 'Body' }).click();
 
-      // enter script
-      await page.getByRole('tab', { name: 'Scripts' }).click();
-      const preRequestScriptEditor = page.getByTestId('CodeEditor').getByRole('textbox');
-      await preRequestScriptEditor.fill(tc.preReqScript);
+    // send
+    await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
 
-      await page.getByRole('tab', { name: 'Body' }).click();
+    // verify
+    await expect.soft(page.getByTestId('response-pane')).toContainText('my custom error');
 
-      // send
-      await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+    await page.getByRole('tab', { name: 'Scripts' }).click();
+    await page.getByTestId('CodeEditor').getByRole('textbox').press('ControlOrMeta+a');
+    await page.keyboard.press('Backspace');
+    await editor.fill(`insomnia.INVALID_FIELD.set('', '')`);
 
-      // verify
-      await expect.soft(responsePane).toContainText(tc.expectedResult.message);
-    });
-  }
+    await page.getByRole('tab', { name: 'Body' }).click();
+
+    // send
+    await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
+
+    // verify
+    await expect
+      .soft(page.getByTestId('response-pane'))
+      .toContainText(`Cannot read properties of undefined (reading 'set')`);
+  });
 });

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -204,20 +204,20 @@ test.describe('pre-request features tests', () => {
   test('run test cases', async ({ page }) => {
     for (const tc of testCases) {
       console.log(`Running test case: ${tc.name}`);
-      const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
-      const responseBody = page.getByTestId('response-pane').getByTestId('CodeEditor').locator('.CodeMirror-line');
 
       await page.getByLabel('Request Collection').getByTestId(tc.name).press('Enter');
 
       // send
+      await page.getByTestId('request-pane').getByLabel('Params').getByText('http://127.0.0.1:4010/echo').click();
       await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
-
       // verify
-      await page.waitForSelector('[data-testid="response-status-tag"]:visible');
+      await expect.soft(page.locator('[data-testid="response-status-tag"]:visible')).toContainText('200 OK');
 
-      await expect.soft(statusTag).toContainText('200 OK');
-
-      const rows = await responseBody.allInnerTexts();
+      const rows = await page
+        .getByTestId('response-pane')
+        .getByTestId('CodeEditor')
+        .locator('.CodeMirror-line')
+        .allInnerTexts();
       expect.soft(rows.length).toBeGreaterThan(0);
 
       const bodyJson = JSON.parse(rows.join(' '));

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -216,8 +216,7 @@ test.describe('pre-request features tests', () => {
 
       await page.getByLabel('Request Collection').getByTestId(tc.name).press('Enter');
 
-      // send
-      await page.getByTestId('request-pane').getByLabel('Params').getByText('http://127.0.0.1:4010/echo').click();
+      await page.getByTestId('request-pane').getByLabel('Params').click();
       await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
       // verify
       await expect.soft(page.locator('[data-testid="response-status-tag"]:visible')).toContainText('200 OK');
@@ -343,16 +342,12 @@ test.describe('pre-request features tests', () => {
           insomnia.environment.set('formdataBody', resps[4].body);
           `);
 
-    // TODO: wait for body and pre - request script are persisted to the disk
-    // should improve this part, we should avoid sync this state through db as it introduces race condition
-    await page.waitForTimeout(500);
+    await page.getByRole('tab', { name: 'Body' }).click();
 
     // send
     await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
 
     // verify
-    await page.waitForSelector('[data-testid="response-status-tag"]:visible');
-
     await expect.soft(statusTag).toContainText('200 OK');
 
     const rows = await responseBody.allInnerTexts();
@@ -389,10 +384,9 @@ test.describe('pre-request features tests', () => {
     await page.locator('[name="noProxy"]').fill('http://a.com,https://b.com');
     await page.locator('.app').press('Escape');
     // add 1s timeout to ensure noProxy settings is applied - INS-4155
-    await page.waitForTimeout(1000);
 
     await page.getByLabel('Request Collection').getByTestId('test proxies manipulation').press('Enter');
-
+    await page.getByRole('tab', { name: 'Body' }).click();
     // send
     await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
 
@@ -487,7 +481,6 @@ test.describe('pre-request features tests', () => {
     await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
 
     // verify response
-    await page.waitForSelector('[data-testid="response-status-tag"]:visible');
     await expect.soft(statusTag).toContainText('200 OK');
 
     // verify persisted environment
@@ -596,7 +589,6 @@ test.describe('pre-request features tests', () => {
     await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
 
     // verify response
-    await page.waitForSelector('[data-testid="response-status-tag"]:visible');
     await expect.soft(statusTag).toContainText('200 OK');
 
     // verify table environments have been updated
@@ -615,7 +607,6 @@ test.describe('pre-request features tests', () => {
 
     // verify response
     const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
-    await page.waitForSelector('[data-testid="response-status-tag"]:visible');
     await expect.soft(statusTag).toContainText('200 OK');
 
     const responsePane = page.getByTestId('response-pane');
@@ -686,15 +677,12 @@ test.describe('unhappy paths', () => {
       const preRequestScriptEditor = page.getByTestId('CodeEditor').getByRole('textbox');
       await preRequestScriptEditor.fill(tc.preReqScript);
 
-      // TODO: wait for body and pre-request script are persisted to the disk
-      // should improve this part, we should avoid sync this state through db as it introduces race condition
-      await page.waitForTimeout(500);
+      await page.getByRole('tab', { name: 'Body' }).click();
 
       // send
       await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
 
       // verify
-      await page.waitForSelector('[data-testid="response-status-tag"]:visible');
       await expect.soft(responsePane).toContainText(tc.expectedResult.message);
     });
   }

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -200,7 +200,16 @@ test.describe('pre-request features tests', () => {
         valFoundByFolder2: 2,
       },
     },
-  ];
+  ].map(tc => {
+    return {
+      ...tc,
+      customVerify:
+        tc.customVerify ??
+        (bodyJson => {
+          expect.soft(JSON.parse(bodyJson.data)).toEqual(tc.expectedBody);
+        }),
+    };
+  });
   test('run test cases', async ({ page }) => {
     for (const tc of testCases) {
       console.log(`Running test case: ${tc.name}`);
@@ -221,12 +230,7 @@ test.describe('pre-request features tests', () => {
       expect.soft(rows.length).toBeGreaterThan(0);
 
       const bodyJson = JSON.parse(rows.join(' '));
-      if (tc.expectedBody) {
-        expect.soft(JSON.parse(bodyJson.data)).toEqual(tc.expectedBody);
-      }
-      if (tc.customVerify) {
-        tc.customVerify(bodyJson);
-      }
+      tc.customVerify(bodyJson);
     }
   });
   test('send request with content type', async ({ page }) => {

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -201,9 +201,9 @@ test.describe('pre-request features tests', () => {
       },
     },
   ];
-
-  for (const tc of testCases) {
-    test(tc.name, async ({ page }) => {
+  test('run test cases', async ({ page }) => {
+    for (const tc of testCases) {
+      console.log(`Running test case: ${tc.name}`);
       const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
       const responseBody = page.getByTestId('response-pane').getByTestId('CodeEditor').locator('.CodeMirror-line');
 
@@ -227,9 +227,8 @@ test.describe('pre-request features tests', () => {
       if (tc.customVerify) {
         tc.customVerify(bodyJson);
       }
-    });
-  }
-
+    }
+  });
   test('send request with content type', async ({ page }) => {
     const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
     const responseBody = page.getByTestId('response-pane').getByTestId('CodeEditor').locator('.CodeMirror-line');
@@ -250,95 +249,95 @@ test.describe('pre-request features tests', () => {
     await page.getByRole('tab', { name: 'Scripts' }).click();
     const preRequestScriptEditor = page.getByTestId('CodeEditor').getByRole('textbox');
     await preRequestScriptEditor.fill(`
-        const rawReq = {
-            url: 'http://127.0.0.1:4010/echo',
-            method: 'POST',
-            header: {
-                'Content-Type': 'text/plain',
-            },
-            body: {
-                mode: 'raw',
-                raw: 'rawContent',
-            },
-        };
-        const urlencodedReq = {
-            url: 'http://127.0.0.1:4010/echo',
-            method: 'POST',
-            header: {
-                'Content-Type': 'application/x-www-form-urlencoded',
-            },
-            body: {
-                mode: 'urlencoded',
-                urlencoded: [
-                    { key: 'k1', value: 'v1' },
-                    { key: 'k2', value: 'v2' },
-                ],
-            },
-        };
-        const gqlReq = {
-            url: 'http://127.0.0.1:4010/echo',
-            method: 'POST',
-            header: {
-                'Content-Type': 'application/graphql',
-            },
-            body: {
-                mode: 'graphql',
-                graphql: {
-                    query: 'query',
-                    operationName: 'operation',
-                    variables: 'var',
-                },
-            },
-        };
-        const fileReq = {
-            url: 'http://127.0.0.1:4010/echo',
-            method: 'POST',
-            header: {
-                'Content-Type': 'application/octet-stream',
-            },
-            body: {
-                mode: 'file',
-                file: "${getFixturePath('files/rawfile.txt')}",
-            },
-        };
-        const formdataReq = {
-            url: 'http://127.0.0.1:4010/echo',
-            method: 'POST',
-            header: {
-                // TODO: try to understand why this breaks the test
-                // 'Content-Type': 'multipart/form-data',
-            },
-            body: {
-                mode: 'formdata',
-                formdata: [
-                    { key: 'k1', type: 'text', value: 'v1' },
-                    { key: 'k2', type: 'file', value: "${getFixturePath('files/rawfile.txt')}" },
-                ],
-            },
-        };
-        const promises = [rawReq, urlencodedReq, gqlReq, fileReq, formdataReq].map(req => {
-            return new Promise((resolve, reject) => {
-                insomnia.sendRequest(
-                    req,
-                    (err, resp) => {
-                        if (err != null) {
-                            reject(err);
-                        } else {
-                            resolve(resp);
-                        }
-                    }
-                );
-            });
-        });
-        // send request
-        const resps = await Promise.all(promises);
-        // set envs
-        insomnia.environment.set('rawBody', resps[0].body);
-        insomnia.environment.set('urlencodedBody', resps[1].body);
-        insomnia.environment.set('gqlBody', resps[2].body);
-        insomnia.environment.set('fileBody', resps[3].body);
-        insomnia.environment.set('formdataBody', resps[4].body);
-        `);
+          const rawReq = {
+              url: 'http://127.0.0.1:4010/echo',
+              method: 'POST',
+              header: {
+                  'Content-Type': 'text/plain',
+              },
+              body: {
+                  mode: 'raw',
+                  raw: 'rawContent',
+              },
+          };
+          const urlencodedReq = {
+              url: 'http://127.0.0.1:4010/echo',
+              method: 'POST',
+              header: {
+                  'Content-Type': 'application/x-www-form-urlencoded',
+              },
+              body: {
+                  mode: 'urlencoded',
+                  urlencoded: [
+                      { key: 'k1', value: 'v1' },
+                      { key: 'k2', value: 'v2' },
+                  ],
+              },
+          };
+          const gqlReq = {
+              url: 'http://127.0.0.1:4010/echo',
+              method: 'POST',
+              header: {
+                  'Content-Type': 'application/graphql',
+              },
+              body: {
+                  mode: 'graphql',
+                  graphql: {
+                      query: 'query',
+                      operationName: 'operation',
+                      variables: 'var',
+                  },
+              },
+          };
+          const fileReq = {
+              url: 'http://127.0.0.1:4010/echo',
+              method: 'POST',
+              header: {
+                  'Content-Type': 'application/octet-stream',
+              },
+              body: {
+                  mode: 'file',
+                  file: "${getFixturePath('files/rawfile.txt')}",
+              },
+          };
+          const formdataReq = {
+              url: 'http://127.0.0.1:4010/echo',
+              method: 'POST',
+              header: {
+                  // TODO: try to understand why this breaks the test
+                  // 'Content-Type': 'multipart/form-data',
+              },
+              body: {
+                  mode: 'formdata',
+                  formdata: [
+                      { key: 'k1', type: 'text', value: 'v1' },
+                      { key: 'k2', type: 'file', value: "${getFixturePath('files/rawfile.txt')}" },
+                  ],
+              },
+          };
+          const promises = [rawReq, urlencodedReq, gqlReq, fileReq, formdataReq].map(req => {
+              return new Promise((resolve, reject) => {
+                  insomnia.sendRequest(
+                      req,
+                      (err, resp) => {
+                          if (err != null) {
+                              reject(err);
+                          } else {
+                              resolve(resp);
+                          }
+                      }
+                  );
+              });
+          });
+          // send request
+          const resps = await Promise.all(promises);
+          // set envs
+          insomnia.environment.set('rawBody', resps[0].body);
+          insomnia.environment.set('urlencodedBody', resps[1].body);
+          insomnia.environment.set('gqlBody', resps[2].body);
+          insomnia.environment.set('fileBody', resps[3].body);
+          insomnia.environment.set('formdataBody', resps[4].body);
+          `);
 
     // TODO: wait for body and pre - request script are persisted to the disk
     // should improve this part, we should avoid sync this state through db as it introduces race condition
@@ -644,8 +643,8 @@ test.describe('unhappy paths', () => {
     {
       name: 'custom error is returned',
       preReqScript: `
-          throw Error('my custom error');
-          `,
+            throw Error('my custom error');
+            `,
       context: {
         insomnia: {},
       },
@@ -656,8 +655,8 @@ test.describe('unhappy paths', () => {
     {
       name: 'syntax error',
       preReqScript: `
-          insomnia.INVALID_FIELD.set('', '')
-          `,
+            insomnia.INVALID_FIELD.set('', '')
+            `,
       context: {
         insomnia: {},
       },

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-window.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-window.test.ts
@@ -79,7 +79,6 @@ test.describe('test hidden window handling', () => {
 
     // it should still work
     const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
-    await page.waitForSelector('[data-testid="response-status-tag"]:visible');
     await expect.soft(statusTag).toContainText('200 OK');
   });
 
@@ -119,7 +118,6 @@ test.describe('test hidden window handling', () => {
 
     // it should still work
     const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
-    await page.waitForSelector('[data-testid="response-status-tag"]:visible');
     await expect.soft(statusTag).toContainText('200 OK');
   });
 });


### PR DESCRIPTION
motivation: pre req tests count for about 15 tests each one was previously restarting the app between runs this costs 30-90 seconds depending on action runner specs and operating systems.

- replace test cases test wrapper with single test with a foreach test case
- Replaced timeouts with navigates and conditions with normalised arrays

measurements
before:
15m30s - 16m30s

after:
13m30s

saving 2-3 minutes per run
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
