### PR TITLE
fix: preference panel crash on the login page

### DIFF
--- a/packages/insomnia/src/ui/hooks/use-organization-features.tsx
+++ b/packages/insomnia/src/ui/hooks/use-organization-features.tsx
@@ -22,7 +22,7 @@ export function useOrganizationPermissions() {
   // Load organization permissions and features if they are not already loaded.
   useEffect(() => {
     const isIdleAndUninitialized = permissionsFetcher.state === 'idle' && !permissionsFetcher.data;
-    if (!isScratchpadOrganizationId(organizationId) && isIdleAndUninitialized) {
+    if (organizationId && !isScratchpadOrganizationId(organizationId) && isIdleAndUninitialized) {
       permissionsFetcher.load({
         organizationId,
       });


### PR DESCRIPTION
[INS-1357](https://konghq.atlassian.net/browse/INS-1357)

## Background

Open the preference panel and switch to the Data tab in the login page throws the following error. `permissionsFetcher` is only allowed to be called with a valid organizationId.

```
Path '/organization/:organizationId/permissions' requires param 'organizationId' but it was not provided
```

## Changes

Fallback to the default features and billing if there's no organizationId

[INS-1357]: https://konghq.atlassian.net/browse/INS-1357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ