### PR TITLE
feat: Enhance the real time event polling mechanism for websocket and socket-io 

### DIFF
--- a/packages/insomnia/src/main/network/socket-io.ts
+++ b/packages/insomnia/src/main/network/socket-io.ts
@@ -82,8 +82,37 @@ export type SocketIOEvent =
 export type SocketIOEventLog = SocketIOEvent[];
 
 const SocketIOConnections = new Map<string, Socket>();
+const requestIdToResponseIdMap = new Map<string, string>();
 const eventLogFileStreams = new Map<string, fs.WriteStream>();
 const timelineFileStreams = new Map<string, fs.WriteStream>();
+
+const protocolName = 'socketIO';
+const getEventNotificationChannel = (responseId: string) => `${protocolName}.${responseId}.newEventReceived`;
+
+const writeEventLogAndNotify = ({
+  requestId,
+  data,
+  clearRequestIdMap = false,
+}: {
+  requestId: string;
+  data: any;
+  clearRequestIdMap?: boolean;
+}) => {
+  eventLogFileStreams.get(requestId)?.write(data, () => {
+    // notify all renderers of new event has been received
+    for (const window of BrowserWindow.getAllWindows()) {
+      const resId = requestIdToResponseIdMap.get(requestId);
+      if (resId) {
+        const notifyChannel = getEventNotificationChannel(resId);
+        notifyChannel && window.webContents.send(notifyChannel);
+        if (clearRequestIdMap) {
+          // clean up maps after last event has been written to file
+          requestIdToResponseIdMap.delete(requestId);
+        }
+      }
+    }
+  });
+};
 
 const buildTimeline = (url: string) => {
   const timeline = [
@@ -210,13 +239,13 @@ const openSocketIOConnection = async (
   if (!request) {
     return;
   }
-
   const responsesDir = path.join(process.env['INSOMNIA_DATA_PATH'] || electron.app.getPath('userData'), 'responses');
 
   const responseBodyPath = path.join(responsesDir, uuidV4() + '.response');
   eventLogFileStreams.set(options.requestId, fs.createWriteStream(responseBodyPath));
   const timelinePath = path.join(responsesDir, responseId + '.timeline');
   timelineFileStreams.set(options.requestId, fs.createWriteStream(timelinePath));
+  requestIdToResponseIdMap.set(options.requestId, responseId);
 
   // fallback to base environment
   const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(options.workspaceId);
@@ -294,8 +323,7 @@ const openSocketIOConnection = async (
         type: 'open',
         timestamp: Date.now(),
       };
-
-      eventLogFileStreams.get(options.requestId)?.write(JSON.stringify(openEvent) + '\n');
+      writeEventLogAndNotify({ requestId: options.requestId, data: JSON.stringify(openEvent) + '\n' });
 
       if (!openedEvents.length) {
         const infoEvent: SocketIOInfoEvent = {
@@ -305,7 +333,7 @@ const openSocketIOConnection = async (
           message: 'Add event listeners to receive messages',
           timestamp: Date.now(),
         };
-        eventLogFileStreams.get(options.requestId)?.write(JSON.stringify(infoEvent) + '\n');
+        writeEventLogAndNotify({ requestId: options.requestId, data: JSON.stringify(infoEvent) + '\n' });
       }
 
       const timeline = buildTimeline(url);
@@ -400,7 +428,11 @@ const deleteRequestMaps = async (
   event?: SocketIOCloseEvent | SocketIOErrorEvent,
 ) => {
   if (event) {
-    eventLogFileStreams.get(requestId)?.write(JSON.stringify(event) + '\n');
+    writeEventLogAndNotify({
+      requestId: requestId,
+      data: JSON.stringify(event) + '\n',
+      clearRequestIdMap: true,
+    });
   }
   eventLogFileStreams.get(requestId)?.end();
   eventLogFileStreams.delete(requestId);
@@ -435,7 +467,7 @@ const sendPayload = async (
         timestamp: Date.now(),
         eventName,
       };
-      eventLogFileStreams.get(options.requestId)?.write(JSON.stringify(ackEvent) + '\n');
+      writeEventLogAndNotify({ requestId: options.requestId, data: JSON.stringify(ackEvent) + '\n' });
     });
   }
 
@@ -448,8 +480,7 @@ const sendPayload = async (
     timestamp: Date.now(),
     eventName,
   };
-
-  eventLogFileStreams.get(options.requestId)?.write(JSON.stringify(lastMessage) + '\n');
+  writeEventLogAndNotify({ requestId: options.requestId, data: JSON.stringify(lastMessage) + '\n' });
 };
 
 const sendWebSocketEvent = async (options: {
@@ -494,7 +525,7 @@ const addSocketIOListener = (options: { eventName: string; requestId: string }) 
     timestamp: Date.now(),
     eventName: options.eventName,
   };
-  eventLogFileStreams.get(options.requestId)?.write(JSON.stringify(onEvent) + '\n');
+  writeEventLogAndNotify({ requestId: options.requestId, data: JSON.stringify(onEvent) + '\n' });
 
   socket.on(options.eventName, (...message: any[]) => {
     console.log('received message', message);
@@ -507,8 +538,7 @@ const addSocketIOListener = (options: { eventName: string; requestId: string }) 
       timestamp: Date.now(),
       eventName: options.eventName,
     };
-
-    eventLogFileStreams.get(options.requestId)?.write(JSON.stringify(messageEvent) + '\n');
+    writeEventLogAndNotify({ requestId: options.requestId, data: JSON.stringify(messageEvent) + '\n' });
   });
 };
 
@@ -527,8 +557,7 @@ const removeSocketIOListener = (options: { eventName: string; requestId: string 
     timestamp: Date.now(),
     eventName: options.eventName,
   };
-  eventLogFileStreams.get(options.requestId)?.write(JSON.stringify(offEvent) + '\n');
-
+  writeEventLogAndNotify({ requestId: options.requestId, data: JSON.stringify(offEvent) + '\n' });
   socket.off(options.eventName);
 };
 

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { type IncomingMessage, request } from 'node:http';
+import { type IncomingMessage } from 'node:http';
 import path from 'node:path';
 import tls, { type KeyObject, type PxfObject } from 'node:tls';
 

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { type IncomingMessage } from 'node:http';
+import { type IncomingMessage, request } from 'node:http';
 import path from 'node:path';
 import tls, { type KeyObject, type PxfObject } from 'node:tls';
 
@@ -71,9 +71,38 @@ export type WebSocketEvent = WebSocketOpenEvent | WebSocketMessageEvent | WebSoc
 
 export type WebSocketEventLog = WebSocketEvent[];
 
+const protocolName = 'webSocket';
 const WebSocketConnections = new Map<string, WebSocket>();
+const requestIdToResponseIdMap = new Map<string, string>();
 const eventLogFileStreams = new Map<string, fs.WriteStream>();
 const timelineFileStreams = new Map<string, fs.WriteStream>();
+
+const getEventNotificationChannel = (responseId: string) => `${protocolName}.${responseId}.newEventReceived`;
+
+const writeEventLogAndNotify = ({
+  requestId,
+  data,
+  clearRequestIdMap = false,
+}: {
+  requestId: string;
+  data: any;
+  clearRequestIdMap?: boolean;
+}) => {
+  eventLogFileStreams.get(requestId)?.write(data, () => {
+    // notify all renderers of new event has been received
+    for (const window of BrowserWindow.getAllWindows()) {
+      const resId = requestIdToResponseIdMap.get(requestId);
+      if (resId) {
+        const notifyChannel = getEventNotificationChannel(resId);
+        notifyChannel && window.webContents.send(notifyChannel);
+        if (clearRequestIdMap) {
+          // clean up maps after last event has been written to file
+          requestIdToResponseIdMap.delete(requestId);
+        }
+      }
+    }
+  });
+};
 
 const parseResponseAndBuildTimeline = (url: string, incomingMessage: IncomingMessage, clientRequestHeaders: string) => {
   const statusMessage = incomingMessage.statusMessage || '';
@@ -129,6 +158,7 @@ const openWebSocketConnection = async (
   eventLogFileStreams.set(options.requestId, fs.createWriteStream(responseBodyPath));
   const timelinePath = path.join(responsesDir, responseId + '.timeline');
   timelineFileStreams.set(options.requestId, fs.createWriteStream(timelinePath));
+  requestIdToResponseIdMap.set(options.requestId, responseId);
 
   const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(options.workspaceId);
   // fallback to base environment
@@ -148,7 +178,7 @@ const openWebSocketConnection = async (
     if (!options.url) {
       throw new Error('URL is required');
     }
-    const readyStateChannel = `webSocket.${request._id}.readyState`;
+    const readyStateChannel = `${protocolName}.${request._id}.readyState`;
 
     const reduceArrayToLowerCaseKeyedDictionary = (
       acc: Record<string, string>,
@@ -354,8 +384,10 @@ const openWebSocketConnection = async (
         type: 'open',
         timestamp: Date.now(),
       };
-
-      eventLogFileStreams.get(options.requestId)?.write(JSON.stringify(openEvent) + '\n');
+      for (const window of BrowserWindow.getAllWindows()) {
+        window.webContents.send(readyStateChannel, ws.readyState === WebSocket.OPEN);
+      }
+      writeEventLogAndNotify({ requestId: options.requestId, data: JSON.stringify(openEvent) + '\n' });
       timelineFileStreams
         .get(options.requestId)
         ?.write(
@@ -379,9 +411,7 @@ const openWebSocketConnection = async (
         direction: 'INCOMING',
         timestamp: Date.now(),
       };
-
-      eventLogFileStreams.get(options.requestId)?.write(JSON.stringify(messageEvent) + '\n');
-
+      writeEventLogAndNotify({ requestId: options.requestId, data: JSON.stringify(messageEvent) + '\n' });
       // send subscribe operation to graphql websocket server
       if (options.isGraphqlSubscriptionRequest) {
         handleGraphQLWsMessage(data, request as Request);
@@ -499,7 +529,11 @@ const deleteRequestMaps = async (
   event?: WebSocketCloseEvent | WebSocketErrorEvent,
 ) => {
   if (event) {
-    eventLogFileStreams.get(requestId)?.write(JSON.stringify(event) + '\n');
+    writeEventLogAndNotify({
+      requestId,
+      data: JSON.stringify(event) + '\n',
+      clearRequestIdMap: true,
+    });
   }
   eventLogFileStreams.get(requestId)?.end();
   eventLogFileStreams.delete(requestId);
@@ -535,7 +569,7 @@ const sendPayload = async (ws: WebSocket, options: { payload: string; requestId:
     timestamp: Date.now(),
   };
 
-  eventLogFileStreams.get(options.requestId)?.write(JSON.stringify(lastMessage) + '\n');
+  writeEventLogAndNotify({ requestId: options.requestId, data: JSON.stringify(lastMessage) + '\n' });
   const response = await database.findOne<WebSocketResponse>(
     'WebSocketResponse',
     {

--- a/packages/insomnia/src/main/network/websocket.ts
+++ b/packages/insomnia/src/main/network/websocket.ts
@@ -384,9 +384,6 @@ const openWebSocketConnection = async (
         type: 'open',
         timestamp: Date.now(),
       };
-      for (const window of BrowserWindow.getAllWindows()) {
-        window.webContents.send(readyStateChannel, ws.readyState === WebSocket.OPEN);
-      }
       writeEventLogAndNotify({ requestId: options.requestId, data: JSON.stringify(openEvent) + '\n' });
       timelineFileStreams
         .get(options.requestId)

--- a/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
@@ -76,35 +76,39 @@ const RealtimeActiveResponsePane: FC<{
     );
   };
 
-  const events = allEvents.filter(event => {
-    // Filter out events that are earlier than the clearEventsBefore timestamp
-    if (clearEventsBefore && event.timestamp <= clearEventsBefore) {
-      return false;
-    }
+  const events = useMemo(
+    () =>
+      allEvents.filter(event => {
+        // Filter out events that are earlier than the clearEventsBefore timestamp
+        if (clearEventsBefore && event.timestamp <= clearEventsBefore) {
+          return false;
+        }
 
-    // Filter out events that don't match the selected event type
-    if (eventType && event.type !== eventType) {
-      return false;
-    }
+        // Filter out events that don't match the selected event type
+        if (eventType && event.type !== eventType) {
+          return false;
+        }
 
-    // Filter out events that don't match the search query
-    if (searchQuery) {
-      if (event.type === 'message') {
-        return event.data.toString().toLowerCase().includes(searchQuery.toLowerCase());
-      }
-      if (event.type === 'error') {
-        return event.message.toLowerCase().includes(searchQuery.toLowerCase());
-      }
-      if (event.type === 'close') {
-        return event.reason.toLowerCase().includes(searchQuery.toLowerCase());
-      }
+        // Filter out events that don't match the search query
+        if (searchQuery) {
+          if (event.type === 'message') {
+            return event.data.toString().toLowerCase().includes(searchQuery.toLowerCase());
+          }
+          if (event.type === 'error') {
+            return event.message.toLowerCase().includes(searchQuery.toLowerCase());
+          }
+          if (event.type === 'close') {
+            return event.reason.toLowerCase().includes(searchQuery.toLowerCase());
+          }
 
-      // Filter out open events
-      return false;
-    }
+          // Filter out open events
+          return false;
+        }
 
-    return true;
-  });
+        return true;
+      }),
+    [allEvents, clearEventsBefore, eventType, searchQuery],
+  );
 
   useEffect(() => {
     setSelectedEvent(null);

--- a/packages/insomnia/src/ui/hooks/use-realtime-connection-events.ts
+++ b/packages/insomnia/src/ui/hooks/use-realtime-connection-events.ts
@@ -1,5 +1,4 @@
-import { useEffect, useState } from 'react';
-import * as reactUse from 'react-use';
+import { useCallback, useEffect, useState } from 'react';
 
 import type { CurlEvent } from '../../main/network/curl';
 import type { SocketIOEvent } from '../../main/network/socket-io';
@@ -13,25 +12,29 @@ export function useRealtimeConnectionEvents({
   protocol: 'curl' | 'webSocket' | 'socketIO';
 }) {
   const [events, setEvents] = useState<CurlEvent[] | WebSocketEvent[] | SocketIOEvent[]>([]);
+  const updateEvents = useCallback(async () => {
+    const allEvents = await window.main[protocol].event.findMany({ responseId });
+    setEvents(allEvents);
+  }, [responseId, protocol]);
 
   useEffect(() => {
-    setEvents([]);
-  }, [responseId]);
+    updateEvents();
+  }, [updateEvents]);
 
-  // TODO: use main process events instead of polling
-  reactUse.useInterval(() => {
+  useEffect(() => {
     let isMounted = true;
-    const fn = async () => {
-      const allEvents = await window.main[protocol].event.findMany({ responseId });
+    // @ts-expect-error -- we use a dynamic channel here+
+    const unsubscribe = window.main.on(`${protocol}.${responseId}.newEventReceived`, () => {
+      // update events when new event message is received
       if (isMounted) {
-        setEvents(allEvents);
+        updateEvents();
       }
-    };
-    fn();
+    });
     return () => {
       isMounted = false;
+      unsubscribe();
     };
-  }, 500);
+  }, [protocol, responseId, updateEvents]);
 
   return events;
 }


### PR DESCRIPTION
# Background 
For real-time events coming from WebSocket and Socket.IO requests, we currently rely on a useInterval hook that polls the file content every 0.5 seconds.
Because each poll recreates the entire events array, the “Events” tab re-renders on every cycle and useMemo provides no benefit.

# Changes
This PR replaces the frequent polling with an observer pattern so that updates are pushed only when new events arrive.
**New workflow**

- Main process
   - When a new event is received from the server and written to the file, invoke a callback.
   - The callback function notifies a predefined channel that a new event is available.

- Render process
  - Add a listener on mount on pre-defined channel
  - When the listener is fired, get the event using existing method `window.main.<protocol>.event.findMany`
  - Update the events and trigger re-render

# Outcome

By moving from time-based polling to an event-driven observer pattern, the “Events” tab updates only when necessary, reducing unnecessary renders and improving overall responsiveness and performance.
This change would also bring huge benefit for the mcp integration since we need to active the latest event automatically but do not break user's selection if exists

Refer [INS-1423](https://konghq.atlassian.net/browse/INS-1423)

[INS-1423]: https://konghq.atlassian.net/browse/INS-1423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ