### PR TITLE
fix: workspace create fails on windows

### DIFF
--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -102,6 +102,8 @@ app.on('ready', async () => {
   // Init some important things first
   await database.init();
   await _createModelInstances();
+  // backup needs the channel from settings which needs the database
+  await backupIfNewerVersionAvailable();
   sentryWatchAnalyticsEnabled();
   watchProxySettings();
   windowUtils.init();
@@ -321,7 +323,6 @@ async function _trackStats() {
   });
 
   ipcMainOnce('halfSecondAfterAppStart', async () => {
-    backupIfNewerVersionAvailable();
     const { currentVersion, launches, lastVersion } = stats;
 
     const firstLaunch = launches === 1;

--- a/packages/insomnia/src/main/backup.ts
+++ b/packages/insomnia/src/main/backup.ts
@@ -23,7 +23,7 @@ export async function backupIfNewerVersionAvailable() {
     );
     if (response) {
       console.log('[main] Found newer version');
-      backup();
+      await backup();
       return;
     }
     console.log('[main] No newer version');
@@ -44,11 +44,12 @@ export async function backup() {
       return;
     }
     const files = await readdir(dataPath);
-    files.forEach(async (file: string) => {
+    for (const file of files) {
       if (file.endsWith('.db')) {
         await copyFile(path.join(dataPath, file), path.join(versionPath, file));
       }
-    });
+    }
+
     console.log('[main] Exported backup to:', versionPath);
   } catch (err) {
     console.log('[main] Error exporting backup:', err);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
@@ -178,8 +178,10 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
       })}/${scopeToActivity(workspace.scope)}`,
     );
   } catch (err) {
+    console.error('Error creating workspace:', err);
+
     return {
-      error: `Failed to create workspace: ${err instanceof Error ? err.message : String(err)}`,
+      error: `Failed to create workspace: ${err instanceof Error ? err.message : JSON.stringify(err)}`,
     };
   }
 }


### PR DESCRIPTION
these is a flake on windows that causes resource busy when opening the app and creating a request, this ticket aims to resolve that flake, ideally by resolving the resource busy race condition. If that is not possible or too challenging we can add other actions before the add request.

<img width="747" height="538" alt="image" src="https://github.com/user-attachments/assets/f8ad77f2-7f07-499f-8528-7979784fdee6" />


approach: await the backup to complete during app start, this will delay app start on users with larger databases. Previously it was concurrent but it causes a race condition on windows.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
