### PR TITLE
[INS-1337] Fix commit-and-push not pushing the changes to the remote

### DIFF
--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -303,7 +303,6 @@ export const GitProjectStagingModal: FC<{
                           <Button
                             type="submit"
                             isDisabled={isCommitting || changes.staged.length === 0}
-                            formAction={`/organization/${organizationId}/project/${projectId}/git/commit`}
                             className="flex h-8 flex-1 items-center justify-center gap-2 rounded-sm bg-[--hl-xxs] px-4 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
                           >
                             <Icon
@@ -315,8 +314,9 @@ export const GitProjectStagingModal: FC<{
 
                           <Button
                             type="submit"
+                            name="push"
+                            value="true"
                             isDisabled={isCommitting || changes.staged.length === 0}
-                            formAction={`/organization/${organizationId}/project/${projectId}/git/commit-and-push`}
                             className="flex h-8 flex-1 items-center justify-center gap-2 rounded-sm bg-[--hl-xxs] px-4 text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
                           >
                             <Icon


### PR DESCRIPTION
# Overview

In the Git staging modal, the commit and push functionality doesn't push the changes to the remote as expected.
This issue seems to have happened during a rebase that reverted the way commit-and-push worked to a previous version.

This PR brings back the missing working code that was using the submitter value to check if a push should also happen.