### PR TITLE
fix: improve env selection/messaging in CI mode and silence warnings [INS-1345]

### DIFF
--- a/packages/insomnia-inso/bin/inso
+++ b/packages/insomnia-inso/bin/inso
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --enable-source-maps
 
 global.require = require;
 const insomniacli = require('../dist/index.js');

--- a/packages/insomnia-inso/src/cli.ts
+++ b/packages/insomnia-inso/src/cli.ts
@@ -7,7 +7,7 @@ import * as commander from 'commander';
 import type { logType } from 'consola';
 import consola, { BasicReporter, FancyReporter, LogLevel } from 'consola';
 import { cosmiconfig } from 'cosmiconfig';
-import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from 'insomnia/src/common/constants';
+import { isDevelopment, JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from 'insomnia/src/common/constants';
 import { getSendRequestCallbackMemDb } from 'insomnia/src/common/send-request';
 import type { Environment, UserUploadEnvironment } from 'insomnia/src/models/environment';
 import { init } from 'insomnia/src/models/environment';
@@ -41,6 +41,11 @@ export interface GlobalOptions {
   printOptions: boolean;
   verbose: boolean;
   workingDir: string;
+}
+
+if (!isDevelopment()) {
+  // in production, silence the deprecation warnings
+  process.removeAllListeners('warning');
 }
 
 export const tryToReadInsoConfigFile = async (configFile?: string, workingDir?: string) => {
@@ -643,7 +648,9 @@ export const go = (args?: string[]) => {
         const isRunningFolder = options.item.length === 1 && options.item[0].startsWith('fld_');
         if (options.item.length && !isRunningFolder) {
           const requestOrder = new Map<string, number>();
-          options.item.forEach((reqId: string, order: number) => requestOrder.set(reqId, order + 1));
+          options.item.forEach((reqId: string, order: number) => {
+            requestOrder.set(reqId, order + 1);
+          });
           requestsToRun = requestsToRun.sort(
             (a, b) =>
               (requestOrder.get(a._id) || requestsToRun.length) - (requestOrder.get(b._id) || requestsToRun.length),

--- a/packages/insomnia-inso/src/db/models/api-spec.ts
+++ b/packages/insomnia-inso/src/db/models/api-spec.ts
@@ -12,7 +12,7 @@ export const loadApiSpec = (db: Database, identifier: string): ApiSpec | null | 
   const items = db.ApiSpec.filter(
     spec => matchIdIsh(spec, identifier) || spec.fileName === identifier || spec.name === identifier,
   );
-  logger.trace('Found %d.', items.length);
+  logger.trace('Found %d api specification(s).', items.length);
   return ensureSingleOrNone(items, entity);
 };
 

--- a/packages/insomnia-inso/src/db/models/environment.ts
+++ b/packages/insomnia-inso/src/db/models/environment.ts
@@ -9,7 +9,7 @@ import { ensureSingle, generateIdIsh, getDbChoice, matchIdIsh } from './util';
 const loadBaseEnvironmentForWorkspace = (db: Database, workspaceId: string): Environment => {
   logger.trace('Load base environment for the workspace `%s` from data store', workspaceId);
   const items = db.Environment.filter(environment => environment.parentId === workspaceId);
-  logger.trace('Found %d.', items.length);
+  logger.trace('Found %d environment(s).', items.length);
   return ensureSingle(items, 'base environment');
 };
 
@@ -19,6 +19,7 @@ export const loadEnvironment = (
   identifier?: string,
 ): Environment | null | undefined => {
   if (!db.Environment.length) {
+    logger.trace('No environments found in given data store, not loading any environment');
     return null;
   }
 
@@ -37,7 +38,8 @@ export const promptEnvironment = async (
   ci: boolean,
   workspaceId: string,
 ): Promise<Environment | null | undefined> => {
-  if (ci || !db.Environment.length) {
+  if (!db.Environment.length) {
+    logger.warn('No environments found');
     return null;
   }
 
@@ -48,6 +50,21 @@ export const promptEnvironment = async (
   if (!subEnvironments.length) {
     logger.trace('No sub environments found, using base environment');
     return baseWorkspaceEnv;
+  }
+
+  // We know at this point that an environment was not specified as an argument, so if there is
+  // only one, and we're in CI mode, use it.
+  if (ci && subEnvironments.length === 1) {
+    logger.trace(`Only one environment found in CI mode, using it (${subEnvironments[0].name})`);
+    return subEnvironments[0];
+  }
+
+  if (ci) {
+    logger.error(
+      `Multiple environments found in CI mode (${subEnvironments.map(s => s.name).join(', ')}). ` +
+        'Select one using --env <identifier>.',
+    );
+    return null;
   }
 
   const prompt = new AutoComplete({

--- a/packages/insomnia-inso/src/db/models/unit-test-suite.ts
+++ b/packages/insomnia-inso/src/db/models/unit-test-suite.ts
@@ -12,7 +12,7 @@ export const loadUnitTestSuite = (db: Database, identifier: string): UnitTestSui
   // Identifier is for one specific suite; find it
   logger.trace('Load unit test suite with identifier `%s` from data store', identifier);
   const items = db.UnitTestSuite.filter(suite => matchIdIsh(suite, identifier) || suite.name === identifier);
-  logger.trace('Found %d.', items.length);
+  logger.trace('Found %d unit test suite(s).', items.length);
   return ensureSingleOrNone(items, 'unit test suite');
 };
 export const loadTestSuites = (db: Database, identifier: string): UnitTestSuite[] => {

--- a/packages/insomnia-inso/src/db/models/workspace.ts
+++ b/packages/insomnia-inso/src/db/models/workspace.ts
@@ -9,7 +9,7 @@ const entity = 'workspace';
 export const loadWorkspace = (db: Database, identifier: string) => {
   logger.trace('Load workspace with identifier `%s` from data store', identifier);
   const items = db.Workspace.filter(workspace => matchIdIsh(workspace, identifier) || workspace.name === identifier);
-  logger.trace('Found %d.', items.length);
+  logger.trace('Found %d workspace(s).', items.length);
   return ensureSingleOrNone(items, 'workspace');
 };
 export const promptWorkspace = async (db: Database, ci: boolean): Promise<Workspace | null | undefined> => {


### PR DESCRIPTION
This PR changes how `inso` environments are selected when the `--ci` flag is used, and provides a more detailed message when an environment cannot be chosen.

If a single sub-environment exists within a workspace, it is selected by default when `--ci` is passed. Under the same conditions without the `--ci` argument, the user would be prompted to select it anyway, and is not given the option to proceed with the base environment.

It also silences the `punycode` deprecation warning (and all other Node warnings) to clean up the output a bit