### PR TITLE
feat: Support Vault Dedicated for Hashicorp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3964,9 +3964,9 @@
       "license": "MIT"
     },
     "node_modules/@kong/insomnia-plugin-external-vault": {
-      "version": "0.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@kong/insomnia-plugin-external-vault/0.1.0/c5122c8d61ce22573869bba27655dd9a78e34c59",
-      "integrity": "sha512-DsWqduuUi16EJVgpZ2SiQep5TS7p/GtZkTithTLBWuuah6UpVnnheah9UniegFqSB27WC2PzapGYS7HN/PNPAA==",
+      "version": "0.1.1-dev.0.20250902151320",
+      "resolved": "https://npm.pkg.github.com/download/@kong/insomnia-plugin-external-vault/0.1.1-dev.0.20250902151320/b124623c7d0e3de9d3b5f66250bcae056f95361f",
+      "integrity": "sha512-jtRSIHTToXSFWyQIrCrO6fYn7klm/N+tIRbBQr432U8uoeY8vI40w9j5omzLPZ6tqi+HBj1NUJTr2/ELbmQp/A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -28814,7 +28814,7 @@
         "zod": "^3.25.75"
       },
       "optionalDependencies": {
-        "@kong/insomnia-plugin-external-vault": "0.1.0"
+        "@kong/insomnia-plugin-external-vault": "0.1.1-dev.0.20250902151320"
       }
     },
     "packages/insomnia-inso": {
@@ -28845,7 +28845,7 @@
         "shellwords": "^1.0.1"
       },
       "optionalDependencies": {
-        "@kong/insomnia-plugin-external-vault": "0.1.0"
+        "@kong/insomnia-plugin-external-vault": "0.1.1-dev.0.20250902151320"
       }
     },
     "packages/insomnia-inso/node_modules/@esbuild/aix-ppc64": {

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -65,6 +65,6 @@
     "yaml": "^2.7.1"
   },
   "optionalDependencies": {
-    "@kong/insomnia-plugin-external-vault": "0.1.0"
+    "@kong/insomnia-plugin-external-vault": "0.1.1-dev.0.20250902151320"
   }
 }

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -201,7 +201,7 @@
     "zod": "^3.25.75"
   },
   "optionalDependencies": {
-    "@kong/insomnia-plugin-external-vault": "0.1.0"
+    "@kong/insomnia-plugin-external-vault": "0.1.1-dev.0.20250902151320"
   },
   "dev": {
     "dev-server-port": 3334

--- a/packages/insomnia/src/models/cloud-credential.ts
+++ b/packages/insomnia/src/models/cloud-credential.ts
@@ -42,7 +42,10 @@ interface HashiCorpBaseCredential {
   expires_at?: number;
 }
 export enum HashiCorpCredentialType {
-  cloud = 'cloud',
+  // Points to the EOS HCP Vault Secrets. Refer: https://developer.hashicorp.com/hcp/docs/vault-secrets/
+  cloudVaultSecrets = 'cloud',
+  // Points to the HCP Vault Dedicated. Refer: https://developer.hashicorp.com/hcp/docs/vault/
+  cloudVaultDedicated = 'cloudVaultDedicated',
   onPrem = 'onPrem',
 }
 export enum HashiCorpVaultAuthMethod {
@@ -52,7 +55,22 @@ export enum HashiCorpVaultAuthMethod {
 export interface HCPCredential extends HashiCorpBaseCredential {
   client_id: string;
   client_secret: string;
-  type: HashiCorpCredentialType.cloud;
+  type: HashiCorpCredentialType.cloudVaultSecrets;
+}
+export interface HCPVaultDedicatedAppRoleCredential extends HashiCorpBaseCredential {
+  role_id: string;
+  secret_id: string;
+  authMethod: HashiCorpVaultAuthMethod.appRole;
+  type: HashiCorpCredentialType.cloudVaultDedicated;
+  serverAddress: string;
+  namespace: string;
+}
+export interface HCPVaultDedicatedTokenCredential extends HashiCorpBaseCredential {
+  authMethod: HashiCorpVaultAuthMethod.token;
+  access_token: string;
+  type: HashiCorpCredentialType.cloudVaultDedicated;
+  serverAddress: string;
+  namespace: string;
 }
 export interface VaultAppRoleCredential extends HashiCorpBaseCredential {
   role_id: string;
@@ -88,7 +106,12 @@ type BaseCloudCredential =
   | { provider: 'azure'; credentials: AzureOAuthCredential }
   | {
       provider: 'hashicorp';
-      credentials: HCPCredential | VaultAppRoleCredential | VaultTokenCredential;
+      credentials:
+        | HCPCredential
+        | VaultAppRoleCredential
+        | VaultTokenCredential
+        | HCPVaultDedicatedAppRoleCredential
+        | HCPVaultDedicatedTokenCredential;
     };
 export type CloudProviderCredential = BaseModel & BaseCloudCredential;
 

--- a/packages/insomnia/src/ui/components/modals/cloud-credential-modal/hashicorp-credential-form.tsx
+++ b/packages/insomnia/src/ui/components/modals/cloud-credential-modal/hashicorp-credential-form.tsx
@@ -252,28 +252,6 @@ export const HashiCorpCredentialForm = (props: HashiCorpCredentialFormProps) => 
               </div>
             </TextField>
           )}
-          {credentialType === HashiCorpCredentialType.cloudVaultDedicated && (
-            <TextField
-              className="flex flex-col gap-2"
-              defaultValue={(credentials as HashiCorpVaultDedicatedCredential).namespace}
-            >
-              <Label className="col-span-4">
-                Namespace:
-                <HelpTooltip className="space-left ml-2">
-                  Target namespace, admin as default top-level namespace for Vault Dedicated clusters
-                </HelpTooltip>
-              </Label>
-              <div className="flex items-center gap-2">
-                <Input
-                  required
-                  className="col-span-3 h-8 w-full flex-1 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] py-1 pl-2 pr-7 text-[--color-font] transition-colors placeholder:italic placeholder:opacity-60 focus:outline-none focus:ring-1 focus:ring-[--hl-md]"
-                  type="text"
-                  name="namespace"
-                  placeholder="Namespace"
-                />
-              </div>
-            </TextField>
-          )}
           {credentialAuthMethod === HashiCorpVaultAuthMethod.appRole && (
             <>
               <TextField className="flex flex-col gap-2" defaultValue={(credentials as VaultAppRoleCredential).role_id}>
@@ -312,6 +290,28 @@ export const HashiCorpCredentialForm = (props: HashiCorpCredentialFormProps) => 
                 </div>
               </TextField>
             </>
+          )}
+          {credentialType === HashiCorpCredentialType.cloudVaultDedicated && (
+            <TextField
+              className="flex flex-col gap-2"
+              defaultValue={(credentials as HashiCorpVaultDedicatedCredential).namespace}
+            >
+              <Label className="col-span-4">
+                Namespace:
+                <HelpTooltip className="space-left ml-2">
+                  Target namespace, admin as default top-level namespace for Vault Dedicated clusters
+                </HelpTooltip>
+              </Label>
+              <div className="flex items-center gap-2">
+                <Input
+                  required
+                  className="col-span-3 h-8 w-full flex-1 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] py-1 pl-2 pr-7 text-[--color-font] transition-colors placeholder:italic placeholder:opacity-60 focus:outline-none focus:ring-1 focus:ring-[--hl-md]"
+                  type="text"
+                  name="namespace"
+                  placeholder="Namespace"
+                />
+              </div>
+            </TextField>
           )}
         </>
       )}

--- a/packages/insomnia/src/ui/components/modals/cloud-credential-modal/hashicorp-credential-form.tsx
+++ b/packages/insomnia/src/ui/components/modals/cloud-credential-modal/hashicorp-credential-form.tsx
@@ -7,6 +7,8 @@ import {
   HashiCorpCredentialType,
   HashiCorpVaultAuthMethod,
   type HCPCredential,
+  type HCPVaultDedicatedAppRoleCredential,
+  type HCPVaultDedicatedTokenCredential,
   type VaultAppRoleCredential,
   type VaultTokenCredential,
 } from '../../../../models/cloud-credential';
@@ -14,6 +16,7 @@ import { HelpTooltip } from '../../help-tooltip';
 import { Icon } from '../../icon';
 
 type HashiCorpOnPremCredential = VaultAppRoleCredential | VaultTokenCredential;
+type HashiCorpVaultDedicatedCredential = HCPVaultDedicatedAppRoleCredential | HCPVaultDedicatedTokenCredential;
 type HashiCorpCredential = Extract<CloudProviderCredential, { provider: 'hashicorp' }>;
 export interface HashiCorpCredentialFormProps {
   data?: HashiCorpCredential;
@@ -80,17 +83,18 @@ export const HashiCorpCredentialForm = (props: HashiCorpCredentialFormProps) => 
           access_token,
           role_id,
           secret_id,
+          namespace,
         } = Object.fromEntries(formData.entries()) as Record<string, string>;
         const commonData = {
           name,
           provider: providerType,
         };
         let newData;
-        if (type === HashiCorpCredentialType.cloud) {
+        if (type === HashiCorpCredentialType.cloudVaultSecrets) {
           newData = {
             ...commonData,
             credentials: {
-              type: type as HashiCorpCredentialType.cloud,
+              type: type as HashiCorpCredentialType.cloudVaultSecrets,
               client_id,
               client_secret,
             },
@@ -99,11 +103,12 @@ export const HashiCorpCredentialForm = (props: HashiCorpCredentialFormProps) => 
           newData = {
             ...commonData,
             credentials: {
-              type: type as HashiCorpCredentialType.onPrem,
+              type: type as HashiCorpCredentialType.onPrem | HashiCorpCredentialType.cloudVaultDedicated,
               authMethod: authMethod as HashiCorpVaultAuthMethod,
               serverAddress,
               ...(authMethod === HashiCorpVaultAuthMethod.token && { access_token }),
               ...(authMethod === HashiCorpVaultAuthMethod.appRole && { role_id, secret_id }),
+              ...(type === HashiCorpCredentialType.cloudVaultDedicated && { namespace }),
             },
           };
         }
@@ -138,19 +143,33 @@ export const HashiCorpCredentialForm = (props: HashiCorpCredentialFormProps) => 
 
           <input
             type="radio"
-            id="hashiCorpEnvironmentTypeChoice-cloud"
+            id="hashiCorpEnvironmentTypeChoice-cloud-vaultDedicated"
             name="type"
             className="mr-2"
-            value={HashiCorpCredentialType.cloud}
-            checked={credentialType === HashiCorpCredentialType.cloud}
-            onChange={() => setCredentialType(HashiCorpCredentialType.cloud)}
+            value={HashiCorpCredentialType.cloudVaultDedicated}
+            checked={credentialType === HashiCorpCredentialType.cloudVaultDedicated}
+            onChange={() => setCredentialType(HashiCorpCredentialType.cloudVaultDedicated)}
           />
-          <label className="pt-0" htmlFor="hashiCorpEnvironmentTypeChoice-cloud">
-            Cloud
+          <label className="mr-8 w-32 pt-0" htmlFor="hashiCorpEnvironmentTypeChoice-cloud-vaultDedicated">
+            Vault Dedicated
+          </label>
+
+          <input
+            type="radio"
+            id="hashiCorpEnvironmentTypeChoice-cloud-vaultSecrets"
+            name="type"
+            className="mr-2"
+            value={HashiCorpCredentialType.cloudVaultSecrets}
+            checked={credentialType === HashiCorpCredentialType.cloudVaultSecrets}
+            onChange={() => setCredentialType(HashiCorpCredentialType.cloudVaultSecrets)}
+          />
+          <label className="pt-0" htmlFor="hashiCorpEnvironmentTypeChoice-cloud-vaultSecrets">
+            Vault Secrets
           </label>
         </div>
       </div>
-      {credentialType === HashiCorpCredentialType.onPrem && (
+      {(credentialType === HashiCorpCredentialType.onPrem ||
+        credentialType === HashiCorpCredentialType.cloudVaultDedicated) && (
         <>
           <div>
             <label>Auth Method:</label>
@@ -189,7 +208,7 @@ export const HashiCorpCredentialForm = (props: HashiCorpCredentialFormProps) => 
             <Label className="col-span-4">
               Server Address:
               <HelpTooltip className="space-left ml-2">
-                HashiCorp on-prem server address like https://localhost:8200
+                HashiCorp Vault server address or Vault Dedicated cluster URL
               </HelpTooltip>
             </Label>
             <Input
@@ -230,6 +249,28 @@ export const HashiCorpCredentialForm = (props: HashiCorpCredentialFormProps) => 
                     <i className="fa fa-eye" />
                   )}
                 </Button>
+              </div>
+            </TextField>
+          )}
+          {credentialType === HashiCorpCredentialType.cloudVaultDedicated && (
+            <TextField
+              className="flex flex-col gap-2"
+              defaultValue={(credentials as HashiCorpVaultDedicatedCredential).namespace}
+            >
+              <Label className="col-span-4">
+                Namespace:
+                <HelpTooltip className="space-left ml-2">
+                  Target namespace, admin as default top-level namespace for Vault Dedicated clusters
+                </HelpTooltip>
+              </Label>
+              <div className="flex items-center gap-2">
+                <Input
+                  required
+                  className="col-span-3 h-8 w-full flex-1 rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] py-1 pl-2 pr-7 text-[--color-font] transition-colors placeholder:italic placeholder:opacity-60 focus:outline-none focus:ring-1 focus:ring-[--hl-md]"
+                  type="text"
+                  name="namespace"
+                  placeholder="Namespace"
+                />
               </div>
             </TextField>
           )}
@@ -274,7 +315,7 @@ export const HashiCorpCredentialForm = (props: HashiCorpCredentialFormProps) => 
           )}
         </>
       )}
-      {credentialType === HashiCorpCredentialType.cloud && (
+      {credentialType === HashiCorpCredentialType.cloudVaultSecrets && (
         <>
           <TextField className="flex flex-col gap-2" defaultValue={(credentials as HCPCredential).client_id}>
             <Label className="col-span-4">Client Id:</Label>

--- a/packages/insomnia/src/ui/components/templating/external-vault/hashicorp-vault-form.tsx
+++ b/packages/insomnia/src/ui/components/templating/external-vault/hashicorp-vault-form.tsx
@@ -20,6 +20,8 @@ export interface HashiCorpVaultFormProps {
 type HashiCorpCredential = Extract<CloudProviderCredential, { provider: 'hashicorp' }>;
 type KeysOfUnion<T> = T extends T ? keyof T : never;
 
+const defaultKVVersion = 'v2';
+
 export const HashiCorpVaultForm = (props: HashiCorpVaultFormProps) => {
   const { cloudCredentials } = useRootLoaderData()!;
 
@@ -27,7 +29,7 @@ export const HashiCorpVaultForm = (props: HashiCorpVaultFormProps) => {
   const { secretName } = formData;
   // onPrem secret config
   const {
-    kvVersion = 'v2',
+    kvVersion = defaultKVVersion,
     secretEnginePath,
     secretKey,
     sendNamespaceViaHeader = true,
@@ -41,7 +43,13 @@ export const HashiCorpVaultForm = (props: HashiCorpVaultFormProps) => {
     name: T,
     newValue: string | boolean | number,
   ) => {
+    // append default configs when not exist
+    const defaultConfig =
+      credentialType === HashiCorpCredentialType.cloudVaultSecrets
+        ? {}
+        : { kvVersion: defaultKVVersion, sendNamespaceViaHeader: true };
     const newConfig = {
+      ...defaultConfig,
       ...formData,
       [name]: newValue,
     };

--- a/packages/insomnia/src/ui/components/templating/external-vault/hashicorp-vault-form.tsx
+++ b/packages/insomnia/src/ui/components/templating/external-vault/hashicorp-vault-form.tsx
@@ -27,16 +27,20 @@ export const HashiCorpVaultForm = (props: HashiCorpVaultFormProps) => {
   const { secretName } = formData;
   // onPrem secret config
   const {
-    kvVersion = 'v1',
+    kvVersion = 'v2',
     secretEnginePath,
     secretKey,
+    sendNamespaceViaHeader = true,
   } = formData as HashiCorpVaultKVV1SecretConfig | HashiCorpVaultKVV2SecretConfig;
   // cloud secret config
   const { organizationId, projectId, appName, version: cloudSecretVersion } = formData as HCPSecretConfig;
   const credentialId = activeTagData.args[1].value as string;
   const selectedCredential = cloudCredentials.find(c => c._id === credentialId) as unknown as HashiCorpCredential;
   const credentialType = selectedCredential?.credentials?.type;
-  const handleOnChange = (name: KeysOfUnion<HashiCorpSecretConfig>, newValue: string) => {
+  const handleOnChange = <T extends KeysOfUnion<HashiCorpSecretConfig>>(
+    name: T,
+    newValue: string | boolean | number,
+  ) => {
     const newConfig = {
       ...formData,
       [name]: newValue,
@@ -46,7 +50,8 @@ export const HashiCorpVaultForm = (props: HashiCorpVaultFormProps) => {
 
   return (
     <>
-      {credentialType === HashiCorpCredentialType.onPrem && (
+      {(credentialType === HashiCorpCredentialType.onPrem ||
+        credentialType === HashiCorpCredentialType.cloudVaultDedicated) && (
         <>
           <div className="form-row">
             <div className="form-control">
@@ -80,6 +85,24 @@ export const HashiCorpVaultForm = (props: HashiCorpVaultFormProps) => {
               </div>
             </div>
           </div>
+          {credentialType === HashiCorpCredentialType.cloudVaultDedicated && (
+            <div className="form-row">
+              <div className="flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={sendNamespaceViaHeader}
+                  onChange={e => handleOnChange('sendNamespaceViaHeader', e.target.checked)}
+                />
+                <span>
+                  Send Namespace Via Header
+                  <HelpTooltip className="space-left">
+                    Whether to send the namespace in the request header. Uncheck this to apply namespace via Secret
+                    Mount Path.
+                  </HelpTooltip>
+                </span>
+              </div>
+            </div>
+          )}
           <div className="form-row">
             <div className="form-control">
               <label>
@@ -140,7 +163,7 @@ export const HashiCorpVaultForm = (props: HashiCorpVaultFormProps) => {
           </div>
         </>
       )}
-      {credentialType === HashiCorpCredentialType.cloud && (
+      {credentialType === HashiCorpCredentialType.cloudVaultSecrets && (
         <>
           <div className="form-row">
             <div className="form-control">

--- a/packages/insomnia/src/ui/components/templating/external-vault/types.ts
+++ b/packages/insomnia/src/ui/components/templating/external-vault/types.ts
@@ -32,6 +32,7 @@ export interface HashiCorpVaultKVV1SecretConfig {
   secretEnginePath: string;
   secretName: string;
   secretKey?: string;
+  sendNamespaceViaHeader?: boolean;
 }
 export interface HashiCorpVaultKVV2SecretConfig {
   kvVersion: 'v2';
@@ -39,6 +40,7 @@ export interface HashiCorpVaultKVV2SecretConfig {
   secretName: string;
   secretKey?: string;
   version?: string | number;
+  sendNamespaceViaHeader?: boolean;
 }
 export type HashiCorpSecretConfig = HCPSecretConfig | HashiCorpVaultKVV1SecretConfig | HashiCorpVaultKVV2SecretConfig;
 


### PR DESCRIPTION
## Background

Since Hashicorp has announced [EOS](https://developer.hashicorp.com/hcp/docs/vault-secrets/end-of-sale-announcement) of legacy HCP Vault Secrets deployment. Insomnia will support the new Hashicorp [Vault Dedicated](https://developer.hashicorp.com/hcp/docs/vault) for cloud intergration.

## Changes
- [x] Add new **Vault Dedicated** type for Hashicorp
<img width="605" height="565" alt="Screenshot 2025-09-02 at 18 13 22" src="https://github.com/user-attachments/assets/f1401b8f-cd0d-41a1-bf52-ea76982259ec" />

- [x] Support specify namespace and using namespace when fetching secrets from Vault Dedicated server
<img width="732" height="415" alt="Screenshot 2025-09-02 at 11 13 20" src="https://github.com/user-attachments/assets/9cc74254-682a-4786-af6d-49c91069ff1a" />

- [x]  Update vault plugin 

Refer: [INS-1290](https://konghq.atlassian.net/browse/INS-1290)

[INS-1290]: https://konghq.atlassian.net/browse/INS-1290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ