### PR TITLE
Remove dependency on @mismerge/react [INS-1418]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4179,18 +4179,6 @@
         "svelte": "^4.0.0"
       }
     },
-    "node_modules/@mismerge/react": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/@mismerge/react/-/react-1.0.1.tgz",
-      "integrity": "sha512-y9jk+b840vEarYDgLfH30u9a7bJuJJ0MLouDPxrlesXmDgIfBBJPPKnk4gH976A+njdrGIr0URPhhtrwbLXvmA==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@mismerge/core": "^1.2.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      }
-    },
     "node_modules/@mjackson/node-fetch-server": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@mjackson/node-fetch-server/-/node-fetch-server-0.2.0.tgz",
@@ -28724,7 +28712,6 @@
         "@getinsomnia/api-client": "0.0.10",
         "@getinsomnia/srp-js": "1.0.0-alpha.1",
         "@mismerge/core": "^1.2.1",
-        "@mismerge/react": "^1.0.1",
         "@react-router/dev": "^7.7.0",
         "@react-router/fs-routes": "^7.7.0",
         "@react-router/node": "^7.7.0",

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -111,7 +111,6 @@
     "@getinsomnia/api-client": "0.0.10",
     "@getinsomnia/srp-js": "1.0.0-alpha.1",
     "@mismerge/core": "^1.2.1",
-    "@mismerge/react": "^1.0.1",
     "@react-router/dev": "^7.7.0",
     "@react-router/fs-routes": "^7.7.0",
     "@react-router/node": "^7.7.0",

--- a/packages/insomnia/src/ui/components/modals/sync-merge-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-merge-modal.tsx
@@ -1,6 +1,6 @@
+import { DefaultDarkColors, DefaultLightColors } from '@mismerge/core/colors';
 import darkCssHref from '@mismerge/core/dark.css?url';
 import lightCssHref from '@mismerge/core/light.css?url';
-import { DefaultDarkColors, DefaultLightColors, MisMerge3 } from '@mismerge/react';
 import classNames from 'classnames';
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import {
@@ -204,6 +204,12 @@ export const SyncMergeModal = forwardRef<SyncMergeModalHandle>((_, ref) => {
     const nextHref = isLightTheme ? lightCssHref : darkCssHref;
     if (link.href !== nextHref) link.href = nextHref;
   }, [isLightTheme]);
+
+  const misMergeRef = useRef<JSX.IntrinsicElements['mis-merge3']>(null);
+  useEffect(() => {
+    // @ts-expect-error No definitions provided for web components
+    import('@mismerge/core/web');
+  }, []);
 
   return (
     <>
@@ -441,13 +447,18 @@ export const SyncMergeModal = forwardRef<SyncMergeModalHandle>((_, ref) => {
                               </li>
                             </ol>
                             <div className="flex-1 overflow-y-auto rounded-sm bg-[--hl-xs] p-2 text-[--color-font]">
-                              <MisMerge3
+                              {/* Use mis-merge3 custom element directly instead of importing @mismerge/react,
+                              because @mismerge/react does not support React 19 */}
+                              <mis-merge3
+                                ref={misMergeRef}
                                 lhs={selectedConflictCurrent}
                                 ctr={selectedConflict?.mergeResult || ''}
                                 rhs={selectedConflictIncoming}
-                                onCtrChange={onMergeEditorResultChange}
-                                colors={isLightTheme ? DefaultLightColors : DefaultDarkColors}
-                                wrapLines={true}
+                                onInput={() => {
+                                  onMergeEditorResultChange(misMergeRef.current.ctr);
+                                }}
+                                colors={JSON.stringify(isLightTheme ? DefaultLightColors : DefaultDarkColors)}
+                                wrapLines
                                 disableWordsCounter
                               />
                             </div>

--- a/packages/insomnia/types/global.d.ts
+++ b/packages/insomnia/types/global.d.ts
@@ -15,6 +15,12 @@ declare global {
     showWrapper: (options?: Record<string, any>) => void;
     showPrompt: (options?: Record<string, any>) => void;
   }
+  namespace JSX {
+    interface IntrinsicElements {
+      'mis-merge2': React.DetailedHTMLProps<>;
+      'mis-merge3': React.DetailedHTMLProps<>;
+    }
+  }
 }
 
 declare const __DEV__: boolean;


### PR DESCRIPTION
Remove dependency on @mismerge/react since it does not support React 19, use the custom element mis-merge3 defined in  @mismerge/core directly.
Close [INS-1418](https://konghq.atlassian.net/browse/INS-1418)

[INS-1418]: https://konghq.atlassian.net/browse/INS-1418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ