### PR TITLE
[INS-1054] Remove .git suffix requirement for custom git repository URL

### DIFF
--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -100,22 +100,22 @@ export function vcsSegmentEventProperties(type: 'git', action: VCSAction, error?
   return { type, action, error };
 }
 
-function parseGitToHttpsURL(s: string) {
+function parseGitToHttpsURL(url: string) {
   // try to convert any git URL to https URL
-  let parsed = fromUrl(s)?.https({ noGitPlus: true }) || '';
+  let parsed = fromUrl(url)?.https({ noGitPlus: true }) || '';
 
   // fallback for self-hosted git servers, see https://github.com/Kong/insomnia/issues/5967
   // and https://github.com/npm/hosted-git-info/issues/11
   if (parsed === '') {
-    let temp = s;
+    let tempURL = url;
     // handle "shorter scp-like syntax"
-    temp = temp.replace(/^git@([^:]+):/, 'https://$1/');
+    tempURL = tempURL.replace(/^git@([^:]+):/, 'https://$1/');
     // handle proper SSH URLs
-    temp = temp.replace(/^ssh:\/\//, 'https://');
+    tempURL = tempURL.replace(/^ssh:\/\//, 'https://');
 
     // final URL fallback for any other git URL
-    temp = new URL(temp).href;
-    parsed = temp;
+    tempURL = (URL.canParse(tempURL) ? URL.parse(tempURL)?.href : url) || '';
+    parsed = tempURL;
   }
 
   return parsed;

--- a/packages/insomnia/src/ui/components/git-credentials/custom-repository-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/custom-repository-settings-form.tsx
@@ -55,7 +55,7 @@ export const CustomRepositorySettingsFormGroup: FunctionComponent<Props> = ({ gi
       <TextField
         name="uri"
         type="url"
-        pattern="https?://.*\.git"
+        pattern="https?://.+"
         autoFocus
         defaultValue={uri}
         onChange={value => setUri(value)}
@@ -71,7 +71,7 @@ export const CustomRepositorySettingsFormGroup: FunctionComponent<Props> = ({ gi
         <FieldError className="text-xs text-[--color-danger]">
           {({ validationDetails, defaultChildren }) =>
             validationDetails.patternMismatch
-              ? 'Please ensure the URL is valid and ends with a .git suffix.'
+              ? 'Please ensure the URL is valid. In most cases it should also end with a .git suffix.'
               : defaultChildren
           }
         </FieldError>

--- a/packages/insomnia/src/ui/components/git-credentials/custom-repository-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/custom-repository-settings-form.tsx
@@ -55,7 +55,6 @@ export const CustomRepositorySettingsFormGroup: FunctionComponent<Props> = ({ gi
       <TextField
         name="uri"
         type="url"
-        pattern="https?://.+"
         autoFocus
         defaultValue={uri}
         onChange={value => setUri(value)}
@@ -69,10 +68,8 @@ export const CustomRepositorySettingsFormGroup: FunctionComponent<Props> = ({ gi
           className="w-full rounded-sm border border-solid border-[--hl-sm] bg-[--color-bg] py-1 pl-2 pr-7 text-[--color-font] transition-colors placeholder:text-sm placeholder:italic focus:outline-none focus:ring-1 focus:ring-[--hl-md]"
         />
         <FieldError className="text-xs text-[--color-danger]">
-          {({ validationDetails, defaultChildren }) =>
-            validationDetails.patternMismatch
-              ? 'Please ensure the URL is valid. In most cases it should also end with a .git suffix.'
-              : defaultChildren
+          {({ isInvalid }) =>
+            isInvalid ? 'Please ensure the URL is valid. In most cases it should also end with a .git suffix.' : null
           }
         </FieldError>
       </TextField>

--- a/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
@@ -8,7 +8,7 @@ import { useGitRemoteBranchesActionFetcher } from '~/routes/git.remote-branches'
 
 import { Icon } from '../icon';
 
-const GitRemoteURISchema = z.url().endsWith('.git');
+const GitRemoteURISchema = z.url();
 
 export const GitRemoteBranchSelect = ({
   url,


### PR DESCRIPTION
Not all providers will use a URL ending in .git. The requirement makes sense for Github/Gitlab since we know which conventions they follow, but not for a form which can connect to any git server. For example, Azure DevOps repo URLs don't end in `.git` and customers report that manually adding it results in a 404.

Note that I have not been able to test cloning an Azure DevOps repo myself, so this PR just makes two changes:
- Modifies validation to no longer require the URL to end in `.git` when adding a URL in the Git—a.k.a. custom repository settings—form.
- Requires at least one character to be present after the URL scheme for the validation to pass.