### PR TITLE
feat: add option to collapse JSON responses by default in settings

### DIFF
--- a/packages/insomnia/src/common/settings.ts
+++ b/packages/insomnia/src/common/settings.ts
@@ -158,4 +158,5 @@ export interface Settings {
   saveVaultKeyToOSSecretManager: boolean;
   vaultSecretCacheDuration: number;
   dataFolders: string[];
+  collapseJsonResponseByDefault: boolean;
 }

--- a/packages/insomnia/src/models/settings.ts
+++ b/packages/insomnia/src/models/settings.ts
@@ -76,6 +76,7 @@ export function init(): BaseSettings {
     // The duration in mins for which the external vault secret is cached
     vaultSecretCacheDuration: 30,
     dataFolders: [],
+    collapseJsonResponseByDefault: false,
   };
 }
 

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -116,6 +116,7 @@ export interface CodeEditorProps {
   // NOTE: for caching scroll and marks
   uniquenessKey?: string;
   updateFilter?: (filter: string) => void;
+  collapseAllOnInit?: boolean;
 }
 
 const normalizeMimeType = (mode?: string) => {
@@ -191,6 +192,7 @@ export const CodeEditor = memo(
         style,
         uniquenessKey,
         updateFilter,
+        collapseAllOnInit,
       },
       ref,
     ) => {
@@ -398,6 +400,15 @@ export const CodeEditor = memo(
           },
         };
         codeMirror.current = CodeMirror.fromTextArea(textAreaRef.current, initialOptions);
+        // If requested, collapse all JSON nodes after initial content set
+        if (collapseAllOnInit && normalizeMimeType(mode)?.includes('json')) {
+          // Defer to allow CM to render
+          setTimeout(() => {
+            try {
+              codeMirror.current?.execCommand('foldAll');
+            } catch {}
+          }, 0);
+        }
         codeMirror.current.on('beforeChange', (doc: CodeMirror.Editor, change: CodeMirror.EditorChangeCancellable) => {
           const isGraphqlWithChange = doc.getOption('mode') === 'graphql' && change.text.length > 0;
           if (isGraphqlWithChange) {

--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -159,6 +159,11 @@ export const General: FC = () => {
         <div>
           <BooleanSetting label="Disable JS in HTML preview" setting="disableHtmlPreviewJs" />
           <BooleanSetting label="Disable links in response viewer" setting="disableResponsePreviewLinks" />
+          <BooleanSetting
+            label="Collapse JSON responses by default"
+            setting="collapseJsonResponseByDefault"
+            help="If checked, JSON response bodies will be rendered with all nodes collapsed initially."
+          />
 
           <BooleanSetting
             label="Disable default User-Agent on new requests"

--- a/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-viewer.tsx
@@ -1,5 +1,6 @@
 import iconv from 'iconv-lite';
 import React, { Fragment, useCallback, useRef, useState } from 'react';
+import { useRootLoaderData } from '~/root';
 
 import { CodeEditor, type CodeEditorHandle } from '~/ui/components/.client/codemirror/code-editor';
 
@@ -213,6 +214,7 @@ export const ResponseViewer = ({
   }
 
   const contentType = _getContentType();
+  const { settings } = useRootLoaderData()!;
 
   if (previewMode === PREVIEW_MODE_FRIENDLY && contentType === 'application/json') {
     let bodyStr = getBodyAsString();
@@ -231,6 +233,7 @@ export const ResponseViewer = ({
         key={`${responseId}-json`}
         ref={editorRef}
         autoPrettify
+        collapseAllOnInit={settings.collapseJsonResponseByDefault}
         defaultValue={bodyStr}
         filter={filter}
         filterHistory={filterHistory}


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Added new user setting `collapseJsonResponseByDefault`

https://github.com/user-attachments/assets/45df1f48-7f37-4fe6-ac1e-d6f15c90b701

Closes #6548
