### PR TITLE
Chore: Avoid loading bundle plugin errors in development mode

### DIFF
--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -8,6 +8,7 @@ import iconv from 'iconv-lite';
 import { v4 as uuidv4 } from 'uuid';
 
 import { getAppBundlePlugins, RESPONSE_CODE_REASONS } from '../common/constants';
+import { isDevelopment } from '../common/constants';
 import { database as db } from '../common/database';
 import * as models from '../models';
 import type { CloudProviderCredential } from '../models/cloud-credential';
@@ -53,7 +54,13 @@ const getBundlePluginModule = (pluginName: string): Plugin['module'] => {
     bundlePluginModuleMap[pluginName] = module;
     return module;
   } catch (err) {
-    console.error(`Failed to load bundled plugin ${pluginName}`, err);
+    if (isDevelopment()) {
+      console.warn(
+        `[plugin] Failed to load bundled plugin ${pluginName}. You can ignore this warning if you not developing external vault feature.`,
+      );
+    } else {
+      console.error(`Failed to load bundled plugin ${pluginName}`, err);
+    }
   }
   return {};
 };
@@ -234,26 +241,22 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     const appBundlePluginTemplateTags: TemplateTag[] = [];
     appBundlePlugins.forEach(p => {
       const { name: pluginName } = p;
-      try {
-        const module = getBundlePluginModule(pluginName);
-        const pluginExportedTemplateTags: PluginTemplateTag[] = module?.templateTags || [];
-        const pluginTemplateTags: TemplateTag[] = pluginExportedTemplateTags.map(tt => ({
-          plugin: {
-            name: pluginName,
-            description: 'Bundle plugin',
-            version: 'Unknown',
-            directory: '',
-            config: {
-              disabled: false,
-            },
-            module,
+      const module = getBundlePluginModule(pluginName);
+      const pluginExportedTemplateTags: PluginTemplateTag[] = module?.templateTags || [];
+      const pluginTemplateTags: TemplateTag[] = pluginExportedTemplateTags.map(tt => ({
+        plugin: {
+          name: pluginName,
+          description: 'Bundle plugin',
+          version: 'Unknown',
+          directory: '',
+          config: {
+            disabled: false,
           },
-          templateTag: tt,
-        }));
-        appBundlePluginTemplateTags.push(...pluginTemplateTags);
-      } catch (err) {
-        console.error(`[plugin] Failed to load bundled plugin ${pluginName}`, err);
-      }
+          module,
+        },
+        templateTag: tt,
+      }));
+      appBundlePluginTemplateTags.push(...pluginTemplateTags);
     });
     return appBundlePluginTemplateTags;
   },

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import electron from 'electron';
 
 import type { ParsedApiSpec } from '../common/api-specs';
-import { getAppBundlePlugins } from '../common/constants';
+import { getAppBundlePlugins, isDevelopment } from '../common/constants';
 import { database as db } from '../common/database';
 import type { PluginConfigMap } from '../common/settings';
 import * as models from '../models';
@@ -257,7 +257,13 @@ export function getBundlePluginMap() {
         module: module,
       };
     } catch (err) {
-      console.error(`[plugin] Failed to load bundled plugin ${pluginName}`, err);
+      if (isDevelopment()) {
+        console.warn(
+          `[plugin] Failed to load bundled plugin ${pluginName}. You can ignore this warning if you not developing external vault feature.`,
+        );
+      } else {
+        console.error(`Failed to load bundled plugin ${pluginName}`, err);
+      }
     }
   });
   return bundlePluginMap;


### PR DESCRIPTION
**Changes:**

Do not show error stack traces when fails to load bundle plugin in development mode. 