### PR TITLE
fix: wrong expiry time of oauth token

### DIFF
--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.test.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.test.tsx
@@ -1,0 +1,25 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from 'vitest';
+
+import { convertEpochToMilliseconds } from './o-auth-2-auth';
+
+describe('convertEpochToMilliseconds()', () => {
+  it('should convert microseconds to milliseconds', () => {
+    expect(convertEpochToMilliseconds(1617616858412123)).toBe(1617616858412);
+  });
+
+  it('should convert seconds to milliseconds', () => {
+    expect(convertEpochToMilliseconds(1617617010)).toBe(1617617010000);
+  });
+
+  it('should output same if value already in milliseconds', () => {
+    expect(convertEpochToMilliseconds(1617617141412)).toBe(1617617141412);
+  });
+
+  it('should ignore the fractional part', () => {
+    expect(convertEpochToMilliseconds(1617617141412.123)).toBe(1617617141412);
+    expect(convertEpochToMilliseconds(1617617141.412123)).toBe(1617617141000);
+  });
+});

--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -336,6 +336,7 @@ export const OAuth2Auth: FC = () => {
   Which is the epoch millisecond representation. (trims last 2 digits)
 */
 export function convertEpochToMilliseconds(epoch: number) {
+  epoch = Math.floor(epoch);
   const expDigitCount = epoch.toString().length;
   return parseInt(String(epoch * 10 ** (13 - expDigitCount)), 10);
 }


### PR DESCRIPTION
[INS-1485](https://konghq.atlassian.net/browse/INS-1485)

fixes #9170 

## Changes

Ignore the fractional part of a timestamp


[INS-1485]: https://konghq.atlassian.net/browse/INS-1485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ