### PR TITLE
fix: Discard actions now respect staged vs unstaged changes and prevent silent data loss [INS-1099]

### DIFF
--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -1827,7 +1827,7 @@ export const discardChangesAction = async ({
 
     const files = changes.unstaged.filter(change => paths.includes(change.path));
 
-    await GitVCS.discardChanges(files);
+    await GitVCS.discardChanges(files, { discardUnstaged: true });
 
     await models.gitRepository.update(gitRepository, {
       cachedGitLastCommitTime: Date.now(),

--- a/packages/insomnia/src/sync/git/__tests__/git-vcs.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/git-vcs.test.ts
@@ -319,7 +319,7 @@ First commit!
         ],
       });
       // Discard changes
-      await GitVCS.discardChanges(status2.unstaged);
+      await GitVCS.discardChanges(status2.unstaged, { discardUnstaged: true });
 
       const status3 = await GitVCS.status();
 
@@ -362,7 +362,7 @@ First commit!
       const status2 = await GitVCS.status();
       // Undo foo1 and foo2, but not foo3
       const changesToUndo = status2.unstaged.filter(change => !change.path.includes(foo3Txt));
-      await GitVCS.discardChanges(changesToUndo);
+      await GitVCS.discardChanges(changesToUndo, { discardUnstaged: true });
       const status3 = await GitVCS.status();
       expect(status3).toEqual({
         staged: [],

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -1465,7 +1465,7 @@ export class GitVCS {
           await git.resetIndex({ ...this._baseOpts, filepath: change.path });
         }
 
-        // Discard unstaged changes only
+        // Discard unstaged changes only.
         if (options?.discardUnstaged) {
           // Restore workdir from index (staged version)
           // 1. Get staged blob OID

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -1449,20 +1449,57 @@ export class GitVCS {
     }
   }
 
-  async discardChanges(changes: { path: string; status: [git.HeadStatus, git.WorkdirStatus, git.StageStatus] }[]) {
+  async discardChanges(
+    changes: { path: string; status: [git.HeadStatus, git.WorkdirStatus, git.StageStatus] }[],
+    options?: { discardStaged?: boolean; discardUnstaged?: boolean },
+  ) {
     for (const change of changes) {
-      // If the file didn't exist in HEAD, we need to remove it
+      // If the file didn't exist in HEAD, remove it
       if (change.status[0] === 0) {
         await git.remove({ ...this._baseOpts, filepath: change.path });
         // @ts-expect-error -- TSCONVERSION
         await this._baseOpts.fs.promises.unlink(change.path);
       } else {
-        await git.checkout({
-          ...this._baseOpts,
-          force: true,
-          ref: await this.getCurrentBranch(),
-          filepaths: [convertToPosixSep(change.path)],
-        });
+        // Discard staged changes only
+        if (options?.discardStaged) {
+          await git.resetIndex({ ...this._baseOpts, filepath: change.path });
+        }
+
+        // Discard unstaged changes only
+        if (options?.discardUnstaged) {
+          // Restore workdir from index (staged version)
+          // 1. Get staged blob OID
+          const statusMatrix = await git.statusMatrix({ ...this._baseOpts });
+          const row = statusMatrix.find(([filepath]) => filepath === change.path);
+          if (row) {
+            const [, , , stageStatusCode] = row;
+            if (stageStatusCode !== 0) {
+              // 2. Get staged blob content
+              const index = await git.listFiles({ ...this._baseOpts });
+              if (index.includes(change.path)) {
+                // Use fileStatus logic to get staged content:
+                const { stage } = await this.fileStatus(change.path);
+                if (stage !== null) {
+                  // 3. Write staged content to workdir
+                  // @ts-expect-error -- TSCONVERSION
+                  await this._baseOpts.fs.promises.writeFile(change.path, stage, 'utf8');
+                }
+              }
+            }
+          }
+          // Do NOT touch the index (staged changes are preserved)
+          continue;
+        }
+
+        // Default: discard both (current behavior)
+        if (!options?.discardStaged && !options?.discardUnstaged) {
+          await git.checkout({
+            ...this._baseOpts,
+            force: true,
+            ref: await this.getCurrentBranch(),
+            filepaths: [convertToPosixSep(change.path)],
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
This PR addresses an issue where using Discard or Discard All removed both staged and unstaged changes, regardless of the user’s intent. The previous behavior caused accidental loss of work, especially when staged and unstaged changes overlapped on the same line.

Closes INS-1099