### PR TITLE
fix: create submit hook with a factory to explicitly declare the return type

### DIFF
--- a/packages/insomnia/src/routes/auth.authorize.tsx
+++ b/packages/insomnia/src/routes/auth.authorize.tsx
@@ -1,6 +1,6 @@
-import { Fragment, useCallback } from 'react';
+import { Fragment } from 'react';
 import { Button, Heading } from 'react-aria-components';
-import { href, redirect, useFetcher, useFetchers, useNavigate } from 'react-router';
+import { href, redirect, useFetchers, useNavigate } from 'react-router';
 
 import { userSession as sessionModel } from '~/models';
 import { SegmentEvent } from '~/ui/analytics';
@@ -9,6 +9,7 @@ import { Icon } from '~/ui/components/icon';
 import { insomniaFetch } from '~/ui/insomniaFetch';
 import { validateVaultKey } from '~/ui/vault-key.client';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 import { getVaultKeyFromStorage } from '~/utils/vault';
 
 import type { Route } from './+types/auth.authorize';
@@ -69,25 +70,16 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return redirect('/organization');
 }
 
-export function useAuthorizeActionFetcher(args: { key?: string } = {}) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    (data: { code: string }) => {
-      fetcherSubmit(data, {
-        action: href('/auth/authorize'),
-        method: 'POST',
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useAuthorizeActionFetcher = createFetcherSubmitHook(
+  submit => (data: { code: string }) => {
+    submit(data, {
+      action: href('/auth/authorize'),
+      method: 'POST',
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);
 
 const Component = () => {
   const url = getLoginUrl();

--- a/packages/insomnia/src/routes/auth.clear-vault-key.tsx
+++ b/packages/insomnia/src/routes/auth.clear-vault-key.tsx
@@ -1,11 +1,11 @@
 import electron from 'electron';
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { userSession as sessionModel } from '~/models';
 import { removeAllSecrets } from '~/models/environment';
 import type { ToastNotification } from '~/ui/components/toast';
 import { insomniaFetch } from '~/ui/insomniaFetch';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/auth.clear-vault-key';
 
@@ -42,22 +42,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return false;
 }
 
-export function useClearVaultKeyFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    (data: { organizations: string[]; sessionId: string }) => {
-      fetcherSubmit(data, {
-        action: href('/auth/clear-vault-key'),
-        method: 'POST',
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useClearVaultKeyFetcher = createFetcherSubmitHook(
+  submit => (data: { organizations: string[]; sessionId: string }) => {
+    submit(data, {
+      action: href('/auth/clear-vault-key'),
+      method: 'POST',
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/auth.create-vault-key.tsx
+++ b/packages/insomnia/src/routes/auth.create-vault-key.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { createVaultKey } from '~/ui/vault-key.client';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/auth.create-vault-key';
 
@@ -9,15 +9,9 @@ export async function clientAction(_args: Route.ClientActionArgs) {
   return createVaultKey('create');
 }
 
-export function useCreateVaultKeyFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(() => {
-    fetcherSubmit({}, { action: href('/auth/create-vault-key'), method: 'POST' });
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useCreateVaultKeyFetcher = createFetcherSubmitHook(
+  submit => () => {
+    submit({}, { action: href('/auth/create-vault-key'), method: 'POST' });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/auth.default-browser-redirect.ts
+++ b/packages/insomnia/src/routes/auth.default-browser-redirect.ts
@@ -1,4 +1,6 @@
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/auth.default-browser-redirect';
 
@@ -11,18 +13,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useDefaultBrowserRedirectActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const fetcher = useFetcher<typeof clientAction>(args);
-  function submit(data: { redirectUrl: string }) {
-    return fetcher.submit(JSON.stringify(data), {
+export const useDefaultBrowserRedirectActionFetcher = createFetcherSubmitHook(
+  submit => (data: { redirectUrl: string }) => {
+    return submit(JSON.stringify(data), {
       method: 'POST',
       action: href('/auth/default-browser-redirect'),
       encType: 'application/json',
     });
-  }
-
-  return {
-    ...fetcher,
-    submit,
-  };
-}
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/auth.login.tsx
+++ b/packages/insomnia/src/routes/auth.login.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from 'react-aria-components';
-import { href, redirect, useFetcher, useNavigate } from 'react-router';
+import { href, redirect, useNavigate } from 'react-router';
 
 import { SCRATCHPAD_ORGANIZATION_ID } from '~/models/organization';
 import { SCRATCHPAD_PROJECT_ID } from '~/models/project';
@@ -8,6 +8,7 @@ import { SCRATCHPAD_WORKSPACE_ID } from '~/models/workspace';
 import { SegmentEvent } from '~/ui/analytics';
 import { getLoginUrl } from '~/ui/auth-session-provider.client';
 import { Icon } from '~/ui/components/icon';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/auth.login';
 
@@ -48,23 +49,15 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return redirect(href('/auth/authorize'));
 }
 
-export function useLoginActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-  const submit = useCallback(
-    (data: { provider: string }) => {
-      fetcherSubmit(data, {
-        action: href('/auth/login'),
-        method: 'POST',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useLoginActionFetcher = createFetcherSubmitHook(
+  submit => (data: { provider: string }) => {
+    submit(data, {
+      action: href('/auth/login'),
+      method: 'POST',
+    });
+  },
+  clientAction,
+);
 
 const Component = () => {
   const loginFetcher = useLoginActionFetcher();

--- a/packages/insomnia/src/routes/auth.logout.tsx
+++ b/packages/insomnia/src/routes/auth.logout.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import { logout } from '~/account/session';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/auth.logout';
 
@@ -10,15 +10,9 @@ export async function clientAction(_args: Route.ClientActionArgs) {
   return redirect(href('/auth/login'));
 }
 
-export function useLogoutFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(() => {
-    return fetcherSubmit({}, { action: href('/auth/logout'), method: 'POST' });
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useLogoutFetcher = createFetcherSubmitHook(
+  submit => () => {
+    return submit({}, { action: href('/auth/logout'), method: 'POST' });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/auth.reset-vault-key.tsx
+++ b/packages/insomnia/src/routes/auth.reset-vault-key.tsx
@@ -1,21 +1,15 @@
-import { useCallback } from 'react';
-import { type ActionFunctionArgs, href, useFetcher } from 'react-router';
+import { type ActionFunctionArgs, href } from 'react-router';
 
 import { createVaultKey } from '~/ui/vault-key.client';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 export async function clientAction(_args: ActionFunctionArgs) {
   return createVaultKey('reset');
 }
 
-export function useResetVaultKeyFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(() => {
-    fetcherSubmit({}, { action: href('/auth/reset-vault-key'), method: 'POST' });
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useResetVaultKeyFetcher = createFetcherSubmitHook(
+  submit => () => {
+    submit({}, { action: href('/auth/reset-vault-key'), method: 'POST' });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/auth.update-vault-salt.tsx
+++ b/packages/insomnia/src/routes/auth.update-vault-salt.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { type ActionFunctionArgs, href, useFetcher } from 'react-router';
+import { type ActionFunctionArgs, href } from 'react-router';
 
 import { userSession as sessionModel } from '~/models';
 import { insomniaFetch } from '~/ui/insomniaFetch';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 export async function clientAction(_args: ActionFunctionArgs) {
   const userSession = await sessionModel.getOrCreate();
@@ -21,15 +21,9 @@ export async function clientAction(_args: ActionFunctionArgs) {
   return vaultSalt;
 }
 
-export function useUpdateVaultSaltFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(() => {
-    return fetcherSubmit({}, { action: href('/auth/update-vault-salt'), method: 'POST' });
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useUpdateVaultSaltFetcher = createFetcherSubmitHook(
+  submit => () => {
+    return submit({}, { action: href('/auth/update-vault-salt'), method: 'POST' });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/auth.validate-vault-key.tsx
+++ b/packages/insomnia/src/routes/auth.validate-vault-key.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { type ActionFunctionArgs, href, useFetcher } from 'react-router';
+import { type ActionFunctionArgs, href } from 'react-router';
 
 import { userSession as sessionModel } from '~/models';
 import { saveVaultKey, validateVaultKey } from '~/ui/vault-key.client';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 export async function clientAction({ request }: ActionFunctionArgs) {
   const { vaultKey, saveVaultKey: saveVaultKeyLocally = false } = await request.json();
@@ -29,24 +29,16 @@ export async function clientAction({ request }: ActionFunctionArgs) {
   }
 }
 
-export function useValidateVaultKeyActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useValidateVaultKeyActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({ vaultKey, saveVaultKey = false }: { vaultKey: string; saveVaultKey?: boolean }) => {
       const url = href('/auth/validate-vault-key');
 
-      return fetcherSubmit(JSON.stringify({ vaultKey, saveVaultKey }), {
+      return submit(JSON.stringify({ vaultKey, saveVaultKey }), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/cloud-credentials.$cloudCredentialId.delete.ts
+++ b/packages/insomnia/src/routes/cloud-credentials.$cloudCredentialId.delete.ts
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/cloud-credentials.$cloudCredentialId.delete';
 
@@ -15,12 +15,10 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useDeleteCloudCredentialActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcher } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    function submit({ cloudCredentialId }: { cloudCredentialId: string }) {
-      return fetcherSubmit(
+export const useDeleteCloudCredentialActionFetcher = createFetcherSubmitHook(
+  submit =>
+    ({ cloudCredentialId }: { cloudCredentialId: string }) => {
+      return submit(
         {},
         {
           method: 'POST',
@@ -31,11 +29,5 @@ export function useDeleteCloudCredentialActionFetcher(args?: Parameters<typeof u
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcher,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/cloud-credentials.$cloudCredentialId.update.ts
+++ b/packages/insomnia/src/routes/cloud-credentials.$cloudCredentialId.update.ts
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { EXTERNAL_VAULT_PLUGIN_NAME } from '~/common/constants';
 import * as models from '~/models';
 import type { CloudProviderCredential } from '~/models/cloud-credential';
 import { executePluginMainAction } from '~/plugins';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/cloud-credentials.$cloudCredentialId.update';
 
@@ -43,18 +43,10 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
   return { error: 'Unexpected response from ' + provider };
 }
 
-export function useUpdateCloudCredentialActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcher } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    function submit({
-      cloudCredentialId,
-      patch,
-    }: {
-      cloudCredentialId: string;
-      patch: Partial<CloudProviderCredential>;
-    }) {
-      return fetcherSubmit(JSON.stringify(patch), {
+export const useUpdateCloudCredentialActionFetcher = createFetcherSubmitHook(
+  submit =>
+    ({ cloudCredentialId, patch }: { cloudCredentialId: string; patch: Partial<CloudProviderCredential> }) => {
+      return submit(JSON.stringify(patch), {
         method: 'POST',
         action: href('/cloud-credentials/:cloudCredentialId/update', {
           cloudCredentialId,
@@ -62,11 +54,5 @@ export function useUpdateCloudCredentialActionFetcher(args?: Parameters<typeof u
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcher,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/cloud-credentials.create.tsx
+++ b/packages/insomnia/src/routes/cloud-credentials.create.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { EXTERNAL_VAULT_PLUGIN_NAME } from '~/common/constants';
 import * as models from '~/models';
 import type { CloudProviderCredential } from '~/models/cloud-credential';
 import { executePluginMainAction } from '~/plugins';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/cloud-credentials.create';
 
@@ -54,22 +54,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return { error: 'Unexpected response from ' + provider };
 }
 
-export function useCreateCloudCredentialActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcher } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    function submit(data: CreateCloudCredentialsData) {
-      return fetcherSubmit(JSON.stringify(data), {
-        method: 'POST',
-        action: href('/cloud-credentials/create'),
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcher,
-    submit,
-  };
-}
+export const useCreateCloudCredentialActionFetcher = createFetcherSubmitHook(
+  submit => (data: CreateCloudCredentialsData) => {
+    return submit(JSON.stringify(data), {
+      method: 'POST',
+      action: href('/cloud-credentials/create'),
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/commands.tsx
+++ b/packages/insomnia/src/routes/commands.tsx
@@ -1,5 +1,3 @@
-import 'react-router';
-
 import { database } from '~/common/database';
 import { fuzzyMatch } from '~/common/misc';
 import {

--- a/packages/insomnia/src/routes/commands.tsx
+++ b/packages/insomnia/src/routes/commands.tsx
@@ -1,5 +1,4 @@
-import { useCallback } from 'react';
-import { useFetcher } from 'react-router';
+import 'react-router';
 
 import { database } from '~/common/database';
 import { fuzzyMatch } from '~/common/misc';
@@ -22,6 +21,7 @@ import type { RequestGroup } from '~/models/request-group';
 import type { WebSocketRequest } from '~/models/websocket-request';
 import { scopeToActivity, type Workspace } from '~/models/workspace';
 import { invariant } from '~/utils/invariant';
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/commands';
 
@@ -287,10 +287,8 @@ export async function clientLoader(args: Route.ClientLoaderArgs) {
   };
 }
 
-export function useCommandsLoaderFetcher() {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>();
-
-  const load = useCallback(
+export const useCommandsLoaderFetcher = createFetcherLoadHook(
+  load =>
     ({
       organizationId,
       projectId,
@@ -312,15 +310,8 @@ export function useCommandsLoaderFetcher() {
         params.set('filter', filter);
       }
 
-      return fetcherLoad(`/commands?${params.toString()}`, {
+      return load(`/commands?${params.toString()}`, {
         flushSync: true,
       });
     },
-    [fetcherLoad],
-  );
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+);

--- a/packages/insomnia/src/routes/commands.tsx
+++ b/packages/insomnia/src/routes/commands.tsx
@@ -314,4 +314,5 @@ export const useCommandsLoaderFetcher = createFetcherLoadHook(
         flushSync: true,
       });
     },
+  clientLoader,
 );

--- a/packages/insomnia/src/routes/git-credentials.github.complete-sign-in.tsx
+++ b/packages/insomnia/src/routes/git-credentials.github.complete-sign-in.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git-credentials.github.complete-sign-in';
 
@@ -13,22 +14,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useGithubCompleteSignInFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    (data: { code: string; state: string }) => {
-      return fetcherSubmit(data, {
-        action: href('/git-credentials/github/complete-sign-in'),
-        method: 'POST',
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useGithubCompleteSignInFetcher = createFetcherSubmitHook(
+  submit => (data: { code: string; state: string }) => {
+    return submit(data, {
+      action: href('/git-credentials/github/complete-sign-in'),
+      method: 'POST',
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git-credentials.github.init-sign-in.tsx
+++ b/packages/insomnia/src/routes/git-credentials.github.init-sign-in.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git-credentials.github.init-sign-in';
 
@@ -9,15 +10,9 @@ export async function clientAction(_args: Route.ClientActionArgs) {
   return null;
 }
 
-export function useInitSignInToGitHubFetcher() {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>();
-
-  const submit = useCallback(() => {
-    return fetcherSubmit({}, { action: href('/git-credentials/github/init-sign-in'), method: 'POST' });
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useInitSignInToGitHubFetcher = createFetcherSubmitHook(
+  submit => () => {
+    return submit({}, { action: href('/git-credentials/github/init-sign-in'), method: 'POST' });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git-credentials.github.sign-out.tsx
+++ b/packages/insomnia/src/routes/git-credentials.github.sign-out.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git-credentials.github.sign-out';
 
@@ -9,15 +10,9 @@ export async function clientAction(_args: Route.ClientActionArgs) {
   return null;
 }
 
-export function useGithubSignOutFetcher() {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>();
-
-  const submit = useCallback(() => {
-    return fetcherSubmit({}, { action: href('/git-credentials/github/sign-out'), method: 'POST' });
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useGithubSignOutFetcher = createFetcherSubmitHook(
+  submit => () => {
+    return submit({}, { action: href('/git-credentials/github/sign-out'), method: 'POST' });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git-credentials.github.tsx
+++ b/packages/insomnia/src/routes/git-credentials.github.tsx
@@ -11,6 +11,9 @@ export async function clientLoader(_args: Route.ClientActionArgs) {
   return credentials;
 }
 
-export const useGitHubCredentialsFetcher = createFetcherLoadHook(load => () => {
-  return load(href('/git-credentials/github'));
-});
+export const useGitHubCredentialsFetcher = createFetcherLoadHook(
+  load => () => {
+    return load(href('/git-credentials/github'));
+  },
+  clientLoader,
+);

--- a/packages/insomnia/src/routes/git-credentials.github.tsx
+++ b/packages/insomnia/src/routes/git-credentials.github.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { gitCredentials } from '~/models';
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/git-credentials.github';
 
@@ -11,15 +11,6 @@ export async function clientLoader(_args: Route.ClientActionArgs) {
   return credentials;
 }
 
-export function useGitHubCredentialsFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(() => {
-    return fetcherLoad(href('/git-credentials/github'));
-  }, [fetcherLoad]);
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+export const useGitHubCredentialsFetcher = createFetcherLoadHook(load => () => {
+  return load(href('/git-credentials/github'));
+});

--- a/packages/insomnia/src/routes/git-credentials.gitlab.complete-sign-in.tsx
+++ b/packages/insomnia/src/routes/git-credentials.gitlab.complete-sign-in.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git-credentials.gitlab.complete-sign-in';
 
@@ -13,22 +14,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useGitLabCompleteSignInFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    (data: { code: string; state: string }) => {
-      return fetcherSubmit(data, {
-        action: href('/git-credentials/gitlab/complete-sign-in'),
-        method: 'POST',
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useGitLabCompleteSignInFetcher = createFetcherSubmitHook(
+  submit => (data: { code: string; state: string }) => {
+    return submit(data, {
+      action: href('/git-credentials/gitlab/complete-sign-in'),
+      method: 'POST',
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git-credentials.gitlab.init-sign-in.tsx
+++ b/packages/insomnia/src/routes/git-credentials.gitlab.init-sign-in.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git-credentials.gitlab.init-sign-in';
 
@@ -9,15 +10,9 @@ export async function clientAction(_args: Route.ClientActionArgs) {
   return null;
 }
 
-export function useInitSignInToGitLabFetcher() {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>();
-
-  const submit = useCallback(() => {
-    return fetcherSubmit({}, { action: href('/git-credentials/gitlab/init-sign-in'), method: 'POST' });
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useInitSignInToGitLabFetcher = createFetcherSubmitHook(
+  submit => () => {
+    return submit({}, { action: href('/git-credentials/gitlab/init-sign-in'), method: 'POST' });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git-credentials.gitlab.sign-out.tsx
+++ b/packages/insomnia/src/routes/git-credentials.gitlab.sign-out.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git-credentials.gitlab.sign-out';
 
@@ -9,15 +10,9 @@ export async function clientAction(_args: Route.ClientActionArgs) {
   return null;
 }
 
-export function useGitLabSignOutFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(() => {
-    return fetcherSubmit({}, { action: href('/git-credentials/gitlab/sign-out'), method: 'POST' });
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useGitLabSignOutFetcher = createFetcherSubmitHook(
+  submit => () => {
+    return submit({}, { action: href('/git-credentials/gitlab/sign-out'), method: 'POST' });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git-credentials.gitlab.tsx
+++ b/packages/insomnia/src/routes/git-credentials.gitlab.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { gitCredentials } from '~/models';
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/git-credentials.gitlab';
 
@@ -11,15 +11,6 @@ export async function clientLoader(_args: Route.ClientActionArgs) {
   return credentials;
 }
 
-export function useGitLabCredentialsFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(() => {
-    return fetcherLoad(href('/git-credentials/gitlab'));
-  }, [fetcherLoad]);
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+export const useGitLabCredentialsFetcher = createFetcherLoadHook(load => () => {
+  return load(href('/git-credentials/gitlab'));
+});

--- a/packages/insomnia/src/routes/git-credentials.gitlab.tsx
+++ b/packages/insomnia/src/routes/git-credentials.gitlab.tsx
@@ -11,6 +11,9 @@ export async function clientLoader(_args: Route.ClientActionArgs) {
   return credentials;
 }
 
-export const useGitLabCredentialsFetcher = createFetcherLoadHook(load => () => {
-  return load(href('/git-credentials/gitlab'));
-});
+export const useGitLabCredentialsFetcher = createFetcherLoadHook(
+  load => () => {
+    return load(href('/git-credentials/gitlab'));
+  },
+  clientLoader,
+);

--- a/packages/insomnia/src/routes/git.branch.checkout.tsx
+++ b/packages/insomnia/src/routes/git.branch.checkout.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.branch.checkout';
 
@@ -19,22 +19,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return window.main.git.checkoutGitBranch(data);
 }
 
-export function useGitProjectCheckoutBranchActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    (data: CheckoutGitBranchData) => {
-      return fetcherSubmit(JSON.stringify(data), {
-        method: 'POST',
-        action: href('/git/branch/checkout'),
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useGitProjectCheckoutBranchActionFetcher = createFetcherSubmitHook(
+  submit => (data: CheckoutGitBranchData) => {
+    return submit(JSON.stringify(data), {
+      method: 'POST',
+      action: href('/git/branch/checkout'),
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.branch.delete.tsx
+++ b/packages/insomnia/src/routes/git.branch.delete.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import { invariant } from '../utils/invariant';
 import type { Route } from './+types/git.branch.delete';
@@ -18,22 +19,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return window.main.git.deleteGitBranch(data);
 }
 
-export function useGitProjectDeleteBranchActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    (data: DeleteGitBranchData) => {
-      return fetcherSubmit(JSON.stringify(data), {
-        method: 'POST',
-        action: href('/git/branch/delete'),
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useGitProjectDeleteBranchActionFetcher = createFetcherSubmitHook(
+  submit => (data: DeleteGitBranchData) => {
+    return submit(JSON.stringify(data), {
+      method: 'POST',
+      action: href('/git/branch/delete'),
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.branch.new.tsx
+++ b/packages/insomnia/src/routes/git.branch.new.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.branch.new';
 
@@ -19,22 +19,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return window.main.git.createNewGitBranch(data);
 }
 
-export function useGitProjectNewBranchActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    (data: NewGitBranchData) => {
-      return fetcherSubmit(JSON.stringify(data), {
-        method: 'POST',
-        action: href('/git/branch/new'),
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useGitProjectNewBranchActionFetcher = createFetcherSubmitHook(
+  submit => (data: NewGitBranchData) => {
+    return submit(JSON.stringify(data), {
+      method: 'POST',
+      action: href('/git/branch/new'),
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.branches.tsx
+++ b/packages/insomnia/src/routes/git.branches.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/git.branches';
 
@@ -15,13 +16,8 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   });
 }
 
-export function useGitProjectBranchesLoaderFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const {
-    load: fetcherLoad,
-    ...fetcherRest
-  } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(
+export const useGitProjectBranchesLoaderFetcher = createFetcherLoadHook(
+  load =>
     ({ projectId, workspaceId }: { workspaceId?: string; projectId: string }) => {
       const searchParams = new URLSearchParams();
 
@@ -29,13 +25,6 @@ export function useGitProjectBranchesLoaderFetcher(args?: Parameters<typeof useF
         searchParams.set('workspaceId', workspaceId);
       }
       searchParams.set('projectId', projectId);
-      return fetcherLoad(`${href('/git/branches')}?${searchParams.toString()}`);
+      return load(`${href('/git/branches')}?${searchParams.toString()}`);
     },
-    [fetcherLoad]
-  );
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+);

--- a/packages/insomnia/src/routes/git.branches.tsx
+++ b/packages/insomnia/src/routes/git.branches.tsx
@@ -27,4 +27,5 @@ export const useGitProjectBranchesLoaderFetcher = createFetcherLoadHook(
       searchParams.set('projectId', projectId);
       return load(`${href('/git/branches')}?${searchParams.toString()}`);
     },
+  clientLoader,
 );

--- a/packages/insomnia/src/routes/git.changes.tsx
+++ b/packages/insomnia/src/routes/git.changes.tsx
@@ -27,4 +27,5 @@ export const useGitProjectChangesFetcher = createFetcherLoadHook(
 
       return load(`${href('/git/changes')}?${searchParams.toString()}`);
     },
+  clientLoader,
 );

--- a/packages/insomnia/src/routes/git.changes.tsx
+++ b/packages/insomnia/src/routes/git.changes.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/git.changes';
 
@@ -15,13 +16,8 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   });
 }
 
-export function useGitProjectChangesFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const {
-    load: fetcherLoad,
-    ...fetcherRest
-  } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(
+export const useGitProjectChangesFetcher = createFetcherLoadHook(
+  load =>
     ({ projectId, workspaceId }: { projectId: string; workspaceId?: string }) => {
       const searchParams = new URLSearchParams();
       if (workspaceId) {
@@ -29,13 +25,6 @@ export function useGitProjectChangesFetcher(args?: Parameters<typeof useFetcher>
       }
       searchParams.set('projectId', projectId);
 
-      return fetcherLoad(`${href('/git/changes')}?${searchParams.toString()}`);
+      return load(`${href('/git/changes')}?${searchParams.toString()}`);
     },
-    [fetcherLoad]
-  );
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+);

--- a/packages/insomnia/src/routes/git.clone.tsx
+++ b/packages/insomnia/src/routes/git.clone.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import type { GitCredentials } from '~/models/git-repository';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.clone';
 
@@ -36,22 +36,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   );
 }
 
-export function useGitCloneActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const {
-    submit: fetcherSubmit,
-    ...fetcherRest
-  } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback((data: CloneGitRepoData) => {
-    return fetcherSubmit(JSON.stringify(data), {
+export const useGitCloneActionFetcher = createFetcherSubmitHook(
+  submit => (data: CloneGitRepoData) => {
+    return submit(JSON.stringify(data), {
       method: 'POST',
       action: href('/git/clone'),
       encType: 'application/json',
     });
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.commit.tsx
+++ b/packages/insomnia/src/routes/git.commit.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.commit';
 
@@ -24,22 +24,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return window.main.git.commitToGitRepo(data);
 }
 
-export function useGitProjectCommitActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const {
-    submit: fetcherSubmit,
-    ...fetcherRest
-  } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback((data: CommitGitRepoData) => {
-    return fetcherSubmit(JSON.stringify(data), {
+export const useGitProjectCommitActionFetcher = createFetcherSubmitHook(
+  submit => (data: CommitGitRepoData) => {
+    return submit(JSON.stringify(data), {
       action: href('/git/commit'),
       method: 'POST',
       encType: 'application/json',
     });
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.diff.tsx
+++ b/packages/insomnia/src/routes/git.diff.tsx
@@ -42,4 +42,5 @@ export const useGitProjectDiffLoaderFetcher = createFetcherLoadHook(
 
       return load(`${href('/git/diff')}?${params.toString()}`);
     },
+  clientLoader,
 );

--- a/packages/insomnia/src/routes/git.diff.tsx
+++ b/packages/insomnia/src/routes/git.diff.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { invariant } from '~/utils/invariant';
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/git.diff';
 
@@ -19,14 +19,9 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   return window.main.git.diffFileLoader({ filepath, staged, projectId, workspaceId });
 }
 
-export function useGitProjectDiffLoaderFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const {
-    load: fetcherLoad,
-    ...fetcherRest
-  } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback((
-    {
+export const useGitProjectDiffLoaderFetcher = createFetcherLoadHook(
+  load =>
+    ({
       workspaceId,
       projectId,
       filePath,
@@ -36,21 +31,15 @@ export function useGitProjectDiffLoaderFetcher(args?: Parameters<typeof useFetch
       projectId: string;
       filePath: string;
       staged: boolean;
-    }
-  ) => {
-    const params = new URLSearchParams();
-    params.set('filepath', filePath);
-    params.set('staged', staged ? 'true' : 'false');
-    if (workspaceId) {
-      params.set('workspaceId', workspaceId);
-    }
-    params.set('projectId', projectId);
+    }) => {
+      const params = new URLSearchParams();
+      params.set('filepath', filePath);
+      params.set('staged', staged ? 'true' : 'false');
+      if (workspaceId) {
+        params.set('workspaceId', workspaceId);
+      }
+      params.set('projectId', projectId);
 
-    return fetcherLoad(`${href('/git/diff')}?${params.toString()}`);
-  }, [fetcherLoad]);
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+      return load(`${href('/git/diff')}?${params.toString()}`);
+    },
+);

--- a/packages/insomnia/src/routes/git.discard.tsx
+++ b/packages/insomnia/src/routes/git.discard.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.discard';
 
@@ -15,22 +16,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return window.main.git.discardChanges(data);
 }
 
-export function useGitProjectDiscardActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const {
-    submit: fetcherSubmit,
-    ...fetcherRest
-  } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback((data: DiscardGitChangesData) => {
-    return fetcherSubmit(JSON.stringify(data), {
+export const useGitProjectDiscardActionFetcher = createFetcherSubmitHook(
+  submit => (data: DiscardGitChangesData) => {
+    return submit(JSON.stringify(data), {
       method: 'POST',
       action: href('/git/discard'),
       encType: 'application/json',
     });
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.fetch.tsx
+++ b/packages/insomnia/src/routes/git.fetch.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.fetch';
 
@@ -14,23 +15,14 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return window.main.git.gitFetchAction(data);
 }
 
-export function useGitProjectFetchActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const {
-    submit: fetcherSubmit,
-    ...fetcherRest
-  } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback((data: FetchGitData) => {
+export const useGitProjectFetchActionFetcher = createFetcherSubmitHook(
+  submit => (data: FetchGitData) => {
     console.log('Submitting git fetch action', data);
-    return fetcherSubmit(JSON.stringify(data), {
+    return submit(JSON.stringify(data), {
       method: 'POST',
       action: href('/git/fetch'),
       encType: 'application/json',
     });
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.init-clone.tsx
+++ b/packages/insomnia/src/routes/git.init-clone.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import type { GitCredentials } from '~/models/git-repository';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.init-clone';
 
@@ -29,22 +29,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   };
 }
 
-export function useGitProjectInitCloneActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const {
-    submit: fetcherSubmit,
-    ...fetcherRest
-  } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback((data: RepoInitCloneData) => {
-    return fetcherSubmit(JSON.stringify(data), {
+export const useGitProjectInitCloneActionFetcher = createFetcherSubmitHook(
+  submit => (data: RepoInitCloneData) => {
+    return submit(JSON.stringify(data), {
       action: href('/git/init-clone'),
       method: 'POST',
       encType: 'application/json',
     });
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.log.tsx
+++ b/packages/insomnia/src/routes/git.log.tsx
@@ -23,4 +23,5 @@ export const useGitProjectLogLoaderFetcher = createFetcherLoadHook(
       searchParams.set('projectId', projectId);
       return load(`${href('/git/log')}?${searchParams.toString()}`);
     },
+  clientLoader,
 );

--- a/packages/insomnia/src/routes/git.log.tsx
+++ b/packages/insomnia/src/routes/git.log.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/git.log';
 
@@ -12,26 +13,14 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   return window.main.git.gitLogLoader({ workspaceId, projectId });
 }
 
-export function useGitProjectLogLoaderFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const {
-    load: fetcherLoad,
-    ...fetcherRest
-  } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(
+export const useGitProjectLogLoaderFetcher = createFetcherLoadHook(
+  load =>
     ({ workspaceId, projectId }: { workspaceId?: string; projectId: string }) => {
       const searchParams = new URLSearchParams();
       if (workspaceId) {
         searchParams.set('workspaceId', workspaceId);
       }
       searchParams.set('projectId', projectId);
-      return fetcherLoad(`${href('/git/log')}?${searchParams.toString()}`);
+      return load(`${href('/git/log')}?${searchParams.toString()}`);
     },
-    [fetcherLoad]
-  );
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+);

--- a/packages/insomnia/src/routes/git.migrate-legacy-insomnia-folder-to-file.tsx
+++ b/packages/insomnia/src/routes/git.migrate-legacy-insomnia-folder-to-file.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.migrate-legacy-insomnia-folder-to-file';
 
@@ -10,12 +11,10 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return window.main.git.migrateLegacyInsomniaFolderToFile({ projectId });
 }
 
-export function useGitProjectMigrateLegacyInsomniaFolderActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useGitProjectMigrateLegacyInsomniaFolderActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({ projectId }: { projectId: string }) => {
-      return fetcherSubmit(
+      return submit(
         {
           projectId,
         },
@@ -26,11 +25,5 @@ export function useGitProjectMigrateLegacyInsomniaFolderActionFetcher(args?: Par
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.push.tsx
+++ b/packages/insomnia/src/routes/git.push.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.push';
 
@@ -15,19 +16,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return window.main.git.pushToGitRemote(data);
 }
 
-export function useGitProjectPushActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    (data: PushGitData) => {
-      return fetcherSubmit(JSON.stringify(data), {
-        method: 'POST',
-        action: href('/git/push'),
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return { ...fetcherRest, submit };
-}
+export const useGitProjectPushActionFetcher = createFetcherSubmitHook(
+  submit => (data: PushGitData) => {
+    return submit(JSON.stringify(data), {
+      method: 'POST',
+      action: href('/git/push'),
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.remote-branches.tsx
+++ b/packages/insomnia/src/routes/git.remote-branches.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import type { GitCredentials } from '~/models/git-repository';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.remote-branches';
 
@@ -16,22 +16,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return window.main.git.fetchGitRemoteBranches(data);
 }
 
-export function useGitRemoteBranchesActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    (data: FetchRemoteBranchesData) => {
-      return fetcherSubmit(JSON.stringify(data), {
-        method: 'POST',
-        action: href(`/git/remote-branches`),
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useGitRemoteBranchesActionFetcher = createFetcherSubmitHook(
+  submit => (data: FetchRemoteBranchesData) => {
+    return submit(JSON.stringify(data), {
+      method: 'POST',
+      action: href(`/git/remote-branches`),
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.repo.tsx
+++ b/packages/insomnia/src/routes/git.repo.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/git.repo';
 
@@ -12,10 +13,8 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   return window.main.git.loadGitRepository({ workspaceId, projectId });
 }
 
-export function useGitProjectRepoFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(
+export const useGitProjectRepoFetcher = createFetcherLoadHook(
+  load =>
     ({ workspaceId, projectId }: { workspaceId?: string; projectId: string }) => {
       const searchParams = new URLSearchParams();
       if (workspaceId) {
@@ -23,13 +22,6 @@ export function useGitProjectRepoFetcher(args?: Parameters<typeof useFetcher>[0]
       }
       searchParams.set('projectId', projectId);
 
-      return fetcherLoad(`${href('/git/repo')}?${searchParams.toString()}`);
+      return load(`${href('/git/repo')}?${searchParams.toString()}`);
     },
-    [fetcherLoad],
-  );
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+);

--- a/packages/insomnia/src/routes/git.repo.tsx
+++ b/packages/insomnia/src/routes/git.repo.tsx
@@ -24,4 +24,5 @@ export const useGitProjectRepoFetcher = createFetcherLoadHook(
 
       return load(`${href('/git/repo')}?${searchParams.toString()}`);
     },
+  clientLoader,
 );

--- a/packages/insomnia/src/routes/git.repository-tree.tsx
+++ b/packages/insomnia/src/routes/git.repository-tree.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/git.repository-tree';
 
@@ -11,22 +12,13 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   return window.main.git.getRepositoryDirectoryTree({ projectId });
 }
 
-export function useGitProjectRepositoryTreeLoaderFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(
+export const useGitProjectRepositoryTreeLoaderFetcher = createFetcherLoadHook(
+  load =>
     ({ projectId }: { projectId: string }) => {
       const searchParams = new URLSearchParams();
 
       searchParams.set('projectId', projectId);
 
-      return fetcherLoad(`${href('/git/repository-tree')}?${searchParams.toString()}`);
+      return load(`${href('/git/repository-tree')}?${searchParams.toString()}`);
     },
-    [fetcherLoad],
-  );
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+);

--- a/packages/insomnia/src/routes/git.repository-tree.tsx
+++ b/packages/insomnia/src/routes/git.repository-tree.tsx
@@ -21,4 +21,5 @@ export const useGitProjectRepositoryTreeLoaderFetcher = createFetcherLoadHook(
 
       return load(`${href('/git/repository-tree')}?${searchParams.toString()}`);
     },
+  clientLoader,
 );

--- a/packages/insomnia/src/routes/git.reset.tsx
+++ b/packages/insomnia/src/routes/git.reset.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.reset';
 
@@ -14,22 +15,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return window.main.git.resetGitRepo(data);
 }
 
-export function useGitProjectResetActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    (data: ResetGitRepoParams) => {
-      return fetcherSubmit(JSON.stringify(data), {
-        method: 'POST',
-        action: href('/git/reset'),
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useGitProjectResetActionFetcher = createFetcherSubmitHook(
+  submit => (data: ResetGitRepoParams) => {
+    return submit(JSON.stringify(data), {
+      method: 'POST',
+      action: href('/git/reset'),
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.stage.tsx
+++ b/packages/insomnia/src/routes/git.stage.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.stage';
 
@@ -14,22 +15,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return window.main.git.stageChanges(data);
 }
 
-export function useGitProjectStageActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    (data: StageGitChangesData) => {
-      return fetcherSubmit(JSON.stringify(data), {
-        method: 'POST',
-        action: href('/git/stage'),
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useGitProjectStageActionFetcher = createFetcherSubmitHook(
+  submit => (data: StageGitChangesData) => {
+    return submit(JSON.stringify(data), {
+      method: 'POST',
+      action: href('/git/stage'),
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.status.tsx
+++ b/packages/insomnia/src/routes/git.status.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.status';
 
@@ -14,22 +15,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return window.main.git.gitStatus(data);
 }
 
-export function useGitProjectStatusActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    (data: GitStatusData) => {
-      return fetcherSubmit(JSON.stringify(data), {
-        method: 'POST',
-        action: href('/git/status'),
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useGitProjectStatusActionFetcher = createFetcherSubmitHook(
+  submit => (data: GitStatusData) => {
+    return submit(JSON.stringify(data), {
+      method: 'POST',
+      action: href('/git/status'),
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.unstage.tsx
+++ b/packages/insomnia/src/routes/git.unstage.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
+
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.unstage';
 
@@ -15,22 +16,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return window.main.git.unstageChanges(data);
 }
 
-export function useGitProjectUnstageActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    (data: UnstageGitChangesData) => {
-      return fetcherSubmit(JSON.stringify(data), {
-        method: 'POST',
-        action: href('/git/unstage'),
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useGitProjectUnstageActionFetcher = createFetcherSubmitHook(
+  submit => (data: UnstageGitChangesData) => {
+    return submit(JSON.stringify(data), {
+      method: 'POST',
+      action: href('/git/unstage'),
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/git.update.tsx
+++ b/packages/insomnia/src/routes/git.update.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import type { GitCredentials } from '~/models/git-repository';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git.update';
 
@@ -22,22 +22,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return window.main.git.updateGitRepo(data);
 }
 
-export function useGitProjectUpdateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    (data: UpdateGitRepoData) => {
-      return fetcherSubmit(JSON.stringify(data), {
-        method: 'POST',
-        action: href(`/git/update`),
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useGitProjectUpdateActionFetcher = createFetcherSubmitHook(
+  submit => (data: UpdateGitRepoData) => {
+    return submit(JSON.stringify(data), {
+      method: 'POST',
+      action: href(`/git/update`),
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -1,5 +1,4 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { importResourcesToProject, importResourcesToWorkspace } from '~/common/import';
 import * as models from '~/models';
@@ -12,6 +11,7 @@ import {
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { fetchAndCacheOrganizationStorageRule } from '~/ui/organization-utils';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/import.resources';
 
@@ -71,23 +71,16 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   }
 }
 
-export function useImportResourcesFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-  const submit = useCallback(
-    (data: { organizationId: string; projectId: string; workspaceId?: string }) => {
-      fetcherSubmit(JSON.stringify(data), {
-        action: href('/import/resources'),
-        method: 'POST',
-        encType: 'application/json',
-      });
-    },
-    [fetcherSubmit],
-  );
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useImportResourcesFetcher = createFetcherSubmitHook(
+  submit => (data: { organizationId: string; projectId: string; workspaceId?: string }) => {
+    submit(JSON.stringify(data), {
+      action: href('/import/resources'),
+      method: 'POST',
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);
 
 // The reason why we put this function here is because this function indirectly depends on some modules that can only run in a browser environment.
 // If we put this function in import.ts which is depended by Inso CLI, Inso CLI will fail to build because it doesn't have access to the browser environment.

--- a/packages/insomnia/src/routes/import.scan.tsx
+++ b/packages/insomnia/src/routes/import.scan.tsx
@@ -1,13 +1,13 @@
 import path from 'node:path';
 
-import { useCallback } from 'react';
-import { type ActionFunctionArgs, href, useFetcher } from 'react-router';
+import { type ActionFunctionArgs, href } from 'react-router';
 
 import type { ScanResult } from '~/common/import';
 import { fetchImportContentFromURI, getFilesFromPostmanExportedDataDump, scanResources } from '~/common/import';
 import { SegmentEvent } from '~/ui/analytics';
 import type { ImportEntry } from '~/utils/importers/entities';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 type SourceType = 'file' | 'uri' | 'clipboard';
 
@@ -153,20 +153,12 @@ export async function clientAction({ request }: ActionFunctionArgs) {
   }
 }
 
-export function useScanResourcesFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-  const submit = useCallback(
-    (data: FormData | HTMLFormElement) => {
-      return fetcherSubmit(data, {
-        action: href('/import/scan'),
-        method: 'POST',
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useScanResourcesFetcher = createFetcherSubmitHook(
+  submit => (data: FormData | HTMLFormElement) => {
+    return submit(data, {
+      action: href('/import/scan'),
+      method: 'POST',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.collaborators-search.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.collaborators-search.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { userSession } from '~/models';
 import { insomniaFetch } from '~/ui/insomniaFetch';
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.collaborators-search';
 
@@ -36,20 +36,11 @@ export async function clientLoader({ params, request }: Route.ClientLoaderArgs) 
   }
 }
 
-export function useCollaboratorsSearchLoaderFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(
+export const useCollaboratorsSearchLoaderFetcher = createFetcherLoadHook(
+  load =>
     ({ organizationId, query }: { organizationId: string; query?: string }) => {
-      return fetcherLoad(
+      return load(
         `${href(`/organization/:organizationId/collaborators-search`, { organizationId })}?${encodeURIComponent(query || '')}`,
       );
     },
-    [fetcherLoad],
-  );
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.collaborators-search.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.collaborators-search.tsx
@@ -43,4 +43,5 @@ export const useCollaboratorsSearchLoaderFetcher = createFetcherLoadHook(
         `${href(`/organization/:organizationId/collaborators-search`, { organizationId })}?${encodeURIComponent(query || '')}`,
       );
     },
+  clientLoader,
 );

--- a/packages/insomnia/src/routes/organization.$organizationId.collaborators.invites.$invitationId.reinvite.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.collaborators.invites.$invitationId.reinvite.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { insomniaFetch } from '~/ui/insomniaFetch';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.collaborators.invites.$invitationId.reinvite';
 
@@ -25,29 +25,19 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   }
 }
 
-export function useReinviteFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const {
-    submit: fetcherSubmit,
-    ...fetcherRest
-  } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback((
-    { organizationId, invitationId }: { organizationId: string; invitationId: string }
-  ) => {
-    return fetcherSubmit(
-      {},
-      {
-        action: href(`/organization/:organizationId/collaborators/invites/:invitationId/reinvite`, {
-          organizationId,
-          invitationId,
-        }),
-        method: 'POST',
-      },
-    );
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+export const useReinviteFetcher = createFetcherSubmitHook(
+  submit =>
+    ({ organizationId, invitationId }: { organizationId: string; invitationId: string }) => {
+      return submit(
+        {},
+        {
+          action: href(`/organization/:organizationId/collaborators/invites/:invitationId/reinvite`, {
+            organizationId,
+            invitationId,
+          }),
+          method: 'POST',
+        },
+      );
+    },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.collaborators.invites.$invitationId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.collaborators.invites.$invitationId.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { insomniaFetch } from '~/ui/insomniaFetch';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.collaborators.invites.$invitationId';
 
@@ -32,12 +32,10 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   }
 }
 
-export function useInviteFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useInviteFetcher = createFetcherSubmitHook(
+  submit =>
     ({ organizationId, invitationId, roleId }: { organizationId: string; invitationId: string; roleId: string }) => {
-      return fetcherSubmit(
+      return submit(
         { roleId },
         {
           action: href(`/organization/:organizationId/collaborators/invites/:invitationId`, {
@@ -48,11 +46,5 @@ export function useInviteFetcher(args?: Parameters<typeof useFetcher>[0]) {
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.collaborators.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.collaborators.tsx
@@ -95,4 +95,5 @@ export const useCollaboratorsFetcher = createFetcherLoadHook(
 
       load(`${href(`/organization/:organizationId/collaborators`, { organizationId })}?${queryParams.toString()}`);
     },
+  clientLoader,
 );

--- a/packages/insomnia/src/routes/organization.$organizationId.collaborators.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.collaborators.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { userSession } from '~/models';
 import { insomniaFetch } from '~/ui/insomniaFetch';
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.collaborators';
 
@@ -75,10 +75,8 @@ export async function clientLoader({ params, request }: Route.ClientLoaderArgs) 
   }
 }
 
-export function useCollaboratorsFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(
+export const useCollaboratorsFetcher = createFetcherLoadHook(
+  load =>
     ({
       organizationId,
       page,
@@ -95,15 +93,6 @@ export function useCollaboratorsFetcher(args?: Parameters<typeof useFetcher>[0])
       if (per_page) queryParams.append('per_page', String(per_page));
       if (filter) queryParams.append('filter', filter);
 
-      fetcherLoad(
-        `${href(`/organization/:organizationId/collaborators`, { organizationId })}?${queryParams.toString()}`,
-      );
+      load(`${href(`/organization/:organizationId/collaborators`, { organizationId })}?${queryParams.toString()}`);
     },
-    [fetcherLoad],
-  );
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.insomnia-sync.pull-remote-file.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.insomnia-sync.pull-remote-file.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import * as models from '~/models';
 import { scopeToActivity } from '~/models/workspace';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { pullBackendProject } from '~/sync/vcs/pull-backend-project';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.insomnia-sync.pull-remote-file';
 
@@ -60,10 +60,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   }
 }
 
-export function useInsomniaSyncPullRemoteFileActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useInsomniaSyncPullRemoteFileActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       backendProjectId,
@@ -81,16 +79,10 @@ export function useInsomniaSyncPullRemoteFileActionFetcher(args?: Parameters<typ
       formData.set('backendProjectId', backendProjectId);
       formData.set('remoteId', remoteId);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         action: url,
         method: 'POST',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.members.$userId.roles.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.members.$userId.roles.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { insomniaFetch } from '~/ui/insomniaFetch';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.members.$userId.roles';
 
@@ -34,15 +34,13 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   }
 }
 
-export function useOrganizationMemberRolesActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useOrganizationMemberRolesActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({ organizationId, userId, roleId }: { organizationId: string; userId: string; roleId: string }) => {
       const formData = new FormData();
       formData.set('roleId', roleId);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         method: 'POST',
         action: href(`/organization/:organizationId/members/:userId/roles`, {
           organizationId,
@@ -50,11 +48,5 @@ export function useOrganizationMemberRolesActionFetcher(args?: Parameters<typeof
         }),
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.permissions.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.permissions.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, redirect, type ShouldRevalidateFunctionArgs, useFetcher } from 'react-router';
+import { href, redirect, type ShouldRevalidateFunctionArgs } from 'react-router';
 
 import { userSession } from '~/models';
 import { isScratchpadOrganizationId, type Organization } from '~/models/organization';
 import { insomniaFetch } from '~/ui/insomniaFetch';
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.permissions';
 import type { Billing, FeatureList } from './organization';
@@ -63,22 +63,14 @@ export function shouldRevalidate(args: ShouldRevalidateFunctionArgs) {
   return args.currentParams.organizationId !== args.nextParams.organizationId;
 }
 
-export function useOrganizationPermissionsLoaderFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(
+export const useOrganizationPermissionsLoaderFetcher = createFetcherLoadHook(
+  load =>
     ({ organizationId }: { organizationId: string }) => {
-      return fetcherLoad(
+      return load(
         href('/organization/:organizationId/permissions', {
           organizationId,
         }),
       );
     },
-    [fetcherLoad],
-  );
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+  clientLoader,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.delete.tsx
@@ -1,12 +1,11 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import { database } from '~/common/database';
 import { projectLock } from '~/common/project';
 import * as models from '~/models';
 import { insomniaFetch } from '~/ui/insomniaFetch';
 import { invariant } from '~/utils/invariant';
-import { getInitialRouteForOrganization } from '~/utils/router';
+import { createFetcherSubmitHook, getInitialRouteForOrganization } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.delete';
 
@@ -70,17 +69,15 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   }
 }
 
-export function useProjectDeleteActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useProjectDeleteActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({ organizationId, projectId }: { organizationId: string; projectId: string }) => {
       const url = href('/organization/:organizationId/project/:projectId/delete', {
         organizationId,
         projectId,
       });
 
-      return fetcherSubmit(
+      return submit(
         {},
         {
           action: url,
@@ -88,11 +85,5 @@ export function useProjectDeleteActionFetcher(args?: Parameters<typeof useFetche
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.list-workspaces.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.list-workspaces.tsx
@@ -1,5 +1,4 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { parseApiSpec, type ParsedApiSpec } from '~/common/api-specs';
 import { database } from '~/common/database';
@@ -14,6 +13,7 @@ import { type Project } from '~/models/project';
 import { isDesign } from '~/models/workspace';
 import type { WorkspaceMeta } from '~/models/workspace-meta';
 import { invariant } from '~/utils/invariant';
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.list-workspaces';
 import { type InsomniaFile, scopeToLabelMap } from './organization.$organizationId.project.$projectId._index';
@@ -135,23 +135,14 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   };
 }
 
-export function useProjectListWorkspacesLoaderFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(
+export const useProjectListWorkspacesLoaderFetcher = createFetcherLoadHook(
+  load =>
     ({ organizationId, projectId }: { organizationId: string; projectId: string }) => {
-      return fetcherLoad(
+      return load(
         href('/organization/:organizationId/project/:projectId/list-workspaces', {
           organizationId,
           projectId,
         }),
       );
     },
-    [fetcherLoad],
-  );
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.list-workspaces.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.list-workspaces.tsx
@@ -145,4 +145,5 @@ export const useProjectListWorkspacesLoaderFetcher = createFetcherLoadHook(
         }),
       );
     },
+  clientLoader,
 );

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.move-workspace.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.move-workspace.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.move-workspace';
 
@@ -25,28 +25,19 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useProjectMoveWorkspaceActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
+export const useProjectMoveWorkspaceActionFetcher = createFetcherSubmitHook(
+  submit => (organizationId: string, projectId: string, workspaceId: string) => {
+    const formData = new FormData();
+    formData.set('projectId', projectId);
+    formData.set('workspaceId', workspaceId);
 
-  const submit = useCallback(
-    (organizationId: string, projectId: string, workspaceId: string) => {
-      const formData = new FormData();
-      formData.set('projectId', projectId);
-      formData.set('workspaceId', workspaceId);
-
-      return fetcherSubmit(formData, {
-        method: 'POST',
-        action: href(`/organization/:organizationId/project/:projectId/move-workspace`, {
-          organizationId,
-          projectId,
-        }),
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+    return submit(formData, {
+      method: 'POST',
+      action: href(`/organization/:organizationId/project/:projectId/move-workspace`, {
+        organizationId,
+        projectId,
+      }),
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.move.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.move.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.move';
 
@@ -26,10 +26,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useProjectMoveActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useProjectMoveActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       currentOrganizationId,
       projectId,
@@ -39,7 +37,7 @@ export function useProjectMoveActionFetcher(args?: Parameters<typeof useFetcher>
       projectId: string;
       newOrganizationId: string;
     }) => {
-      return fetcherSubmit(
+      return submit(
         {
           organizationId: newOrganizationId,
         },
@@ -52,11 +50,5 @@ export function useProjectMoveActionFetcher(args?: Parameters<typeof useFetcher>
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.update.tsx
@@ -1,5 +1,4 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { database } from '~/common/database';
 import { projectLock } from '~/common/project';
@@ -11,6 +10,7 @@ import type { WorkspaceMeta } from '~/models/workspace-meta';
 import { SegmentEvent } from '~/ui/analytics';
 import { insomniaFetch } from '~/ui/insomniaFetch';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.update';
 
@@ -321,10 +321,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   }
 }
 
-export function useProjectUpdateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useProjectUpdateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -334,7 +332,7 @@ export function useProjectUpdateActionFetcher(args?: Parameters<typeof useFetche
       projectId: string;
       projectData: UpdateProjectInputData;
     }) => {
-      return fetcherSubmit(JSON.stringify(projectData), {
+      return submit(JSON.stringify(projectData), {
         method: 'POST',
         action: href('/organization/:organizationId/project/:projectId/update', {
           organizationId,
@@ -343,11 +341,5 @@ export function useProjectUpdateActionFetcher(args?: Parameters<typeof useFetche
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.cacert.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.cacert.delete.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.cacert.delete';
 
@@ -15,10 +15,8 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useCaCertDeleteActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useCaCertDeleteActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -34,7 +32,7 @@ export function useCaCertDeleteActionFetcher(args?: Parameters<typeof useFetcher
         workspaceId,
       });
 
-      return fetcherSubmit(
+      return submit(
         {},
         {
           action: url,
@@ -42,11 +40,5 @@ export function useCaCertDeleteActionFetcher(args?: Parameters<typeof useFetcher
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.cacert.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.cacert.new.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.cacert.new';
 
@@ -11,10 +11,8 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useCACertNewActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useCACertNewActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -32,17 +30,11 @@ export function useCACertNewActionFetcher(args?: Parameters<typeof useFetcher>[0
         workspaceId,
       });
 
-      return fetcherSubmit(JSON.stringify(patch), {
+      return submit(JSON.stringify(patch), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.cacert.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.cacert.update.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import type { CaCertificate } from '~/models/ca-certificate';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.cacert.update';
 
@@ -19,10 +19,8 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useCACertUpdateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useCACertUpdateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -40,17 +38,11 @@ export function useCACertUpdateActionFetcher(args?: Parameters<typeof useFetcher
         workspaceId,
       });
 
-      return fetcherSubmit(JSON.stringify(patch), {
+      return submit(JSON.stringify(patch), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.clientcert.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.clientcert.delete.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.clientcert.delete';
 
@@ -15,10 +15,8 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useClientCertDeleteActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useClientCertDeleteActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -36,17 +34,11 @@ export function useClientCertDeleteActionFetcher(args?: Parameters<typeof useFet
         workspaceId,
       });
 
-      return fetcherSubmit(JSON.stringify({ _id }), {
+      return submit(JSON.stringify({ _id }), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.clientcert.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.clientcert.new.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import type { ClientCertificate } from '~/models/client-certificate';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.clientcert.new';
 
@@ -15,10 +15,8 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   };
 }
 
-export function useClientCertNewActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useClientCertNewActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -30,7 +28,7 @@ export function useClientCertNewActionFetcher(args?: Parameters<typeof useFetche
       workspaceId: string;
       patch: Partial<ClientCertificate>;
     }) => {
-      return fetcherSubmit(JSON.stringify(patch), {
+      return submit(JSON.stringify(patch), {
         method: 'POST',
         action: href(`/organization/:organizationId/project/:projectId/workspace/:workspaceId/clientcert/new`, {
           organizationId,
@@ -40,11 +38,5 @@ export function useClientCertNewActionFetcher(args?: Parameters<typeof useFetche
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.clientcert.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.clientcert.update.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import type { ClientCertificate } from '~/models/client-certificate';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.clientcert.update';
 
@@ -19,10 +19,8 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useClientCertUpdateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useClientCertUpdateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -40,17 +38,11 @@ export function useClientCertUpdateActionFetcher(args?: Parameters<typeof useFet
         workspaceId,
       });
 
-      return fetcherSubmit(JSON.stringify(patch), {
+      return submit(JSON.stringify(patch), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.reorder.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.reorder.tsx
@@ -1,10 +1,10 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { getById, update } from '~/models/helpers/request-operations';
 import { isRequestGroup, isRequestGroupId } from '~/models/request-group';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.reorder';
 
@@ -46,10 +46,8 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useDebugReorderActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useDebugReorderActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -66,7 +64,7 @@ export function useDebugReorderActionFetcher(args?: Parameters<typeof useFetcher
         metaSortKey: number;
       };
     }) => {
-      return fetcherSubmit(JSON.stringify(params), {
+      return submit(JSON.stringify(params), {
         method: 'POST',
         action: href(`/organization/:organizationId/project/:projectId/workspace/:workspaceId/debug/reorder`, {
           organizationId,
@@ -76,11 +74,5 @@ export function useDebugReorderActionFetcher(args?: Parameters<typeof useFetcher
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.$requestGroupId.update-meta.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.$requestGroupId.update-meta.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import type { RequestGroupMeta } from '~/models/request-group-meta';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.$requestGroupId.update';
 
@@ -20,10 +20,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useRequestGroupUpdateMetaActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRequestGroupUpdateMetaActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -47,17 +45,11 @@ export function useRequestGroupUpdateMetaActionFetcher(args?: Parameters<typeof 
         },
       );
 
-      return fetcherSubmit(JSON.stringify(patch), {
+      return submit(JSON.stringify(patch), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.$requestGroupId.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.$requestGroupId.update.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import type { RequestGroup } from '~/models/request-group';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.$requestGroupId.update-meta';
 
@@ -20,10 +20,8 @@ export async function clientAction({ request, params }: Route.ActionArgs) {
   return null;
 }
 
-export function useRequestGroupUpdateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRequestGroupUpdateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -47,17 +45,11 @@ export function useRequestGroupUpdateActionFetcher(args?: Parameters<typeof useF
         },
       );
 
-      return fetcherSubmit(JSON.stringify(patch), {
+      return submit(JSON.stringify(patch), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.delete.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.delete';
 
@@ -20,10 +20,8 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useRequestGroupDeleteActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRequestGroupDeleteActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -47,16 +45,10 @@ export function useRequestGroupDeleteActionFetcher(args?: Parameters<typeof useF
       const formData = new FormData();
       formData.set('id', id);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         action: url,
         method: 'POST',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.duplicate.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.duplicate.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import type { RequestGroup } from '~/models/request-group';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.duplicate';
 
@@ -37,14 +37,9 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useRequestGroupDuplicateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const {
-    submit: fetcherSubmit,
-    ...fetcherRest
-  } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback((
-    {
+export const useRequestGroupDuplicateActionFetcher = createFetcherSubmitHook(
+  submit =>
+    ({
       organizationId,
       projectId,
       workspaceId,
@@ -54,23 +49,21 @@ export function useRequestGroupDuplicateActionFetcher(args?: Parameters<typeof u
       projectId: string;
       workspaceId: string;
       requestGroupData: Partial<RequestGroup>;
-    }
-  ) => {
-    const url = href('/organization/:organizationId/project/:projectId/workspace/:workspaceId/debug/request-group/duplicate', {
-      organizationId,
-      projectId,
-      workspaceId,
-    });
+    }) => {
+      const url = href(
+        '/organization/:organizationId/project/:projectId/workspace/:workspaceId/debug/request-group/duplicate',
+        {
+          organizationId,
+          projectId,
+          workspaceId,
+        },
+      );
 
-    return fetcherSubmit(JSON.stringify(requestGroupData), {
-      action: url,
-      method: 'POST',
-      encType: 'application/json',
-    });
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+      return submit(JSON.stringify(requestGroupData), {
+        action: url,
+        method: 'POST',
+        encType: 'application/json',
+      });
+    },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.new.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { EnvironmentType } from '~/models/environment';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.new';
 
@@ -20,10 +20,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useRequestGroupNewActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRequestGroupNewActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -53,16 +51,10 @@ export function useRequestGroupNewActionFetcher(args?: Parameters<typeof useFetc
       if (parentId) formData.set('parentId', parentId);
       if (environmentType) formData.set('environmentType', environmentType);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         action: url,
         method: 'POST',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.connect.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.connect.tsx
@@ -1,6 +1,5 @@
 import { GRAPHQL_TRANSPORT_WS_PROTOCOL, MessageType } from 'graphql-ws';
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import type { ChangeBufferEvent } from '~/common/database';
 import type { CookieJar } from '~/models/cookie-jar';
@@ -13,6 +12,7 @@ import { isWebSocketRequestId } from '~/models/websocket-request';
 import { getAuthHeader } from '~/network/authentication';
 import type { RenderedRequest } from '~/templating/types';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.connect';
 
@@ -105,10 +105,8 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
   });
 }
 
-export function useRequestConnectActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRequestConnectActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -132,17 +130,11 @@ export function useRequestConnectActionFetcher(args?: Parameters<typeof useFetch
         },
       );
 
-      return fetcherSubmit(JSON.stringify(connectParams), {
+      return submit(JSON.stringify(connectParams), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.duplicate.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.duplicate.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import * as models from '~/models';
 import * as requestOperations from '~/models/helpers/request-operations';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.duplicate';
 
@@ -42,10 +42,8 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
   );
 }
 
-export function useRequestDuplicateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRequestDuplicateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -71,17 +69,11 @@ export function useRequestDuplicateActionFetcher(args?: Parameters<typeof useFet
         },
       );
 
-      return fetcherSubmit(JSON.stringify({ name, parentId }), {
+      return submit(JSON.stringify({ name, parentId }), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.response.delete-all.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.response.delete-all.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import * as requestOperations from '~/models/helpers/request-operations';
 import { isSocketIORequestId } from '~/models/socket-io-request';
 import { isWebSocketRequestId } from '~/models/websocket-request';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.response.delete';
 
@@ -29,10 +29,8 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useRequestResponseDeleteAllActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRequestResponseDeleteAllActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -54,7 +52,7 @@ export function useRequestResponseDeleteAllActionFetcher(args?: Parameters<typeo
         },
       );
 
-      return fetcherSubmit(
+      return submit(
         {},
         {
           action: url,
@@ -62,11 +60,5 @@ export function useRequestResponseDeleteAllActionFetcher(args?: Parameters<typeo
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.response.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.response.delete.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import * as requestOperations from '~/models/helpers/request-operations';
 import { isSocketIORequestId } from '~/models/socket-io-request';
 import { isWebSocketRequestId } from '~/models/websocket-request';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.response.delete';
 
@@ -53,10 +53,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useRequestResponseDeleteActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRequestResponseDeleteActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -80,17 +78,11 @@ export function useRequestResponseDeleteActionFetcher(args?: Parameters<typeof u
         },
       );
 
-      return fetcherSubmit(JSON.stringify({ responseId }), {
+      return submit(JSON.stringify({ responseId }), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
@@ -3,8 +3,7 @@ import path from 'node:path';
 
 import contentDisposition from 'content-disposition';
 import { extension as mimeExtension } from 'mime-types';
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 import { v4 as uuidv4 } from 'uuid';
 
 import { getContentDispositionHeader } from '~/common/misc';
@@ -28,6 +27,7 @@ import {
 } from '~/network/network';
 import { parseGraphQLReqeustBody } from '~/utils/graph-ql';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { RequestTestResult } from '../../../insomnia-scripting-environment/src/objects';
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send';
@@ -201,12 +201,7 @@ export const sendActionImplementation = async (options: {
 
   invariant(requestMeta, 'RequestMeta not found');
 
-  isFsAccessingAllowed(
-    renderedRequest,
-    mutatedContext.settings,
-    mutatedContext.clientCertificates,
-    requestData.caCert,
-  );
+  isFsAccessingAllowed(renderedRequest, mutatedContext.settings, mutatedContext.clientCertificates, requestData.caCert);
 
   window.main.addExecutionStep({ requestId, stepName: 'Sending request' });
   const response = await sendCurlAndWriteTimeline(
@@ -375,10 +370,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   }
 }
 
-export function useDebugRequestSendActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useDebugRequestSendActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -392,7 +385,7 @@ export function useDebugRequestSendActionFetcher(args?: Parameters<typeof useFet
       requestId: string;
       params: { shouldPromptForPathAfterResponse?: boolean; ignoreUndefinedEnvVariable?: boolean };
     }) => {
-      return fetcherSubmit(JSON.stringify(params), {
+      return submit(JSON.stringify(params), {
         method: 'POST',
         action: href(
           `/organization/:organizationId/project/:projectId/workspace/:workspaceId/debug/request/:requestId/send`,
@@ -406,11 +399,5 @@ export function useDebugRequestSendActionFetcher(args?: Parameters<typeof useFet
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.update-meta.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.update-meta.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { isGrpcRequestId } from '~/models/grpc-request';
 import type { GrpcRequestMeta } from '~/models/grpc-request-meta';
 import type { RequestMeta } from '~/models/request-meta';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.update-meta';
 
@@ -21,10 +21,8 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useRequestUpdateMetaActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRequestUpdateMetaActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -48,17 +46,11 @@ export function useRequestUpdateMetaActionFetcher(args?: Parameters<typeof useFe
         },
       );
 
-      return fetcherSubmit(JSON.stringify(patch), {
+      return submit(JSON.stringify(patch), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.update-payload.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.update-payload.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import type { SocketIOPayload } from '~/models/socket-io-payload';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.update-payload';
 
@@ -16,10 +16,8 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useRequestUpdatePayloadActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRequestUpdatePayloadActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -43,17 +41,11 @@ export function useRequestUpdatePayloadActionFetcher(args?: Parameters<typeof us
         },
       );
 
-      return fetcherSubmit(JSON.stringify(payload), {
+      return submit(JSON.stringify(payload), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.update.tsx
@@ -1,5 +1,4 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as requestOperations from '~/models/helpers/request-operations';
 import { getPathParametersFromUrl, isRequest } from '~/models/request';
@@ -7,6 +6,7 @@ import type { WebSocketRequest } from '~/models/websocket-request';
 import { isWebSocketRequest } from '~/models/websocket-request';
 import { updateMimeType } from '~/ui/components/dropdowns/content-type-dropdown';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.update';
 
@@ -45,10 +45,8 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useRequestUpdateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRequestUpdateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -72,17 +70,11 @@ export function useRequestUpdateActionFetcher(args?: Parameters<typeof useFetche
         },
       );
 
-      return fetcherSubmit(JSON.stringify(patch), {
+      return submit(JSON.stringify(patch), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import * as models from '~/models';
 import * as requestOperations from '~/models/helpers/request-operations';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.delete';
 
@@ -33,10 +33,8 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useRequestDeleteActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRequestDeleteActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -57,16 +55,10 @@ export function useRequestDeleteActionFetcher(args?: Parameters<typeof useFetche
       const formData = new FormData();
       formData.append('id', id);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         action: url,
         method: 'POST',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new-mock-send.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new-mock-send.tsx
@@ -1,5 +1,4 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import type { Request } from '~/models/request';
@@ -11,6 +10,7 @@ import {
   tryToTransformRequestWithPlugins,
 } from '~/network/network';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new-mock-send';
 
@@ -59,10 +59,8 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useRequestNewMockSendActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRequestNewMockSendActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -83,17 +81,11 @@ export function useRequestNewMockSendActionFetcher(args?: Parameters<typeof useF
         },
       );
 
-      return fetcherSubmit(JSON.stringify(patch), {
+      return submit(JSON.stringify(patch), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
@@ -1,5 +1,4 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import {
   CONTENT_TYPE_EVENT_STREAM,
@@ -14,6 +13,7 @@ import type { Request, RequestBody, RequestParameter } from '~/models/request';
 import { SegmentEvent } from '~/ui/analytics';
 import type { CreateRequestType } from '~/ui/hooks/use-request';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new';
 
@@ -129,10 +129,8 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
   );
 }
 
-export function useRequestNewActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRequestNewActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -154,17 +152,11 @@ export function useRequestNewActionFetcher(args?: Parameters<typeof useFetcher>[
         workspaceId,
       });
 
-      return fetcherSubmit(JSON.stringify({ requestType, parentId, req }), {
+      return submit(JSON.stringify({ requestType, parentId, req }), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.create.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.create.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { EnvironmentType } from '~/models/environment';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.create';
 
@@ -25,10 +25,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return environment;
 }
 
-export function useEnvironmentCreateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useEnvironmentCreateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -40,7 +38,7 @@ export function useEnvironmentCreateActionFetcher(args?: Parameters<typeof useFe
       workspaceId: string;
       params: { isPrivate: boolean; environmentType?: string };
     }) => {
-      return fetcherSubmit(JSON.stringify(params), {
+      return submit(JSON.stringify(params), {
         method: 'POST',
         action: href(`/organization/:organizationId/project/:projectId/workspace/:workspaceId/environment/create`, {
           organizationId,
@@ -50,11 +48,5 @@ export function useEnvironmentCreateActionFetcher(args?: Parameters<typeof useFe
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.delete.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.delete';
 
@@ -24,10 +24,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useEnvironmentDeleteActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useEnvironmentDeleteActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -48,16 +46,10 @@ export function useEnvironmentDeleteActionFetcher(args?: Parameters<typeof useFe
       const formData = new FormData();
       formData.set('environmentId', environmentId);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         action: url,
         method: 'POST',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.duplicate.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.duplicate.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.duplicate';
 
@@ -21,10 +21,8 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return newEnvironment;
 }
 
-export function useEnvironmentDuplicateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useEnvironmentDuplicateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -48,16 +46,10 @@ export function useEnvironmentDuplicateActionFetcher(args?: Parameters<typeof us
       const formData = new FormData();
       formData.set('environmentId', environmentId);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         action: url,
         method: 'POST',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.set-active-global.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.set-active-global.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.set-active-global';
 
@@ -22,10 +22,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useEnvironmentSetActiveGlobalActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useEnvironmentSetActiveGlobalActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -49,16 +47,10 @@ export function useEnvironmentSetActiveGlobalActionFetcher(args?: Parameters<typ
       const formData = new FormData();
       formData.set('environmentId', environmentId);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         action: url,
         method: 'POST',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.set-active.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.set-active.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.set-active';
 
@@ -22,10 +22,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useSetActiveEnvironmentFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useSetActiveEnvironmentFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -37,7 +35,7 @@ export function useSetActiveEnvironmentFetcher(args?: Parameters<typeof useFetch
       workspaceId: string;
       environmentId: string;
     }) => {
-      return fetcherSubmit(
+      return submit(
         {
           environmentId,
         },
@@ -54,11 +52,5 @@ export function useSetActiveEnvironmentFetcher(args?: Parameters<typeof useFetch
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.update.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import type { Environment } from '~/models/environment';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.environment.update';
 
@@ -26,10 +26,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return updatedEnvironment;
 }
 
-export function useEnvironmentUpdateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useEnvironmentUpdateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -49,17 +47,11 @@ export function useEnvironmentUpdateActionFetcher(args?: Parameters<typeof useFe
         workspaceId,
       });
 
-      return fetcherSubmit(JSON.stringify({ environmentId, patch }), {
+      return submit(JSON.stringify({ environmentId, patch }), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.checkout.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.checkout.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import type { Operation } from '~/common/database';
 import { database } from '~/common/database';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { getSyncItems, remoteCompareCache } from '~/ui/sync-utils';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.checkout';
 
@@ -42,10 +42,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   );
 }
 
-export function useInsomniaSyncBranchCheckoutActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useInsomniaSyncBranchCheckoutActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       branch,
       organizationId,
@@ -60,7 +58,7 @@ export function useInsomniaSyncBranchCheckoutActionFetcher(args?: Parameters<typ
       const formData = new FormData();
       formData.set('branch', branch);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         method: 'POST',
         action: href(
           `/organization/:organizationId/project/:projectId/workspace/:workspaceId/insomnia-sync/branch/checkout`,
@@ -72,11 +70,5 @@ export function useInsomniaSyncBranchCheckoutActionFetcher(args?: Parameters<typ
         ),
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.create.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.create.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import type { Operation } from '~/common/database';
 import { database } from '~/common/database';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { getSyncItems, remoteCompareCache } from '~/ui/sync-utils';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.delete';
 
@@ -38,31 +38,22 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useInsomniaSyncBranchCreateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
+export const useInsomniaSyncBranchCreateActionFetcher = createFetcherSubmitHook(
+  submit => (branchName: string, organizationId: string, projectId: string, workspaceId: string) => {
+    const formData = new FormData();
+    formData.set('branchName', branchName);
 
-  const submit = useCallback(
-    (branchName: string, organizationId: string, projectId: string, workspaceId: string) => {
-      const formData = new FormData();
-      formData.set('branchName', branchName);
-
-      return fetcherSubmit(formData, {
-        method: 'POST',
-        action: href(
-          `/organization/:organizationId/project/:projectId/workspace/:workspaceId/insomnia-sync/branch/create`,
-          {
-            organizationId,
-            projectId,
-            workspaceId,
-          },
-        ),
-      });
-    },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+    return submit(formData, {
+      method: 'POST',
+      action: href(
+        `/organization/:organizationId/project/:projectId/workspace/:workspaceId/insomnia-sync/branch/create`,
+        {
+          organizationId,
+          projectId,
+          workspaceId,
+        },
+      ),
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.delete.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { remoteBranchesCache } from '~/ui/sync-utils';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.delete';
 
@@ -40,10 +40,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   );
 }
 
-export function useInsomniaSyncBranchDeleteActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useInsomniaSyncBranchDeleteActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       branch,
       organizationId,
@@ -58,7 +56,7 @@ export function useInsomniaSyncBranchDeleteActionFetcher(args?: Parameters<typeo
       const formData = new FormData();
       formData.set('branch', branch);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         method: 'POST',
         action: href(
           `/organization/:organizationId/project/:projectId/workspace/:workspaceId/insomnia-sync/branch/delete`,
@@ -70,11 +68,5 @@ export function useInsomniaSyncBranchDeleteActionFetcher(args?: Parameters<typeo
         ),
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.merge.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.merge.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import type { Operation } from '~/common/database';
 import { database } from '~/common/database';
 import { UserAbortResolveMergeConflictError, VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { getSyncItems, remoteCompareCache } from '~/ui/sync-utils';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.branch.merge';
 
@@ -40,10 +40,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useInsomniaSyncBranchMergeActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useInsomniaSyncBranchMergeActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       branch,
       organizationId,
@@ -58,7 +56,7 @@ export function useInsomniaSyncBranchMergeActionFetcher(args?: Parameters<typeof
       const formData = new FormData();
       formData.set('branch', branch);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         method: 'POST',
         action: href(
           `/organization/:organizationId/project/:projectId/workspace/:workspaceId/insomnia-sync/branch/merge`,
@@ -70,11 +68,5 @@ export function useInsomniaSyncBranchMergeActionFetcher(args?: Parameters<typeof
         ),
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.create-snapshot.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.create-snapshot.tsx
@@ -1,10 +1,10 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { remoteCompareCache } from '~/ui/sync-utils';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.create-snapshot';
 
@@ -47,10 +47,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useInsomniaSyncCreateSnapshotActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useInsomniaSyncCreateSnapshotActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       message,
       push,
@@ -64,7 +62,7 @@ export function useInsomniaSyncCreateSnapshotActionFetcher(args?: Parameters<typ
       workspaceId: string;
       push?: boolean;
     }) => {
-      return fetcherSubmit(JSON.stringify({ message, push }), {
+      return submit(JSON.stringify({ message, push }), {
         method: 'POST',
         action: href(
           `/organization/:organizationId/project/:projectId/workspace/:workspaceId/insomnia-sync/create-snapshot`,
@@ -77,11 +75,5 @@ export function useInsomniaSyncCreateSnapshotActionFetcher(args?: Parameters<typ
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.fetch.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.fetch.tsx
@@ -1,10 +1,10 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { database } from '~/common/database';
 import * as models from '~/models';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.fetch';
 
@@ -43,10 +43,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useInsomniaSyncFetchActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useInsomniaSyncFetchActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -58,7 +56,7 @@ export function useInsomniaSyncFetchActionFetcher(args?: Parameters<typeof useFe
       workspaceId: string;
       branch: string;
     }) => {
-      return fetcherSubmit(
+      return submit(
         {
           branch,
         },
@@ -72,11 +70,5 @@ export function useInsomniaSyncFetchActionFetcher(args?: Parameters<typeof useFe
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.pull.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.pull.tsx
@@ -1,5 +1,4 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { database } from '~/common/database';
 import * as models from '~/models';
@@ -7,6 +6,7 @@ import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { SegmentEvent } from '~/ui/analytics';
 import { getSyncItems, remoteCompareCache, vcsSegmentEventProperties } from '~/ui/sync-utils';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.pull';
 
@@ -52,10 +52,8 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   };
 }
 
-export function useInsomniaSyncPullActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useInsomniaSyncPullActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -65,7 +63,7 @@ export function useInsomniaSyncPullActionFetcher(args?: Parameters<typeof useFet
       projectId: string;
       workspaceId: string;
     }) => {
-      return fetcherSubmit(
+      return submit(
         {},
         {
           action: href('/organization/:organizationId/project/:projectId/workspace/:workspaceId/insomnia-sync/pull', {
@@ -77,11 +75,5 @@ export function useInsomniaSyncPullActionFetcher(args?: Parameters<typeof useFet
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.push.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.push.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { SegmentEvent } from '~/ui/analytics';
 import { remoteCompareCache, vcsSegmentEventProperties } from '~/ui/sync-utils';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.push';
 
@@ -45,10 +45,8 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useInsomniaSyncPushActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useInsomniaSyncPushActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -64,7 +62,7 @@ export function useInsomniaSyncPushActionFetcher(args?: Parameters<typeof useFet
         workspaceId,
       });
 
-      return fetcherSubmit(
+      return submit(
         {},
         {
           action: url,
@@ -72,11 +70,5 @@ export function useInsomniaSyncPushActionFetcher(args?: Parameters<typeof useFet
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.restore.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.restore.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import type { Operation } from '~/common/database';
 import { database } from '~/common/database';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { getSyncItems, remoteCompareCache } from '~/ui/sync-utils';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.restore';
 
@@ -38,10 +38,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   );
 }
 
-export function useInsomniaSyncRestoreActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useInsomniaSyncRestoreActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       id,
       organizationId,
@@ -56,7 +54,7 @@ export function useInsomniaSyncRestoreActionFetcher(args?: Parameters<typeof use
       const formData = new FormData();
       formData.set('id', id);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         method: 'POST',
         action: href(`/organization/:organizationId/project/:projectId/workspace/:workspaceId/insomnia-sync/restore`, {
           organizationId,
@@ -65,11 +63,5 @@ export function useInsomniaSyncRestoreActionFetcher(args?: Parameters<typeof use
         }),
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.rollback.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.rollback.tsx
@@ -1,10 +1,10 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import type { Operation } from '~/common/database';
 import { database } from '~/common/database';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { getSyncItems, remoteCompareCache } from '~/ui/sync-utils';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.rollback';
 
@@ -34,10 +34,8 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   );
 }
 
-export function useInsomniaSyncRollbackActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useInsomniaSyncRollbackActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -56,7 +54,7 @@ export function useInsomniaSyncRollbackActionFetcher(args?: Parameters<typeof us
         },
       );
 
-      return fetcherSubmit(
+      return submit(
         {},
         {
           action: url,
@@ -64,11 +62,5 @@ export function useInsomniaSyncRollbackActionFetcher(args?: Parameters<typeof us
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.stage.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.stage.tsx
@@ -1,10 +1,10 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { isNotNullOrUndefined } from '~/common/misc';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { getSyncItems } from '~/ui/sync-utils';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.stage';
 
@@ -34,10 +34,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useInsomniaSyncStageActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useInsomniaSyncStageActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       keys,
       organizationId,
@@ -49,7 +47,7 @@ export function useInsomniaSyncStageActionFetcher(args?: Parameters<typeof useFe
       projectId: string;
       workspaceId: string;
     }) => {
-      return fetcherSubmit(JSON.stringify({ keys }), {
+      return submit(JSON.stringify({ keys }), {
         method: 'POST',
         action: href(`/organization/:organizationId/project/:projectId/workspace/:workspaceId/insomnia-sync/stage`, {
           organizationId,
@@ -59,11 +57,5 @@ export function useInsomniaSyncStageActionFetcher(args?: Parameters<typeof useFe
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.sync-data.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.sync-data.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import type { BackendProject, Compare } from '~/sync/types';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { getSyncItems } from '~/ui/sync-utils';
 import { invariant } from '~/utils/invariant';
+import { createFetcherLoadHook, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.sync-data';
 
@@ -109,10 +109,8 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   }
 }
 
-export function useInsomniaSyncDataLoaderFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(
+export const useInsomniaSyncDataLoaderFetcher = createFetcherLoadHook(
+  load =>
     ({
       organizationId,
       projectId,
@@ -131,21 +129,12 @@ export function useInsomniaSyncDataLoaderFetcher(args?: Parameters<typeof useFet
         },
       );
 
-      return fetcherLoad(url);
+      return load(url);
     },
-    [fetcherLoad],
-  );
+);
 
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
-
-export function useInsomniaSyncDataActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useInsomniaSyncDataActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -164,7 +153,7 @@ export function useInsomniaSyncDataActionFetcher(args?: Parameters<typeof useFet
         },
       );
 
-      return fetcherSubmit(
+      return submit(
         {},
         {
           action: url,
@@ -172,11 +161,5 @@ export function useInsomniaSyncDataActionFetcher(args?: Parameters<typeof useFet
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.sync-data.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.sync-data.tsx
@@ -131,6 +131,7 @@ export const useInsomniaSyncDataLoaderFetcher = createFetcherLoadHook(
 
       return load(url);
     },
+  clientLoader,
 );
 
 export const useInsomniaSyncDataActionFetcher = createFetcherSubmitHook(

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { database } from '~/common/database';
 import * as models from '~/models';
 import type { Workspace } from '~/models/workspace';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { invariant } from '~/utils/invariant';
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync';
 
@@ -60,10 +60,8 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   };
 }
 
-export function useInsomniaSyncLoaderFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(
+export const useInsomniaSyncLoaderFetcher = createFetcherLoadHook(
+  load =>
     ({
       organizationId,
       projectId,
@@ -79,13 +77,6 @@ export function useInsomniaSyncLoaderFetcher(args?: Parameters<typeof useFetcher
         workspaceId,
       });
 
-      return fetcherLoad(url);
+      return load(url);
     },
-    [fetcherLoad],
-  );
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.unstage.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.unstage.tsx
@@ -1,10 +1,10 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { isNotNullOrUndefined } from '~/common/misc';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { getSyncItems } from '~/ui/sync-utils';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.insomnia-sync.unstage';
 
@@ -34,10 +34,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useInsomniaSyncUnstageActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useInsomniaSyncUnstageActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -58,17 +56,11 @@ export function useInsomniaSyncUnstageActionFetcher(args?: Parameters<typeof use
         },
       );
 
-      return fetcherSubmit(JSON.stringify({ keys }), {
+      return submit(JSON.stringify({ keys }), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId.delete.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId.delete';
 
@@ -26,10 +26,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useMockRouteDeleteActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useMockRouteDeleteActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -53,17 +51,11 @@ export function useMockRouteDeleteActionFetcher(args?: Parameters<typeof useFetc
         },
       );
 
-      return fetcherSubmit(JSON.stringify({ isSelected }), {
+      return submit(JSON.stringify({ isSelected }), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId.update.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import type { MockRoute } from '~/models/mock-route';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId.update';
 
@@ -20,10 +20,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useMockRouteUpdateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useMockRouteUpdateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -47,17 +45,11 @@ export function useMockRouteUpdateActionFetcher(args?: Parameters<typeof useFetc
         },
       );
 
-      return fetcherSubmit(JSON.stringify(patch), {
+      return submit(JSON.stringify(patch), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.new.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import * as models from '~/models';
 import type { MockRoute } from '~/models/mock-route';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.new';
 
@@ -60,10 +60,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   );
 }
 
-export function useMockRouteNewActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useMockRouteNewActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -75,7 +73,7 @@ export function useMockRouteNewActionFetcher(args?: Parameters<typeof useFetcher
       workspaceId: string;
       patch: NewMockRoutePatch;
     }) => {
-      return fetcherSubmit(JSON.stringify(patch), {
+      return submit(JSON.stringify(patch), {
         method: 'POST',
         action: href(
           `/organization/:organizationId/project/:projectId/workspace/:workspaceId/mock-server/mock-route/new`,
@@ -88,11 +86,5 @@ export function useMockRouteNewActionFetcher(args?: Parameters<typeof useFetcher
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.generate-request-collection.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.generate-request-collection.tsx
@@ -1,13 +1,13 @@
 import path from 'node:path';
 
 import type { IRuleResult } from '@stoplight/spectral-core';
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import { importResourcesToWorkspace, scanResources } from '~/common/import';
 import * as models from '~/models';
 import { isGitProject } from '~/models/project';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.generate-request-collection';
 
@@ -62,10 +62,8 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   );
 }
 
-export function useSpecGenerateRequestCollectionActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useSpecGenerateRequestCollectionActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -84,7 +82,7 @@ export function useSpecGenerateRequestCollectionActionFetcher(args?: Parameters<
         },
       );
 
-      return fetcherSubmit(
+      return submit(
         {},
         {
           action: url,
@@ -92,11 +90,5 @@ export function useSpecGenerateRequestCollectionActionFetcher(args?: Parameters<
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.update.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { database } from '~/common/database';
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.update';
 
@@ -29,10 +29,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useSpecUpdateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useSpecUpdateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -58,16 +56,9 @@ export function useSpecUpdateActionFetcher(args?: Parameters<typeof useFetcher>[
         formData.append('fromTemplate', 'true');
       }
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         action: url,
         method: 'POST',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.delete.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import * as models from '~/models';
 import { SegmentEvent } from '~/ui/analytics';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.delete';
 
@@ -27,10 +27,8 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   );
 }
 
-export function useTestSuiteDeleteActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useTestSuiteDeleteActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -52,7 +50,7 @@ export function useTestSuiteDeleteActionFetcher(args?: Parameters<typeof useFetc
         },
       );
 
-      return fetcherSubmit(
+      return submit(
         {},
         {
           action: url,
@@ -60,11 +58,5 @@ export function useTestSuiteDeleteActionFetcher(args?: Parameters<typeof useFetc
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.run-all-tests.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.run-all-tests.tsx
@@ -1,6 +1,5 @@
 import { generate, runTests, type Test, type TestResults } from 'insomnia-testing';
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import { database } from '~/common/database';
 import * as models from '~/models';
@@ -8,6 +7,7 @@ import type { UnitTest } from '~/models/unit-test';
 import { getSendRequestCallback } from '~/network/unit-test-feature';
 import { SegmentEvent } from '~/ui/analytics';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.run-all-tests';
 
@@ -110,10 +110,8 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   }
 }
 
-export function useRunAllTestsActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useRunAllTestsActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -135,7 +133,7 @@ export function useRunAllTestsActionFetcher(args?: Parameters<typeof useFetcher>
         },
       );
 
-      return fetcherSubmit(
+      return submit(
         {},
         {
           action: url,
@@ -143,11 +141,5 @@ export function useRunAllTestsActionFetcher(args?: Parameters<typeof useFetcher>
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.delete.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { database } from '~/common/database';
 import * as models from '~/models';
 import type { UnitTest } from '~/models/unit-test';
 import { SegmentEvent } from '~/ui/analytics';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.delete';
 
@@ -23,10 +23,8 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useTestDeleteActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useTestDeleteActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -51,7 +49,7 @@ export function useTestDeleteActionFetcher(args?: Parameters<typeof useFetcher>[
         },
       );
 
-      return fetcherSubmit(
+      return submit(
         {},
         {
           action: url,
@@ -59,11 +57,5 @@ export function useTestDeleteActionFetcher(args?: Parameters<typeof useFetcher>[
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.run.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.run.tsx
@@ -1,6 +1,5 @@
 import { generate, runTests, type Test, type TestResults } from 'insomnia-testing';
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import { database } from '~/common/database';
 import * as models from '~/models';
@@ -8,6 +7,7 @@ import type { UnitTest } from '~/models/unit-test';
 import { getSendRequestCallback } from '~/network/unit-test-feature';
 import { SegmentEvent } from '~/ui/analytics';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.run';
 
@@ -111,10 +111,8 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   }
 }
 
-export function useTestRunActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useTestRunActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -139,7 +137,7 @@ export function useTestRunActionFetcher(args?: Parameters<typeof useFetcher>[0])
         },
       );
 
-      return fetcherSubmit(
+      return submit(
         {},
         {
           action: url,
@@ -147,11 +145,5 @@ export function useTestRunActionFetcher(args?: Parameters<typeof useFetcher>[0])
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.update.tsx
@@ -1,10 +1,10 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { database } from '~/common/database';
 import * as models from '~/models';
 import type { UnitTest } from '~/models/unit-test';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.$testId.update';
 
@@ -22,10 +22,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useTestUpdateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useTestUpdateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -52,17 +50,11 @@ export function useTestUpdateActionFetcher(args?: Parameters<typeof useFetcher>[
         },
       );
 
-      return fetcherSubmit(JSON.stringify(data), {
+      return submit(JSON.stringify(data), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.new.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { SegmentEvent } from '~/ui/analytics';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.test.new';
 
@@ -27,10 +27,8 @@ expect(response1.status).to.equal(200);`,
   return null;
 }
 
-export function useTestNewActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useTestNewActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -57,16 +55,10 @@ export function useTestNewActionFetcher(args?: Parameters<typeof useFetcher>[0])
       const formData = new FormData();
       formData.append('name', name);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         action: url,
         method: 'POST',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.update.tsx
@@ -1,10 +1,10 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { database } from '~/common/database';
 import * as models from '~/models';
 import type { UnitTestSuite } from '~/models/unit-test-suite';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.update';
 
@@ -24,10 +24,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useTestSuiteUpdateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useTestSuiteUpdateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -51,17 +49,11 @@ export function useTestSuiteUpdateActionFetcher(args?: Parameters<typeof useFetc
         },
       );
 
-      return fetcherSubmit(JSON.stringify(data), {
+      return submit(JSON.stringify(data), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.new.tsx
@@ -1,9 +1,9 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import * as models from '~/models';
 import { SegmentEvent } from '~/ui/analytics';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.new';
 
@@ -31,10 +31,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   );
 }
 
-export function useTestSuiteNewActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useTestSuiteNewActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -55,16 +53,10 @@ export function useTestSuiteNewActionFetcher(args?: Parameters<typeof useFetcher
       const formData = new FormData();
       formData.append('name', name);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         action: url,
         method: 'POST',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.toggle-expand-all.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.toggle-expand-all.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { database } from '~/common/database';
 import * as models from '~/models';
 import { isRequestGroup } from '~/models/request-group';
 import { isRequestGroupMeta } from '~/models/request-group-meta';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.toggle-expand-all';
 
@@ -38,10 +38,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useToggleExpandAllActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useToggleExpandAllActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -59,17 +57,11 @@ export function useToggleExpandAllActionFetcher(args?: Parameters<typeof useFetc
         workspaceId,
       });
 
-      return fetcherSubmit(JSON.stringify({ toggle }), {
+      return submit(JSON.stringify({ toggle }), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx
@@ -1,5 +1,4 @@
-import { useCallback } from 'react';
-import { href, Outlet, useFetcher, useRouteLoaderData } from 'react-router';
+import { href, Outlet, useRouteLoaderData } from 'react-router';
 
 import type { SortOrder } from '~/common/constants';
 import { database } from '~/common/database';
@@ -28,6 +27,7 @@ import type { WorkspaceMeta } from '~/models/workspace-meta';
 import { pushSnapshotOnInitialize } from '~/sync/vcs/initialize-backend-project';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { invariant } from '~/utils/invariant';
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 
@@ -326,10 +326,8 @@ export function useWorkspaceLoaderData() {
   );
 }
 
-export function useWorkspaceLoaderFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(
+export const useWorkspaceLoaderFetcher = createFetcherLoadHook(
+  load =>
     ({
       organizationId,
       projectId,
@@ -339,7 +337,7 @@ export function useWorkspaceLoaderFetcher(args?: Parameters<typeof useFetcher>[0
       projectId: string;
       workspaceId: string;
     }) => {
-      return fetcherLoad(
+      return load(
         href(`/organization/:organizationId/project/:projectId/workspace/:workspaceId`, {
           organizationId,
           projectId,
@@ -347,14 +345,7 @@ export function useWorkspaceLoaderFetcher(args?: Parameters<typeof useFetcher>[0
         }),
       );
     },
-    [fetcherLoad],
-  );
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+);
 
 export const revalidateWorkspaceActiveRequest = async (requestId: string, workspaceId: string) => {
   const workspaceMeta = await models.workspaceMeta.getByParentId(workspaceId);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx
@@ -345,6 +345,7 @@ export const useWorkspaceLoaderFetcher = createFetcherLoadHook(
         }),
       );
     },
+  clientLoader,
 );
 
 export const revalidateWorkspaceActiveRequest = async (requestId: string, workspaceId: string) => {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.update-cookie-jar.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.update-cookie-jar.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.update-cookie-jar';
 
@@ -20,10 +20,8 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return updatedCookieJar;
 }
 
-export function useUpdateCookieJarActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useUpdateCookieJarActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -43,17 +41,11 @@ export function useUpdateCookieJarActionFetcher(args?: Parameters<typeof useFetc
         workspaceId,
       });
 
-      return fetcherSubmit(JSON.stringify({ cookieJarId, patch }), {
+      return submit(JSON.stringify({ cookieJarId, patch }), {
         action: url,
         method: 'POST',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.update-meta.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.update-meta.tsx
@@ -1,8 +1,8 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import type { WorkspaceMeta } from '~/models/workspace-meta';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.update-meta';
 
@@ -16,10 +16,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   return null;
 }
 
-export function useWorkspaceUpdateMetaActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useWorkspaceUpdateMetaActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -31,7 +29,7 @@ export function useWorkspaceUpdateMetaActionFetcher(args?: Parameters<typeof use
       workspaceId: string;
       patch: Partial<WorkspaceMeta>;
     }) => {
-      return fetcherSubmit(JSON.stringify(patch), {
+      return submit(JSON.stringify(patch), {
         method: 'POST',
         action: href(`/organization/:organizationId/project/:projectId/workspace/:workspaceId/update-meta`, {
           organizationId,
@@ -41,11 +39,5 @@ export function useWorkspaceUpdateMetaActionFetcher(args?: Parameters<typeof use
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.delete.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import * as models from '~/models';
 import { isRemoteProject, type Project } from '~/models/project';
 import type { Workspace } from '~/models/workspace';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.delete';
 
@@ -77,10 +77,8 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   );
 }
 
-export function useWorkspaceDeleteActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useWorkspaceDeleteActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
@@ -98,16 +96,10 @@ export function useWorkspaceDeleteActionFetcher(args?: Parameters<typeof useFetc
       const formData = new FormData();
       formData.append('workspaceId', workspaceId);
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         action: url,
         method: 'POST',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.move.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.move.tsx
@@ -1,5 +1,4 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import { importResourcesToNewWorkspace } from '~/common/import';
 import { getInsomniaV5DataExport, importInsomniaV5Data } from '~/common/insomnia-v5';
@@ -8,6 +7,7 @@ import type { Project } from '~/models/project';
 import { scopeToActivity } from '~/models/workspace';
 import { syncNewWorkspaceIfNeeded } from '~/routes/import.resources';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.move';
 
@@ -67,10 +67,8 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   }
 }
 
-export function useWorkspaceMoveActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useWorkspaceMoveActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       workspaceId,
       orgId,
@@ -95,16 +93,10 @@ export function useWorkspaceMoveActionFetcher(args?: Parameters<typeof useFetche
         projectId,
       });
 
-      return fetcherSubmit(formData, {
+      return submit(formData, {
         action: url,
         method: 'POST',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
@@ -1,7 +1,6 @@
 import path from 'node:path';
 
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import { getAppVersion, METHOD_GET } from '~/common/constants';
 import { database } from '~/common/database';
@@ -14,6 +13,7 @@ import { initializeLocalBackendProjectAndMarkForSync } from '~/sync/vcs/initiali
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { SegmentEvent } from '~/ui/analytics';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 interface NewWorkspaceData {
   name: string;
@@ -184,16 +184,14 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   }
 }
 
-export function useWorkspaceNewActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useWorkspaceNewActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({
       organizationId,
       projectId,
       ...workspaceData
     }: NewWorkspaceData & { organizationId: string; projectId: string }) => {
-      return fetcherSubmit(JSON.stringify(workspaceData), {
+      return submit(JSON.stringify(workspaceData), {
         method: 'POST',
         action: href('/organization/:organizationId/project/:projectId/workspace/new', {
           organizationId,
@@ -202,11 +200,5 @@ export function useWorkspaceNewActionFetcher(args?: Parameters<typeof useFetcher
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.update.tsx
@@ -1,12 +1,12 @@
 import path from 'node:path';
 
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import * as models from '~/models';
 import { isGitProject } from '~/models/project';
 import { safeToUseInsomniaFileNameWithExt } from '~/sync/git/insomnia-filename';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.update';
 
@@ -82,12 +82,10 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   };
 }
 
-export function useWorkspaceUpdateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useWorkspaceUpdateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({ organizationId, projectId, patch }: { organizationId: string; projectId: string; patch: WorkspacePatch }) => {
-      return fetcherSubmit(JSON.stringify(patch), {
+      return submit(JSON.stringify(patch), {
         method: 'POST',
         action: href('/organization/:organizationId/project/:projectId/workspace/update', {
           organizationId,
@@ -96,11 +94,5 @@ export function useWorkspaceUpdateActionFetcher(args?: Parameters<typeof useFetc
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.new.tsx
@@ -1,5 +1,4 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import { projectLock } from '~/common/project';
 import * as models from '~/models';
@@ -8,6 +7,7 @@ import { EMPTY_GIT_PROJECT_ID } from '~/models/project';
 import { SegmentEvent } from '~/ui/analytics';
 import { insomniaFetch } from '~/ui/insomniaFetch';
 import { invariant } from '~/utils/invariant';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.new';
 
@@ -172,12 +172,10 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   }
 }
 
-export function useProjectNewActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useProjectNewActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({ organizationId, projectData }: { organizationId: string; projectData: CreateProjectData }) => {
-      return fetcherSubmit(JSON.stringify(projectData), {
+      return submit(JSON.stringify(projectData), {
         method: 'POST',
         action: href('/organization/:organizationId/project/new', {
           organizationId,
@@ -185,11 +183,5 @@ export function useProjectNewActionFetcher(args?: Parameters<typeof useFetcher>[
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.storage-rules.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.storage-rules.tsx
@@ -1,8 +1,9 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import type { StorageRules } from '~/models/organization';
 import { fetchAndCacheOrganizationStorageRule } from '~/ui/organization-utils';
+import { createFetcherLoadHook } from '~/utils/router';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.storage-rules';
 
@@ -23,32 +24,22 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useStorageRulesLoaderFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(
+export const useStorageRulesLoaderFetcher = createFetcherLoadHook(
+  load =>
     ({ organizationId }: { organizationId: string }) => {
-      return fetcherLoad(
+      return load(
         href('/organization/:organizationId/storage-rules', {
           organizationId,
         }),
       );
     },
-    [fetcherLoad],
-  );
+  clientLoader,
+);
 
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
-
-export function useStorageRulesActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useStorageRulesActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({ organizationId }: { organizationId: string }) => {
-      return fetcherSubmit(
+      return submit(
         {},
         {
           method: 'POST',
@@ -58,11 +49,5 @@ export function useStorageRulesActionFetcher(args?: Parameters<typeof useFetcher
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.$organizationId.storage-rules.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.storage-rules.tsx
@@ -2,8 +2,7 @@ import { href } from 'react-router';
 
 import type { StorageRules } from '~/models/organization';
 import { fetchAndCacheOrganizationStorageRule } from '~/ui/organization-utils';
-import { createFetcherLoadHook } from '~/utils/router';
-import { createFetcherSubmitHook } from '~/utils/router';
+import { createFetcherLoadHook, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.storage-rules';
 

--- a/packages/insomnia/src/routes/organization.$organizationId.sync-projects.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.sync-projects.tsx
@@ -1,7 +1,7 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { syncProjects } from '~/ui/organization-utils';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.sync-projects';
 
@@ -13,12 +13,10 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useOrganizationSyncProjectsActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useOrganizationSyncProjectsActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({ organizationId }: { organizationId: string }) => {
-      return fetcherSubmit(
+      return submit(
         {},
         {
           method: 'POST',
@@ -28,11 +26,5 @@ export function useOrganizationSyncProjectsActionFetcher(args?: Parameters<typeo
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.sync-organizations-and-projects.tsx
+++ b/packages/insomnia/src/routes/organization.sync-organizations-and-projects.tsx
@@ -1,5 +1,4 @@
-import { useCallback } from 'react';
-import { href, redirect, useFetcher } from 'react-router';
+import { href, redirect } from 'react-router';
 
 import { database } from '~/common/database';
 import { project, userSession } from '~/models';
@@ -7,7 +6,7 @@ import { findPersonalOrganization, type Organization } from '~/models/organizati
 import type { Project } from '~/models/project';
 import { migrateProjectsUnderOrganization, syncOrganizations, syncProjects } from '~/ui/organization-utils';
 import { invariant } from '~/utils/invariant';
-import { AsyncTask } from '~/utils/router';
+import { AsyncTask, createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.sync-organizations-and-projects';
 
@@ -74,11 +73,9 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   }
 }
 
-export function useSyncOrganizationsAndProjectsActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcher } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
-    function submit({
+export const useSyncOrganizationsAndProjectsActionFetcher = createFetcherSubmitHook(
+  submit =>
+    ({
       organizationId,
       projectId,
       asyncTaskList,
@@ -86,8 +83,8 @@ export function useSyncOrganizationsAndProjectsActionFetcher(args?: Parameters<t
       organizationId: string;
       projectId?: string;
       asyncTaskList: AsyncTask[];
-    }) {
-      return fetcherSubmit(
+    }) => {
+      return submit(
         JSON.stringify({
           organizationId,
           projectId,
@@ -100,11 +97,5 @@ export function useSyncOrganizationsAndProjectsActionFetcher(args?: Parameters<t
         },
       );
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcher,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.sync.tsx
+++ b/packages/insomnia/src/routes/organization.sync.tsx
@@ -1,8 +1,6 @@
-import { useCallback } from 'react';
-import { useFetcher } from 'react-router';
-
 import { userSession } from '~/models';
 import { syncOrganizations } from '~/ui/organization-utils';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.sync';
 
@@ -16,21 +14,15 @@ export async function clientAction(_args: Route.ClientActionArgs) {
   return null;
 }
 
-export function useOrganizationSyncActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(() => {
-    return fetcherSubmit(
+export const useOrganizationSyncActionFetcher = createFetcherSubmitHook(
+  submit => () => {
+    return submit(
       {},
       {
         method: 'POST',
         action: '/organization/sync',
       },
     );
-  }, [fetcherSubmit]);
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/routes/organization.tsx
+++ b/packages/insomnia/src/routes/organization.tsx
@@ -247,7 +247,7 @@ const Component = ({ loaderData }: Route.ComponentProps) => {
   const untrackedWorkspaces = untrackedProjectsFetcher.data?.untrackedWorkspaces || [];
   const hasUntrackedData = untrackedProjects.length > 0 || untrackedWorkspaces.length > 0;
 
-  const [isOrganizationSidebarOpen, setIsOganizationSidebarOpen] = reactUse.useLocalStorage(
+  const [isOrganizationSidebarOpen, setIsOrganizationSidebarOpen] = reactUse.useLocalStorage(
     'organizationSidebarOpen',
     true,
   );
@@ -460,7 +460,7 @@ const Component = ({ loaderData }: Route.ComponentProps) => {
                 <TooltipTrigger>
                   <ToggleButton
                     className="h-[10px] w-[10px] flex-grow-0 gap-2 text-xs text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md]"
-                    onChange={setIsOganizationSidebarOpen}
+                    onChange={setIsOrganizationSidebarOpen}
                     isSelected={isOrganizationSidebarOpen}
                   >
                     {({ isSelected }) => {

--- a/packages/insomnia/src/routes/remote-files.tsx
+++ b/packages/insomnia/src/routes/remote-files.tsx
@@ -88,6 +88,9 @@ export async function clientLoader(_args: Route.ClientLoaderArgs) {
   }
 }
 
-export const useRemoteFilesLoaderFetcher = createFetcherLoadHook(load => () => {
-  return load(href('/remote-files'));
-});
+export const useRemoteFilesLoaderFetcher = createFetcherLoadHook(
+  load => () => {
+    return load(href('/remote-files'));
+  },
+  clientLoader,
+);

--- a/packages/insomnia/src/routes/remote-files.tsx
+++ b/packages/insomnia/src/routes/remote-files.tsx
@@ -1,11 +1,11 @@
-import { useCallback } from 'react';
-import { href, useFetcher } from 'react-router';
+import { href } from 'react-router';
 
 import { database } from '~/common/database';
 import { project, userSession } from '~/models';
 import { type Organization } from '~/models/organization';
 import { type Project } from '~/models/project';
 import { insomniaFetch } from '~/ui/insomniaFetch';
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/remote-files';
 
@@ -88,15 +88,6 @@ export async function clientLoader(_args: Route.ClientLoaderArgs) {
   }
 }
 
-export function useRemoteFilesLoaderFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(() => {
-    return fetcherLoad(href('/remote-files'));
-  }, [fetcherLoad]);
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+export const useRemoteFilesLoaderFetcher = createFetcherLoadHook(load => () => {
+  return load(href('/remote-files'));
+});

--- a/packages/insomnia/src/routes/settings.update.tsx
+++ b/packages/insomnia/src/routes/settings.update.tsx
@@ -1,9 +1,7 @@
-import { useCallback } from 'react';
-import { useFetcher } from 'react-router';
-
 import * as models from '~/models';
 import type { Settings } from '~/models/settings';
 import { SegmentEvent } from '~/ui/analytics';
+import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/settings.update';
 
@@ -16,22 +14,14 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   return null;
 }
 
-export function useSettingsUpdateActionFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { submit: fetcherSubmit, ...fetcherRest } = useFetcher<typeof clientAction>(args);
-
-  const submit = useCallback(
+export const useSettingsUpdateActionFetcher = createFetcherSubmitHook(
+  submit =>
     ({ patch }: { patch: Partial<Settings> }) => {
-      return fetcherSubmit(JSON.stringify(patch), {
+      return submit(JSON.stringify(patch), {
         method: 'POST',
         action: '/settings/update',
         encType: 'application/json',
       });
     },
-    [fetcherSubmit],
-  );
-
-  return {
-    ...fetcherRest,
-    submit,
-  };
-}
+  clientAction,
+);

--- a/packages/insomnia/src/routes/untracked-projects.tsx
+++ b/packages/insomnia/src/routes/untracked-projects.tsx
@@ -1,11 +1,9 @@
-import { useCallback } from 'react';
-import { useFetcher } from 'react-router';
-
 import { database } from '~/common/database';
 import { userSession } from '~/models';
 import { type Organization, SCRATCHPAD_ORGANIZATION_ID } from '~/models/organization';
 import type { Project } from '~/models/project';
 import type { Workspace } from '~/models/workspace';
+import { createFetcherLoadHook } from '~/utils/router';
 
 import type { Route } from './+types/untracked-projects';
 
@@ -46,15 +44,9 @@ export async function clientLoader(_args: Route.ClientLoaderArgs) {
   };
 }
 
-export function useUntrackedProjectsLoaderFetcher(args?: Parameters<typeof useFetcher>[0]) {
-  const { load: fetcherLoad, ...fetcherRest } = useFetcher<typeof clientLoader>(args);
-
-  const load = useCallback(() => {
-    return fetcherLoad('/untracked-projects');
-  }, [fetcherLoad]);
-
-  return {
-    ...fetcherRest,
-    load,
-  };
-}
+export const useUntrackedProjectsLoaderFetcher = createFetcherLoadHook(
+  load => () => {
+    return load('/untracked-projects');
+  },
+  clientLoader,
+);

--- a/packages/insomnia/src/utils/router.ts
+++ b/packages/insomnia/src/utils/router.ts
@@ -1,4 +1,5 @@
-import { href, matchPath, type PathMatch } from 'react-router';
+import { useCallback } from 'react';
+import { href, matchPath, type PathMatch, useFetcher } from 'react-router';
 
 import { database } from '../common/database';
 import * as models from '../models';
@@ -146,3 +147,37 @@ export const getInitialEntry = async () => {
     });
   }
 };
+
+type Override<T, R> = Omit<T, keyof R> & R;
+
+export const createFetcherSubmitHook =
+  <T extends (fetcher: ReturnType<typeof useFetcher<A>>['submit']) => any, A extends (...args: any) => unknown>(
+    fn: T,
+    _actionType?: A, // Only used for type inference
+  ) =>
+  (...args: Parameters<typeof useFetcher>) => {
+    const fetcher = useFetcher<A>(...args);
+
+    const submit = useCallback(((...args: any[]) => fn(fetcher.submit)(...args)) as ReturnType<T>, [fetcher.submit]);
+
+    return {
+      ...fetcher,
+      submit,
+    } as Override<typeof fetcher, { submit: ReturnType<T> }>;
+  };
+
+export const createFetcherLoadHook =
+  <T extends (fetcher: ReturnType<typeof useFetcher<A>>['load']) => any, A extends (...args: any) => unknown>(
+    fn: T,
+    _actionType?: A, // Only used for type inference
+  ) =>
+  (...args: Parameters<typeof useFetcher>) => {
+    const fetcher = useFetcher<A>(...args);
+
+    const load = useCallback(((...args: any[]) => fn(fetcher.load)(...args)) as ReturnType<T>, [fetcher.load]);
+
+    return {
+      ...fetcher,
+      load,
+    } as Override<typeof fetcher, { load: ReturnType<T> }>;
+  };


### PR DESCRIPTION
[INS-1293](https://konghq.atlassian.net/browse/INS-1293)

## Background
Typescript service gets stuck once we open any of the fetcher hooks; it seems to be caused by the type inference of a deconstruction of the fetcher.

<img width="233" height="65" alt="image" src="https://github.com/user-attachments/assets/ed59b053-cef4-4c64-9c9b-d1bd5e7da4ac" />

Reproduce steps
- Open a route file which contains a custom hook, such as `git-credentials.gitlab.complete-sign-in.tsx`, then the ts service gets stuck.
- Remove the return statement from the custom hook, and reload vscode, ts service works as expected.
- Add the return statement back to the custom hook; it gets stuck again.

## Changes
- Add `createFetcherSubmitHook` and `createFetcherLoadHook` to generate custom hooks that explicitly declares the return value type
- Replace all custom hooks with the factory function


[INS-1293]: https://konghq.atlassian.net/browse/INS-1293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ