### PR TITLE
bump: @kong/insomnia-plugin-external-vault

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3964,9 +3964,9 @@
       "license": "MIT"
     },
     "node_modules/@kong/insomnia-plugin-external-vault": {
-      "version": "0.1.1-dev.0.20250902151320",
-      "resolved": "https://npm.pkg.github.com/download/@kong/insomnia-plugin-external-vault/0.1.1-dev.0.20250902151320/b124623c7d0e3de9d3b5f66250bcae056f95361f",
-      "integrity": "sha512-jtRSIHTToXSFWyQIrCrO6fYn7klm/N+tIRbBQr432U8uoeY8vI40w9j5omzLPZ6tqi+HBj1NUJTr2/ELbmQp/A==",
+      "version": "0.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@kong/insomnia-plugin-external-vault/0.1.1/7feb56f72b716d9ca9c110a4f2829baaedab1e6a",
+      "integrity": "sha512-yzg6UG9Jbvifu79uk+NBb0bxWcBfTVNLdXtKsnNboiHAlYhyQxE8UbUSsPNKy9lVM1/eir2xJ947rrPIyeunmQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -28801,7 +28801,7 @@
         "zod": "^3.25.75"
       },
       "optionalDependencies": {
-        "@kong/insomnia-plugin-external-vault": "0.1.1-dev.0.20250902151320"
+        "@kong/insomnia-plugin-external-vault": "0.1.1"
       }
     },
     "packages/insomnia-inso": {
@@ -28832,7 +28832,7 @@
         "shellwords": "^1.0.1"
       },
       "optionalDependencies": {
-        "@kong/insomnia-plugin-external-vault": "0.1.1-dev.0.20250902151320"
+        "@kong/insomnia-plugin-external-vault": "0.1.1"
       }
     },
     "packages/insomnia-inso/node_modules/@esbuild/aix-ppc64": {

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -65,6 +65,6 @@
     "yaml": "^2.7.1"
   },
   "optionalDependencies": {
-    "@kong/insomnia-plugin-external-vault": "0.1.1-dev.0.20250902151320"
+    "@kong/insomnia-plugin-external-vault": "0.1.1"
   }
 }

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -200,7 +200,7 @@
     "zod": "^3.25.75"
   },
   "optionalDependencies": {
-    "@kong/insomnia-plugin-external-vault": "0.1.1-dev.0.20250902151320"
+    "@kong/insomnia-plugin-external-vault": "0.1.1"
   },
   "dev": {
     "dev-server-port": 3334


### PR DESCRIPTION

Update `@kong/insomnia-plugin-external-vault` to version `0.1.1`.