### PR TITLE
Change the validation rule for branch name in cloud sync [INS-1041]

### DIFF
--- a/packages/insomnia/src/sync/vcs/__tests__/vcs.test.ts
+++ b/packages/insomnia/src/sync/vcs/__tests__/vcs.test.ts
@@ -962,4 +962,28 @@ describe('VCS', () => {
       expect(hasProject).toBe(false);
     });
   });
+
+  it('validate branch names', async () => {
+    expect(VCS.validateBranchName('branchA')).toEqual('');
+    expect(VCS.validateBranchName('feat/branch-A')).toEqual('');
+    expect(VCS.validateBranchName('A')).toEqual(
+      'Branch names must be at least 3 characters long and can only contain English letters, numbers, period (.), hyphen (-), underscore (_) and forward slash (/)',
+    );
+    expect(VCS.validateBranchName('U*&(')).toEqual(
+      'Branch names must be at least 3 characters long and can only contain English letters, numbers, period (.), hyphen (-), underscore (_) and forward slash (/)',
+    );
+    expect(VCS.validateBranchName('/feature')).toEqual('Branch names must start with a letter or number');
+    expect(VCS.validateBranchName('feature/')).toEqual('Branch names must not end with a forward slash (/)');
+    expect(VCS.validateBranchName('feature//A')).toEqual(
+      'Branch names must not contain consecutive forward slashes (//)',
+    );
+    expect(VCS.validateBranchName('feature.')).toEqual('Branch names must not end with a period (.)');
+    expect(VCS.validateBranchName('feature/../A')).toEqual('Branch names must not contain consecutive periods (..)');
+    expect(VCS.validateBranchName('feature/.A/B')).toEqual(
+      'No slash-separated component in branch name can begin with a period (.)',
+    );
+    expect(VCS.validateBranchName('feature/A.lock/B')).toEqual(
+      'No slash-separated component in branch name can end with the sequence .lock',
+    );
+  });
 });

--- a/packages/insomnia/src/sync/vcs/vcs.ts
+++ b/packages/insomnia/src/sync/vcs/vcs.ts
@@ -312,8 +312,34 @@ export class VCS {
   }
 
   static validateBranchName(branchName: string) {
-    if (!branchName.match(/^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,}$/)) {
-      return 'Branch names must be at least 3 characters long and can only contain ' + 'letters, numbers, - and _';
+    if (!branchName.match(/^[a-zA-Z0-9._/-]{3,}$/)) {
+      return 'Branch names must be at least 3 characters long and can only contain English letters, numbers, period (.), hyphen (-), underscore (_) and forward slash (/)';
+    }
+    if (!branchName.match(/^[a-zA-Z0-9].*$/)) {
+      return 'Branch names must start with a letter or number';
+    }
+    if (branchName.endsWith('/')) {
+      return 'Branch names must not end with a forward slash (/)';
+    }
+    if (branchName.includes('//')) {
+      return 'Branch names must not contain consecutive forward slashes (//)';
+    }
+    if (branchName.endsWith('.')) {
+      return 'Branch names must not end with a period (.)';
+    }
+    if (branchName.includes('..')) {
+      return 'Branch names must not contain consecutive periods (..)';
+    }
+    const parts = branchName.split('/');
+    if (parts.length > 1) {
+      for (const part of parts) {
+        if (part.startsWith('.')) {
+          return 'No slash-separated component in branch name can begin with a period (.)';
+        }
+        if (part.endsWith('.lock')) {
+          return 'No slash-separated component in branch name can end with the sequence .lock';
+        }
+      }
     }
 
     return '';
@@ -1346,7 +1372,7 @@ export class VCS {
   }
 
   async _getBranch(name: string): Promise<Branch | null> {
-    return this._store.getItem(`/projects/${this._backendProjectId()}/branches/${name}.json`);
+    return this._store.getItem(`/projects/${this._backendProjectId()}/branches/${encodeBranchName(name)}.json`);
   }
 
   async _getBranches(backendProjectId?: string) {
@@ -1516,14 +1542,17 @@ export class VCS {
     }
 
     branch.modified = new Date();
+    // toLowerCase may introduce issues under case sensitive filesystems
     return this._store.setItem(
-      `/projects/${this._backendProjectId()}/branches/${branch.name.toLowerCase()}.json`,
+      `/projects/${this._backendProjectId()}/branches/${encodeBranchName(branch.name).toLowerCase()}.json`,
       branch,
     );
   }
 
   async _removeBranch(branch: Branch) {
-    return this._store.removeItem(`/projects/${this._backendProjectId()}/branches/${branch.name}.json`);
+    return this._store.removeItem(
+      `/projects/${this._backendProjectId()}/branches/${encodeBranchName(branch.name)}.json`,
+    );
   }
 
   async _removeProject(project: BackendProject) {
@@ -1614,4 +1643,8 @@ function _generateSnapshotID(parentId: string, backendProjectId: string, state: 
   }
 
   return hash.digest('hex');
+}
+
+function encodeBranchName(branchName: string) {
+  return branchName.replaceAll('/', '~');
 }


### PR DESCRIPTION
According to [Git’s official branch-naming rules](https://git-scm.com/docs/git-check-ref-format#_description) and [GitHub’s recommended naming conventions](https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names#naming-branches-and-tags), I updated the branch-name requirements for Cloud Sync in Insomnia:

1. Branch names must be at least 3 characters long and can only contain English letters, numbers, period (.), hyphen (-), underscore (_) and forward slash (/)
2. Branch names must start with a letter or number
3. Branch names must not end with a forward slash (/)
4. Branch names must not contain consecutive forward slashes (//)
5. Branch names must not end with a period (.)
6. Branch names must not contain consecutive periods (..)
7. No slash-separated component in branch name can begin with a period (.)
8. No slash-separated component in branch name can end with the sequence .lock



Because each branch’s metadata is stored in a corresponding JSON file, and we now allow forward slashes in branch names, the implementation converts any forward slashes to tildes when reading or writing those JSON files to avoid conflicts.

After this feature is released, older versions of the Insomnia client will show the following error if a user tries to fetch a branch from remote whose name contains a forward slash.

<img width="1044" height="398" alt="2025-09-11_161412" src="https://github.com/user-attachments/assets/9d7fff8a-ae81-431f-b3df-c94c530a2452" />
