### PR TITLE
fix: mcp multiple tab issue

### DIFF
--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -201,9 +201,10 @@ const writeEventLogAndNotify = (
 
 const _getMcpClient = (id: string) => {
   const mcpClient = mcpConnections.get(id);
-  if (!mcpClient) {
-    console.log(`No existing MCP client connection found for requestId: ${id}. It might have been disconnected.`);
-  }
+  invariant(
+    mcpClient,
+    `No existing MCP client connection found for requestId: ${id}. It might have been disconnected.`,
+  );
   return mcpClient;
 };
 
@@ -971,6 +972,8 @@ const closeMcpConnection = async (options: CommonMcpOptions) => {
       // Alway close the connection even the transport terminate session fails
       // This occurs when the server is not reachable, terminateSession failure will cause the connection to never close
       mcpClient.close();
+      // Execute clear resource subscription in main process rather than UI to make sure closeAllMcpConnections method will clear subscriptions
+      await models.mcpRequest.clearResourceSubscriptions(requestId);
     }
   }
 };

--- a/packages/insomnia/src/models/mcp-request.ts
+++ b/packages/insomnia/src/models/mcp-request.ts
@@ -27,6 +27,7 @@ export interface BaseMcpRequest {
   env: EnvironmentKvPairData[];
   mcpStdioAccess: boolean;
   roots: Root[];
+  subscribeResources: string[];
 }
 export type McpServerPrimitiveTypes = 'tools' | 'resources' | 'prompts' | 'resourceTemplates';
 
@@ -49,6 +50,7 @@ export function init(): BaseMcpRequest {
     env: [],
     mcpStdioAccess: false,
     roots: [],
+    subscribeResources: [],
   };
 }
 

--- a/packages/insomnia/src/models/mcp-request.ts
+++ b/packages/insomnia/src/models/mcp-request.ts
@@ -1,5 +1,7 @@
 import type { Root } from '@modelcontextprotocol/sdk/types.js';
 
+import { invariant } from '~/utils/invariant';
+
 import { database as db } from '../common/database';
 import { type EnvironmentKvPairData } from './environment';
 import type { BaseModel } from './index';
@@ -82,6 +84,12 @@ export function getById(id: string) {
   return db.findOne<McpRequest>(type, { _id: id });
 }
 
-export function update(mockServer: McpRequest, patch: Partial<McpRequest> = {}) {
-  return db.docUpdate<McpRequest>(mockServer, patch);
+export function update(request: McpRequest, patch: Partial<McpRequest> = {}) {
+  return db.docUpdate<McpRequest>(request, patch);
+}
+
+export async function clearResourceSubscriptions(requestId: string) {
+  const request = await getById(requestId);
+  invariant(request, 'McpRequest not found');
+  return update(request, { subscribeResources: [] });
 }

--- a/packages/insomnia/src/ui/components/mcp/mcp-pane.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-pane.tsx
@@ -55,7 +55,7 @@ import { OrganizationTabList } from '~/ui/components/tabs/tab-list';
 import { RealtimeResponsePane } from '~/ui/components/websockets/realtime-response-pane';
 import { INSOMNIA_TAB_HEIGHT } from '~/ui/constant';
 import { useReadyState } from '~/ui/hooks/use-ready-state';
-import { useRequestMetaPatcher } from '~/ui/hooks/use-request';
+import { useRequestMetaPatcher, useRequestPatcher } from '~/ui/hooks/use-request';
 
 const emptyServerData: McpServerData = {
   serverCapabilities: getDefaultServerCapabilities(),
@@ -79,9 +79,11 @@ export const McpPane = () => {
   const [collapsedPrimitives, setCollapsedPrimitives] = useState<McpServerPrimitiveTypes[]>([]);
   const [selectedPrimitiveItem, setSelectedPrimitiveItem] = useState<PrimitiveSubItem | null>(null);
   const [primitiveNextCursor, setPrimitiveNextCursor] = useState<Partial<Record<McpServerPrimitiveTypes, string>>>({});
-  const [subscribeResources, setSubscribeResources] = useState<string[]>([]);
   const requestMetaPatcher = useRequestMetaPatcher();
   const [requestPaneActiveTab, setRequestPaneActiveTab] = useState<RequestPaneTabs>('params');
+  const patchRootsRequest = useRequestPatcher();
+
+  const subscribeResources = activeRequest.subscribeResources;
 
   const visibleCollection = useMemo(() => {
     const collection: (PrimitiveTypeItem | PrimitiveSubItem)[] = [];
@@ -214,14 +216,14 @@ export const McpPane = () => {
     if (isSubscribed) {
       try {
         await window.main.mcp.primitive.unsubscribeResource({ uri: item.uri, requestId: requestId });
-        setSubscribeResources(prev => prev.filter(name => name !== item.name));
+        patchRootsRequest(requestId, { subscribeResources: subscribeResources.filter(r => r !== item.name) });
       } catch (error) {
         console.error(`Failed to unsubscribe resource ${item.name}: ${error}`);
       }
     } else {
       try {
         await window.main.mcp.primitive.subscribeResource({ uri: item.uri, requestId: requestId });
-        setSubscribeResources(prev => [...prev, item.name]);
+        patchRootsRequest(requestId, { subscribeResources: [...subscribeResources, item.name] });
       } catch (error) {
         console.error(`Failed to subscribe resource ${item.name}: ${error}`);
       }
@@ -361,11 +363,11 @@ export const McpPane = () => {
   }, [activeResponse?._id]);
 
   useEffect(() => {
-    if (!readyState) {
+    if (!readyState && subscribeResources.length > 0) {
       // clear subscriptions when connection is closed
-      setSubscribeResources([]);
+      patchRootsRequest(requestId, { subscribeResources: [] });
     }
-  }, [readyState]);
+  }, [patchRootsRequest, readyState, requestId, subscribeResources]);
 
   return (
     <PanelGroup
@@ -496,7 +498,7 @@ export const McpPane = () => {
                       onRefreshPrimitive={updatePrimitiveData}
                       onLoadMorePrimitive={loadMorePrimitiveData}
                       allowSubscribeResources={allowSubscribeResources}
-                      subscribeResources={subscribeResources}
+                      subscribeResources={subscribeResources || []}
                       handleSubscribe={handleSubscribe}
                       style={{
                         height: `${virtualItem.size}px`,

--- a/packages/insomnia/src/ui/components/mcp/mcp-pane.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-pane.tsx
@@ -82,6 +82,13 @@ export const McpPane = () => {
   const requestMetaPatcher = useRequestMetaPatcher();
   const [requestPaneActiveTab, setRequestPaneActiveTab] = useState<RequestPaneTabs>('params');
   const patchRootsRequest = useRequestPatcher();
+  const requestId = activeRequest._id;
+  const { activeEnvironment } = useWorkspaceLoaderData()!;
+  const readyState = useReadyState({ requestId, protocol: 'mcp' });
+  const parentRef = useRef<HTMLDivElement>(null);
+  const [direction, setDirection] = useState<'horizontal' | 'vertical'>(
+    settings.forceVerticalLayout ? 'vertical' : 'horizontal',
+  );
 
   const subscribeResources = activeRequest.subscribeResources;
 
@@ -177,6 +184,9 @@ export const McpPane = () => {
     }
     return serverCapabilities;
   };
+  const serverCapabilities = getServerCapabilities();
+  const allowSubscribeResources =
+    readyState && serverCapabilities.resources.enabled && serverCapabilities.resources.subscribe;
 
   const updatePrimitiveNextCursor = (newNextCursor: string, type: McpServerPrimitiveTypes) => {
     setPrimitiveNextCursor(prev => ({
@@ -230,20 +240,12 @@ export const McpPane = () => {
     }
   };
 
-  const serverCapabilities = getServerCapabilities();
-  const allowSubscribeResources = serverCapabilities.resources.enabled && serverCapabilities.resources.subscribe;
-
   useEffect(() => {
     const [, type, name] = activeRequestMeta?.activeMcpPrimitive?.match(/^([^_]+)_(.+)$/) || [];
     const primitiveItem = visibleCollection.find(i => i.itemLevel === 1 && i.type === type && i.name === name);
     primitiveItem && setSelectedPrimitiveItem(primitiveItem as PrimitiveSubItem);
   }, [activeRequest._id, activeRequestMeta?.activeMcpPrimitive, visibleCollection]);
 
-  const requestId = activeRequest._id;
-  const { activeEnvironment } = useWorkspaceLoaderData()!;
-  const readyState = useReadyState({ requestId, protocol: 'mcp' });
-
-  const parentRef = useRef<HTMLDivElement>(null);
   const virtualizer = useVirtualizer<HTMLDivElement, Element>({
     getScrollElement: () => parentRef.current,
     count: visibleCollection.length,
@@ -275,10 +277,6 @@ export const McpPane = () => {
     const unsubscribe = window.main.on('toggle-sidebar', toggleSidebar);
     return unsubscribe;
   }, []);
-
-  const [direction, setDirection] = useState<'horizontal' | 'vertical'>(
-    settings.forceVerticalLayout ? 'vertical' : 'horizontal',
-  );
 
   useEffect(() => {
     if (settings.forceVerticalLayout) {

--- a/packages/insomnia/src/ui/components/mcp/mcp-pane.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-pane.tsx
@@ -362,13 +362,6 @@ export const McpPane = () => {
     }
   }, [activeResponse?._id]);
 
-  useEffect(() => {
-    if (!readyState && subscribeResources.length > 0) {
-      // clear subscriptions when connection is closed
-      patchRootsRequest(requestId, { subscribeResources: [] });
-    }
-  }, [patchRootsRequest, readyState, requestId, subscribeResources]);
-
   return (
     <PanelGroup
       ref={sidebarPanelRef}

--- a/packages/insomnia/src/ui/components/mcp/mcp-pane.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-pane.tsx
@@ -57,6 +57,11 @@ import { INSOMNIA_TAB_HEIGHT } from '~/ui/constant';
 import { useReadyState } from '~/ui/hooks/use-ready-state';
 import { useRequestMetaPatcher } from '~/ui/hooks/use-request';
 
+const emptyServerData: McpServerData = {
+  serverCapabilities: getDefaultServerCapabilities(),
+  primitives: { tools: [], resources: [], resourceTemplates: [], prompts: [] },
+};
+
 export const McpPane = () => {
   const { organizationId, projectId, workspaceId } = useParams() as {
     organizationId: string;
@@ -70,10 +75,7 @@ export const McpPane = () => {
   const [allExpanded, setAllExpanded] = useState(true);
   const [filter, setFilter] = useLocalStorage<string>(`${workspaceId}:mcp-list-filter`);
   const { settings } = useRootLoaderData()!;
-  const [mcpServerData, setMcpServerData] = useState<McpServerData>({
-    serverCapabilities: getDefaultServerCapabilities(),
-    primitives: { tools: [], resources: [], resourceTemplates: [], prompts: [] },
-  });
+  const [mcpServerData, setMcpServerData] = useState<McpServerData>(emptyServerData);
   const [collapsedPrimitives, setCollapsedPrimitives] = useState<McpServerPrimitiveTypes[]>([]);
   const [selectedPrimitiveItem, setSelectedPrimitiveItem] = useState<PrimitiveSubItem | null>(null);
   const [primitiveNextCursor, setPrimitiveNextCursor] = useState<Partial<Record<McpServerPrimitiveTypes, string>>>({});
@@ -349,11 +351,14 @@ export const McpPane = () => {
         setMcpServerData(mcpServerData);
       }
     };
-    if (readyState) {
-      // Get MCP server data when connection is ready
+    if (activeResponse?._id) {
+      // Get MCP server data when active response changes
       updateServerData();
+    } else {
+      // Clear MCP server data when no active response
+      setMcpServerData(emptyServerData);
     }
-  }, [readyState, activeResponse?._id]);
+  }, [activeResponse?._id]);
 
   useEffect(() => {
     if (!readyState) {


### PR DESCRIPTION
**Changes:**
- Retrieve server data whenever the active response ID changes to ensure the capability list updates correctly when switching between tabs.
- Persist resource subscription data in MCP requests to prevent the loss of subscription data when navigating across tabs.
