### PR TITLE
[INS-1309] - Improve init/complete sign in flows with GitHub/GitLab

### DIFF
--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -2118,15 +2118,22 @@ export const GITHUB_GRAPHQL_API_URL = getGitHubGraphQLApiURL();
 const statesCache = new Set<string>();
 
 async function initSignInToGitHub() {
-  const state = v4();
-  statesCache.add(state);
-  const url = new URL(getAppWebsiteBaseURL() + '/oauth/github-app');
+  try {
+    const state = v4();
+    statesCache.add(state);
+    const url = new URL(getAppWebsiteBaseURL() + '/oauth/github-app');
 
-  url.search = new URLSearchParams({
-    state,
-  }).toString();
+    url.search = new URLSearchParams({
+      state,
+    }).toString();
 
-  await shell.openExternal(url.toString());
+    await shell.openExternal(url.toString());
+    return {};
+  } catch (error) {
+    console.error('Failed to initiate the GitHub OAuth flow:', error);
+
+    return { errors: [`Failed to initiate the GitHub OAuth flow. ${getErrorMessage(error)}`] };
+  }
 }
 
 interface GitHubUserApiResponse {
@@ -2138,65 +2145,76 @@ interface GitHubUserApiResponse {
 }
 
 async function completeSignInToGitHub({ code, state }: { code: string; state: string }) {
-  if (!PLAYWRIGHT && !statesCache.has(state)) {
-    throw new Error('Invalid state parameter. It looks like the authorization flow was not initiated by the app.');
-  }
+  try {
+    if (!PLAYWRIGHT && !statesCache.has(state)) {
+      throw new Error('Invalid state parameter. It looks like the authorization flow was not initiated by the app.');
+    }
 
-  const response = await net.fetch(getApiBaseURL() + '/v1/oauth/github-app', {
-    method: 'POST',
-    body: JSON.stringify({
-      code,
-    }),
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-
-  const data = (await response.json()) as { access_token: string };
-  statesCache.delete(state);
-  const existingGitHubCredentials = await models.gitCredentials.getByProvider('github');
-
-  // need both requests because the email in GET /user
-  // is the public profile email and may not exist
-  const emailsPromise = net.fetch(getGitHubRestApiUrl() + '/user/emails', {
-    method: 'GET',
-    headers: {
-      Authorization: `token ${data.access_token}`,
-    },
-  }).then(response => response.json() as Promise<{ email: string; primary: boolean }[]>);
-
-  const userPromise = net.fetch(getGitHubRestApiUrl() + '/user', {
-    method: 'GET',
-    headers: {
-      Authorization: `token ${data.access_token}`,
-    },
-  }).then(response => response.json() as Promise<GitHubUserApiResponse>);
-
-  const [emails, user] = await Promise.all([emailsPromise, userPromise]);
-
-  const userProfileEmail = user.email ?? '';
-  const email = emails.find(e => e.primary)?.email ?? userProfileEmail ?? '';
-
-  if (existingGitHubCredentials) {
-    await models.gitCredentials.update(existingGitHubCredentials, {
-      token: data.access_token,
-      provider: 'githubapp',
-      author: {
-        email,
-        name: user.name ?? user.login ?? '',
-        avatarUrl: user.avatar_url,
+    const response = await net.fetch(getApiBaseURL() + '/v1/oauth/github-app', {
+      method: 'POST',
+      body: JSON.stringify({
+        code,
+      }),
+      headers: {
+        'Content-Type': 'application/json',
       },
     });
-  } else {
-    await models.gitCredentials.create({
-      token: data.access_token,
-      provider: 'githubapp',
-      author: {
-        email,
-        name: user.name ?? user.login ?? '',
-        avatarUrl: user.avatar_url,
-      },
-    });
+
+    const data = (await response.json()) as { access_token: string };
+    statesCache.delete(state);
+    const existingGitHubCredentials = await models.gitCredentials.getByProvider('github');
+
+    // need both requests because the email in GET /user
+    // is the public profile email and may not exist
+    const emailsPromise = net
+      .fetch(getGitHubRestApiUrl() + '/user/emails', {
+        method: 'GET',
+        headers: {
+          Authorization: `token ${data.access_token}`,
+        },
+      })
+      .then(response => response.json() as Promise<{ email: string; primary: boolean }[]>);
+
+    const userPromise = net
+      .fetch(getGitHubRestApiUrl() + '/user', {
+        method: 'GET',
+        headers: {
+          Authorization: `token ${data.access_token}`,
+        },
+      })
+      .then(response => response.json() as Promise<GitHubUserApiResponse>);
+
+    const [emails, user] = await Promise.all([emailsPromise, userPromise]);
+
+    const userProfileEmail = user.email ?? '';
+    const email = emails.find(e => e.primary)?.email ?? userProfileEmail ?? '';
+
+    if (existingGitHubCredentials) {
+      await models.gitCredentials.update(existingGitHubCredentials, {
+        token: data.access_token,
+        provider: 'githubapp',
+        author: {
+          email,
+          name: user.name ?? user.login ?? '',
+          avatarUrl: user.avatar_url,
+        },
+      });
+    } else {
+      await models.gitCredentials.create({
+        token: data.access_token,
+        provider: 'githubapp',
+        author: {
+          email,
+          name: user.name ?? user.login ?? '',
+          avatarUrl: user.avatar_url,
+        },
+      });
+    }
+
+    return {};
+  } catch (error) {
+    console.error('Failed to complete the GitHub OAuth flow:', error);
+    return { errors: ['Failed to complete the GitHub OAuth flow.'] };
   }
 }
 
@@ -2286,8 +2304,8 @@ async function getGitHubRepositories({
       }
     }
     return { repos, errors: [] };
-  } catch (e) {
-    const errorMessage = `Failed to fetch repositories from GitHub: ${e.message}`;
+  } catch (error) {
+    const errorMessage = `Failed to fetch repositories from GitHub. ${getErrorMessage(error)}`;
     return { repos: [], errors: [errorMessage] };
   }
 }
@@ -2313,8 +2331,8 @@ async function getGitHubRepository({ uri }: { uri: string }) {
     }
 
     return { repo: (await response.json()) as GitHubRepositoryApiResponse, errors: [], notFound: false };
-  } catch (e) {
-    const errorMessage = `Failed to fetch repository from GitHub: ${e.message}`;
+  } catch (error) {
+    const errorMessage = `Failed to fetch repository from GitHub. ${getErrorMessage(error)}`;
     return {
       errors: [errorMessage],
       notFound: false,
@@ -2367,92 +2385,114 @@ function base64URLEncode(buffer: Buffer) {
 export const getGitLabOauthApiURL = () => INSOMNIA_GITLAB_API_URL || 'https://gitlab.com';
 
 async function initSignInToGitLab() {
-  const state = v4();
+  try {
+    const state = v4();
 
-  const verifier = base64URLEncode(randomBytes(32));
-  gitLabStatesCache.set(state, verifier);
+    const verifier = base64URLEncode(randomBytes(32));
+    gitLabStatesCache.set(state, verifier);
 
-  const scopes = [
-    // Needed to read the user's email address, username and avatar_url from the /user GitLab API
-    'read_user',
-    // Read/Write access to the user's projects to allow for syncing (push/pull etc.)
-    'write_repository',
-  ];
+    const scopes = [
+      // Needed to read the user's email address, username and avatar_url from the /user GitLab API
+      'read_user',
+      // Read/Write access to the user's projects to allow for syncing (push/pull etc.)
+      'write_repository',
+    ];
 
-  const scope = scopes.join(' ');
+    const scope = scopes.join(' ');
 
-  function sha256(str: string) {
-    return createHash('sha256').update(str).digest();
+    function sha256(str: string) {
+      return createHash('sha256').update(str).digest();
+    }
+
+    const challenge = base64URLEncode(sha256(verifier));
+
+    const gitlabURL = new URL(`${getGitLabOauthApiURL()}/oauth/authorize`);
+    const { clientId, redirectUri } = await getGitLabConfig();
+    gitlabURL.search = new URLSearchParams({
+      client_id: clientId,
+      scope,
+      state,
+      response_type: 'code',
+      redirect_uri: redirectUri,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+    }).toString();
+
+    await shell.openExternal(gitlabURL.toString());
+
+    return {};
+  } catch (err) {
+    console.error('Failed to initiate the GitLab OAuth flow:\n', err);
+    return {
+      errors: [`Failed to initiate the the GitLab OAuth flow. ${getErrorMessage(err)}`],
+    };
   }
-
-  const challenge = base64URLEncode(sha256(verifier));
-
-  const gitlabURL = new URL(`${getGitLabOauthApiURL()}/oauth/authorize`);
-  const { clientId, redirectUri } = await getGitLabConfig();
-  gitlabURL.search = new URLSearchParams({
-    client_id: clientId,
-    scope,
-    state,
-    response_type: 'code',
-    redirect_uri: redirectUri,
-    code_challenge: challenge,
-    code_challenge_method: 'S256',
-  }).toString();
-
-  await shell.openExternal(gitlabURL.toString());
 }
 
 async function completeSignInToGitLab({ code, state }: { code: string; state: string }) {
-  let verifier = gitLabStatesCache.get(state);
+  try {
+    let verifier = gitLabStatesCache.get(state);
 
-  if (PLAYWRIGHT) {
-    verifier = 'test-verifier';
-  }
-  if (!verifier) {
-    throw new Error('Invalid state parameter. It looks like the authorization flow was not initiated by the app.');
-  }
-  const { clientId, redirectUri } = await getGitLabConfig();
-  const url = new URL(`${getGitLabOauthApiURL()}/oauth/token`);
-  url.search = new URLSearchParams({
-    code,
-    state,
-    client_id: clientId,
-    grant_type: 'authorization_code',
-    redirect_uri: redirectUri,
-    code_verifier: verifier,
-  }).toString();
+    if (PLAYWRIGHT) {
+      verifier = 'test-verifier';
+    }
+    if (!verifier) {
+      throw new Error('Invalid state parameter. It looks like the authorization flow was not initiated by the app.');
+    }
+    const { clientId, redirectUri } = await getGitLabConfig();
+    const url = new URL(`${getGitLabOauthApiURL()}/oauth/token`);
+    url.search = new URLSearchParams({
+      code,
+      state,
+      client_id: clientId,
+      grant_type: 'authorization_code',
+      redirect_uri: redirectUri,
+      code_verifier: verifier,
+    }).toString();
 
-  const gitLabResponse = await net.fetch(getGitLabOauthApiURL() + url.pathname + url.search, {
-    method: 'POST',
-  });
+    const gitLabResponse = await net.fetch(getGitLabOauthApiURL() + url.pathname + url.search, {
+      method: 'POST',
+    });
 
-  const { access_token, refresh_token } = (await gitLabResponse.json()) as {
-    access_token: string;
-    refresh_token: string;
-  };
+    const { access_token, refresh_token } = (await gitLabResponse.json()) as {
+      access_token: string;
+      refresh_token: string;
+    };
 
-  gitLabStatesCache.delete(state);
-  const existingGitLabCredentials = await models.gitCredentials.getByProvider('gitlab');
+    gitLabStatesCache.delete(state);
+    const existingGitLabCredentials = await models.gitCredentials.getByProvider('gitlab');
 
-  const gitLabUserResponse = await net.fetch(`${getGitLabOauthApiURL()}/api/v4/user`, {
-    headers: {
-      Authorization: `Bearer ${access_token}`,
-    },
-  });
+    const gitLabUserResponse = await net.fetch(`${getGitLabOauthApiURL()}/api/v4/user`, {
+      headers: {
+        Authorization: `Bearer ${access_token}`,
+      },
+    });
 
-  const user = (await gitLabUserResponse.json()) as {
-    id: number;
-    username: string;
-    name: string;
-    avatar_url: string;
-    public_email: string;
-    email: string;
-    projects_limit: number;
-    commit_email: string;
-  };
+    const user = (await gitLabUserResponse.json()) as {
+      id: number;
+      username: string;
+      name: string;
+      avatar_url: string;
+      public_email: string;
+      email: string;
+      projects_limit: number;
+      commit_email: string;
+    };
 
-  if (existingGitLabCredentials) {
-    return await models.gitCredentials.update(existingGitLabCredentials, {
+    if (existingGitLabCredentials) {
+      return await models.gitCredentials.update(existingGitLabCredentials, {
+        token: access_token,
+        refreshToken: refresh_token,
+        provider: 'gitlab',
+        author: {
+          email: user.commit_email ?? user.public_email ?? user.email ?? '',
+          name: user.username ?? user.name ?? '',
+          avatarUrl: user.avatar_url,
+        },
+      });
+    }
+
+    return await models.gitCredentials.create({
       token: access_token,
       refreshToken: refresh_token,
       provider: 'gitlab',
@@ -2462,18 +2502,10 @@ async function completeSignInToGitLab({ code, state }: { code: string; state: st
         avatarUrl: user.avatar_url,
       },
     });
+  } catch (error) {
+    console.error('Failed to complete the GitLab OAuth flow:', error);
+    return { errors: [`Failed to complete the GitLab OAuth flow. ${getErrorMessage(error)}`] };
   }
-
-  return await models.gitCredentials.create({
-    token: access_token,
-    refreshToken: refresh_token,
-    provider: 'gitlab',
-    author: {
-      email: user.commit_email ?? user.public_email ?? user.email ?? '',
-      name: user.username ?? user.name ?? '',
-      avatarUrl: user.avatar_url,
-    },
-  });
 }
 
 async function signOutOfGitLab() {

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -2158,14 +2158,14 @@ async function completeSignInToGitHub({ code, state }: { code: string; state: st
 
   // need both requests because the email in GET /user
   // is the public profile email and may not exist
-  const emailsPromise = fetch(getGitHubRestApiUrl() + '/user/emails', {
+  const emailsPromise = net.fetch(getGitHubRestApiUrl() + '/user/emails', {
     method: 'GET',
     headers: {
       Authorization: `token ${data.access_token}`,
     },
   }).then(response => response.json() as Promise<{ email: string; primary: boolean }[]>);
 
-  const userPromise = fetch(getGitHubRestApiUrl() + '/user', {
+  const userPromise = net.fetch(getGitHubRestApiUrl() + '/user', {
     method: 'GET',
     headers: {
       Authorization: `token ${data.access_token}`,
@@ -2237,7 +2237,7 @@ async function getGitHubRepositories({
       },
     };
 
-    const response = await fetch(url, opts);
+    const response = await net.fetch(url, opts);
     if (!response.ok) {
       const raw = await response.text();
       if (response.status === 401) {
@@ -2267,7 +2267,7 @@ async function getGitHubRepositories({
           const pages = Number(lastPage);
           const pageList = await Promise.all(
             Array.from({ length: pages - 1 }, (_, i) =>
-              fetch(`${GITHUB_USER_REPOS_URL}?per_page=100&page=${i + 2}`, opts),
+              net.fetch(`${GITHUB_USER_REPOS_URL}?per_page=100&page=${i + 2}`, opts),
             ),
           );
           for (const page of pageList) {
@@ -2303,7 +2303,7 @@ async function getGitHubRepository({ uri }: { uri: string }) {
       },
     };
 
-    const response = await fetch(`${getGitHubRestApiUrl()}/repos/${owner}/${name}`, opts);
+    const response = await net.fetch(`${getGitHubRestApiUrl()}/repos/${owner}/${name}`, opts);
     if (!response.ok) {
       const raw = await response.text();
       return {
@@ -2345,7 +2345,7 @@ const getGitLabConfig = async () => {
     };
   }
 
-  const configResponse = await fetch(getApiBaseURL() + '/v1/oauth/gitlab/config', {
+  const configResponse = await net.fetch(getApiBaseURL() + '/v1/oauth/gitlab/config', {
     method: 'GET',
   });
 
@@ -2422,7 +2422,7 @@ async function completeSignInToGitLab({ code, state }: { code: string; state: st
     code_verifier: verifier,
   }).toString();
 
-  const gitLabResponse = await fetch(getGitLabOauthApiURL() + url.pathname + url.search, {
+  const gitLabResponse = await net.fetch(getGitLabOauthApiURL() + url.pathname + url.search, {
     method: 'POST',
   });
 
@@ -2434,7 +2434,7 @@ async function completeSignInToGitLab({ code, state }: { code: string; state: st
   gitLabStatesCache.delete(state);
   const existingGitLabCredentials = await models.gitCredentials.getByProvider('gitlab');
 
-  const gitLabUserResponse = await fetch(`${getGitLabOauthApiURL()}/api/v4/user`, {
+  const gitLabUserResponse = await net.fetch(`${getGitLabOauthApiURL()}/api/v4/user`, {
     headers: {
       Authorization: `Bearer ${access_token}`,
     },

--- a/packages/insomnia/src/routes/git-credentials.github.complete-sign-in.tsx
+++ b/packages/insomnia/src/routes/git-credentials.github.complete-sign-in.tsx
@@ -6,12 +6,10 @@ import type { Route } from './+types/git-credentials.github.complete-sign-in';
 
 export async function clientAction({ request }: Route.ClientActionArgs) {
   const { code, state } = (await request.json()) as { code: string; state: string; path: string };
-  await window.main.git.completeSignInToGitHub({
+  return await window.main.git.completeSignInToGitHub({
     code,
     state,
   });
-
-  return null;
 }
 
 export const useGithubCompleteSignInFetcher = createFetcherSubmitHook(

--- a/packages/insomnia/src/routes/git-credentials.github.init-sign-in.tsx
+++ b/packages/insomnia/src/routes/git-credentials.github.init-sign-in.tsx
@@ -5,9 +5,7 @@ import { createFetcherSubmitHook } from '~/utils/router';
 import type { Route } from './+types/git-credentials.github.init-sign-in';
 
 export async function clientAction(_args: Route.ClientActionArgs) {
-  await window.main.git.initSignInToGitHub();
-
-  return null;
+  return await window.main.git.initSignInToGitHub();
 }
 
 export const useInitSignInToGitHubFetcher = createFetcherSubmitHook(

--- a/packages/insomnia/src/routes/git-credentials.gitlab.complete-sign-in.tsx
+++ b/packages/insomnia/src/routes/git-credentials.gitlab.complete-sign-in.tsx
@@ -6,12 +6,11 @@ import type { Route } from './+types/git-credentials.gitlab.complete-sign-in';
 
 export async function clientAction({ request }: Route.ClientActionArgs) {
   const { code, state } = (await request.json()) as { code: string; state: string; path: string };
-  await window.main.git.completeSignInToGitLab({
+
+  return await window.main.git.completeSignInToGitLab({
     code,
     state,
   });
-
-  return null;
 }
 
 export const useGitLabCompleteSignInFetcher = createFetcherSubmitHook(

--- a/packages/insomnia/src/routes/git-credentials.gitlab.init-sign-in.tsx
+++ b/packages/insomnia/src/routes/git-credentials.gitlab.init-sign-in.tsx
@@ -5,9 +5,7 @@ import { createFetcherSubmitHook } from '~/utils/router';
 import type { Route } from './+types/git-credentials.gitlab.init-sign-in';
 
 export async function clientAction(_args: Route.ClientActionArgs) {
-  await window.main.git.initSignInToGitLab();
-
-  return null;
+  return await window.main.git.initSignInToGitLab();
 }
 
 export const useInitSignInToGitLabFetcher = createFetcherSubmitHook(

--- a/packages/insomnia/src/ui/components/git-credentials/github-repository-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/github-repository-settings-form.tsx
@@ -8,6 +8,7 @@ import { useGithubCompleteSignInFetcher } from '~/routes/git-credentials.github.
 import { useInitSignInToGitHubFetcher } from '~/routes/git-credentials.github.init-sign-in';
 import { useGithubSignOutFetcher } from '~/routes/git-credentials.github.sign-out';
 import { PromptButton } from '~/ui/components/base/prompt-button';
+import { Icon } from '~/ui/components/icon';
 
 import { GitHubRepositorySelect } from './github-repository-select';
 
@@ -127,12 +128,20 @@ const GitHubRepositoryForm = ({ uri, credentials, onSubmit }: GitHubRepositoryFo
     </Form>
   );
 };
-
+const getErrorResult = (data: any) => {
+  if (data && 'errors' in data && Array.isArray(data.errors) && data.errors.length > 0) {
+    return data.errors.join(', ');
+  }
+  return null;
+};
 const GitHubSignInForm = () => {
   const [error, setError] = useState('');
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const initSignInFetcher = useInitSignInToGitHubFetcher();
   const completeSignInFetcher = useGithubCompleteSignInFetcher();
+
+  const initSignInError = getErrorResult(initSignInFetcher.data);
+  const completeSignInError = getErrorResult(completeSignInFetcher.data);
 
   return (
     <div className="flex flex-col items-center justify-center border border-solid border-[--hl-sm] p-4">
@@ -193,9 +202,15 @@ const GitHubSignInForm = () => {
           {error && (
             <p className="notice error margin-bottom-sm">
               <Button className="pull-right icon" onPress={() => setError('')}>
-                <i className="fa fa-times" />
+                <Icon icon="times" className="size-4" />
               </Button>
               {error}
+            </p>
+          )}
+          {(initSignInError || completeSignInError) && (
+            <p className="margin-bottom-sm flex items-center rounded-sm border border-solid border-[--color-danger] bg-[--color-danger-bg] p-2 text-[--color-danger]">
+              <Icon icon="exclamation-triangle" className="size-4" />
+              <span>{initSignInError || completeSignInError}</span>
             </p>
           )}
         </form>

--- a/packages/insomnia/src/ui/components/git-credentials/gitlab-repository-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/gitlab-repository-settings-form.tsx
@@ -157,11 +157,21 @@ const GitLabRepositoryForm = ({ uri, credentials, onSubmit }: GitLabRepositoryFo
   );
 };
 
+const getErrorResult = (data: any) => {
+  if (data && 'errors' in data && Array.isArray(data.errors) && data.errors.length > 0) {
+    return data.errors.join(', ');
+  }
+  return null;
+};
+
 const GitLabSignInForm = () => {
   const [error, setError] = useState('');
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const initSignInFetcher = useInitSignInToGitLabFetcher();
   const completeSignInFetcher = useGitLabCompleteSignInFetcher();
+
+  const initSignInError = getErrorResult(initSignInFetcher.data);
+  const completeSignInError = getErrorResult(completeSignInFetcher.data);
 
   return (
     <div className="flex flex-col items-center justify-center border border-solid border-[--hl-sm] p-4">
@@ -222,9 +232,15 @@ const GitLabSignInForm = () => {
           {error && (
             <p className="notice error margin-bottom-sm">
               <Button className="pull-right icon" onPress={() => setError('')}>
-                <i className="fa fa-times" />
+                <Icon icon="times" className="size-4" />
               </Button>
               {error}
+            </p>
+          )}
+          {(initSignInError || completeSignInError) && (
+            <p className="margin-bottom-sm flex items-center rounded-sm border border-solid border-[--color-danger] bg-[--color-danger-bg] p-2 text-[--color-danger]">
+              <Icon icon="exclamation-triangle" className="size-4" />
+              <span>{initSignInError || completeSignInError}</span>
             </p>
           )}
         </form>


### PR DESCRIPTION
# Overview

There are some cases where the sign-in flow for GitHub/GitLab can fail which are not handled properly in the UI.

## Highlights
- [x] Added a new result to the signIn/completeSignIn methods for GitHub/GitLab flows in GitService.
- [x] We now display the errors in the form instead of the global error page
- [x] Replaced node `fetch` with `net.fetch` to make sure those API calls use the proxy and system settings from the app.