### PR TITLE
feat: Improve global modals

### DIFF
--- a/packages/insomnia-smoke-test/tests/critical/bundling.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/bundling.test.ts
@@ -6,7 +6,8 @@ import { test } from '../../playwright/test';
 test('can use bundled plugins, node-libcurl, httpsnippet, hidden browser window', async ({ app, page }) => {
   await page.getByTestId('settings-button').click();
   await page.getByRole('tab', { name: 'Cloud Credentials' }).click();
-  await page.getByRole('button', { name: 'Create Credential' }).click();
+  // Check that bundled plugins are available in the Cloud Credentials tab
+  await expect.soft(page.getByRole('button', { name: 'Create Credential' })).toBeVisible();
   await page.locator('.app').press('Escape');
 
   const statusTag = page.locator('[data-testid="response-status-tag"]:visible');

--- a/packages/insomnia-smoke-test/tests/critical/bundling.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/bundling.test.ts
@@ -7,7 +7,7 @@ test('can use bundled plugins, node-libcurl, httpsnippet, hidden browser window'
   await page.getByTestId('settings-button').click();
   await page.getByRole('tab', { name: 'Cloud Credentials' }).click();
   await page.getByRole('button', { name: 'Create Credential' }).click();
-  await page.locator('body').press('Escape');
+  await page.locator('.app').press('Escape');
 
   const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
   const responseBody = page.locator('[data-testid="CodeEditor"]:visible', {

--- a/packages/insomnia-smoke-test/tests/smoke/invite.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/invite.test.ts
@@ -19,7 +19,7 @@ test('Can invite users in app', async ({ page }) => {
     await organizationMembersSelector.getByRole('option').nth(i).click();
   }
 
-  await page.locator('body').press('Escape');
+  await page.locator('.app').press('Escape');
   await page.getByRole('dialog').getByRole('button', { name: 'Invite' }).click();
 
   const invitationListLocator = page.getByLabel('Invitation list');

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -507,8 +507,8 @@ test.describe('pre-request features tests', () => {
       },
     });
     // close modal and go back
-    await page.locator('body').press('Escape');
-    await page.locator('body').press('Escape');
+    await page.locator('.app').press('Escape');
+    await page.locator('.app').press('Escape');
     await page.getByTestId('project').click();
     // import global environment
     const globalEnvText = await loadFixture('script-global-environment.yaml');

--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -849,15 +849,7 @@ export const CodeEditor = memo(
                   </MenuTrigger>
                 )}
 
-                {showFilter ? (
-                  <Button
-                    key="help"
-                    className="flex h-full items-center justify-center gap-2 px-4 py-1 text-xs text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
-                    onPress={() => showModal(FilterHelpModal, { isJSON: Boolean(mode?.includes('json')) })}
-                  >
-                    <i className="fa fa-question-circle" />
-                  </Button>
-                ) : null}
+                {showFilter ? <FilterHelpModal isJSON={Boolean(mode?.includes('json'))} /> : null}
                 {showPrettify ? (
                   <Button
                     key="prettify"

--- a/packages/insomnia/src/ui/components/base/modal.tsx
+++ b/packages/insomnia/src/ui/components/base/modal.tsx
@@ -8,12 +8,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { FocusScope } from 'react-aria';
-
-import { createKeybindingsHandler } from '../keydown-binder';
-// Keep global z-index reference so that every modal will
-// appear over top of an existing one.
-let globalZIndex = 1000;
+import { Dialog, Modal as RACModal } from 'react-aria-components';
 
 export interface ModalProps {
   centered?: boolean;
@@ -52,14 +47,12 @@ export const Modal = forwardRef<ModalHandle, ModalProps>(
   ) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const [open, setOpen] = useState(false);
-    const [zIndex, setZIndex] = useState(globalZIndex);
     const [onHideArgument, setOnHideArgument] = useState<() => void>();
 
     const show: ModalHandle['show'] = useCallback(
       options => {
         options?.onHide && setOnHideArgument(options.onHide);
         setOpen(true);
-        setZIndex(globalZIndex++);
         onShow?.();
       },
       [onShow],
@@ -93,6 +86,7 @@ export const Modal = forwardRef<ModalHandle, ModalProps>(
       { 'modal--fixed-height': tall },
       { 'modal--wide': wide },
       { 'modal--skinny': skinny },
+      'z-10',
     );
 
     useEffect(() => {
@@ -109,34 +103,16 @@ export const Modal = forwardRef<ModalHandle, ModalProps>(
       };
     }, [hide, open, maskClosable, keyboardClosable]);
 
-    const handleKeydown = createKeybindingsHandler({
-      Escape: () => {
-        if (!keyboardClosable) {
-          return;
-        }
-        hide();
-      },
-    });
-
-    useEffect(() => {
-      document.body.addEventListener('keydown', handleKeydown);
-
-      return () => {
-        document.body.removeEventListener('keydown', handleKeydown);
-      };
-    }, [handleKeydown]);
-
     return open ? (
-      <FocusScope autoFocus>
-        <div
-          ref={containerRef}
-          onKeyDown={handleKeydown}
-          tabIndex={-1}
-          className={classes}
-          style={{ zIndex }}
-          aria-hidden={false}
-          role="dialog"
-        >
+      <RACModal
+        ref={containerRef}
+        isOpen={open}
+        isDismissable={keyboardClosable}
+        onOpenChange={isOpen => {
+          !isOpen && hide();
+        }}
+      >
+        <Dialog aria-label="Some dialog fix me" className={classes}>
           <div
             className="modal__backdrop overlay theme--transparent-overlay"
             {...(maskClosable ? { 'data-close-modal': true } : {})}
@@ -144,8 +120,8 @@ export const Modal = forwardRef<ModalHandle, ModalProps>(
           <div className={classnames('modal__content__wrapper', { 'modal--centered': centered })}>
             <div className="modal__content">{children}</div>
           </div>
-        </div>
-      </FocusScope>
+        </Dialog>
+      </RACModal>
     ) : null;
   },
 );

--- a/packages/insomnia/src/ui/components/base/modal.tsx
+++ b/packages/insomnia/src/ui/components/base/modal.tsx
@@ -112,7 +112,7 @@ export const Modal = forwardRef<ModalHandle, ModalProps>(
           !isOpen && hide();
         }}
       >
-        <Dialog aria-label="Some dialog fix me" className={classes}>
+        <Dialog aria-label="Modal" className={classes}>
           <div
             className="modal__backdrop overlay theme--transparent-overlay"
             {...(maskClosable ? { 'data-close-modal': true } : {})}

--- a/packages/insomnia/src/ui/components/modals/filter-help-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/filter-help-modal.tsx
@@ -1,9 +1,9 @@
-import React, { type FC, forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import React, { type FC } from 'react';
+import { Button, Dialog, DialogTrigger, Heading, Modal, ModalOverlay } from 'react-aria-components';
+
+import { Icon } from '~/ui/components/icon';
 
 import { Link } from '../base/link';
-import { Modal, type ModalHandle, type ModalProps } from '../base/modal';
-import { ModalBody } from '../base/modal-body';
-import { ModalHeader } from '../base/modal-header';
 
 interface HelpExample {
   code: string;
@@ -26,7 +26,7 @@ const HelpExamples: FC<{ helpExamples: HelpExample[] }> = ({ helpExamples }) => 
 );
 
 const JSONPathHelp: FC = () => (
-  <ModalBody className="pad">
+  <div>
     <p>
       Use <Link href="http://goessner.net/articles/JsonPath/">JSONPath</Link> to filter the response body. Here are some
       examples that you might use on a book store API:
@@ -47,11 +47,11 @@ const JSONPathHelp: FC = () => (
       Note that there's <Link href="https://cburgmer.github.io/json-path-comparison/">no standard</Link> for JSONPath.
       Insomnia uses <Link href="https://www.npmjs.com/package/jsonpath-plus">jsonpath-plus</Link>.
     </p>
-  </ModalBody>
+  </div>
 );
 
 const XPathHelp: FC = () => (
-  <ModalBody className="pad">
+  <div>
     <p>
       Use <Link href="https://www.w3.org/TR/xpath/">XPath</Link> to filter the response body. Here are some examples
       that you might use on a book store API:
@@ -64,44 +64,54 @@ const XPathHelp: FC = () => (
         { code: 'count(/store/books)', description: 'Get the number of books in the store' },
       ]}
     />
-  </ModalBody>
+  </div>
 );
 interface FilterHelpModalOptions {
   isJSON: boolean;
 }
-export interface FilterHelpModalHandle {
-  show: (options: FilterHelpModalOptions) => void;
-  hide: () => void;
-}
 
-export const FilterHelpModal = forwardRef<FilterHelpModalHandle, ModalProps>((_, ref) => {
-  const modalRef = useRef<ModalHandle>(null);
-  const [state, setState] = useState<FilterHelpModalOptions>({
-    isJSON: true,
-  });
-
-  useImperativeHandle(
-    ref,
-    () => ({
-      hide: () => {
-        modalRef.current?.hide();
-      },
-      show: options => {
-        const { isJSON } = options;
-        setState({ isJSON });
-        modalRef.current?.show();
-      },
-    }),
-    [],
-  );
-  const { isJSON } = state;
-  const isXPath = !isJSON;
+export const FilterHelpModal: FC<FilterHelpModalOptions> = ({ isJSON }) => {
   return (
-    <Modal ref={modalRef}>
-      <ModalHeader>Response Filtering Help</ModalHeader>
-      {isJSON ? <JSONPathHelp /> : null}
-      {isXPath ? <XPathHelp /> : null}
-    </Modal>
+    <>
+      <DialogTrigger>
+        <Button
+          key="help"
+          className="flex h-full items-center justify-center gap-2 px-4 py-1 text-xs text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+        >
+          <i className="fa fa-question-circle" />
+        </Button>
+        <ModalOverlay
+          isDismissable
+          className="fixed left-0 top-0 z-10 flex h-[--visual-viewport-height] w-full items-center justify-center bg-black/30"
+        >
+          <Modal className="flex h-[calc(100%-var(--padding-xl))] w-[calc(100%-var(--padding-xl))] flex-col rounded-md border border-solid border-[--hl-sm] bg-[--color-bg] p-[--padding-lg] text-[--color-font]">
+            <Dialog className="flex h-full flex-1 flex-col overflow-hidden outline-none data-[loading]:animate-pulse">
+              {({ close }) => (
+                <div className="flex flex-1 flex-col gap-4 overflow-hidden">
+                  <div className="flex flex-shrink-0 items-center justify-between gap-2">
+                    <Heading slot="title" className="flex items-center gap-2 text-2xl">
+                      Response Filtering Help
+                    </Heading>
+
+                    <Button
+                      className="flex aspect-square h-6 flex-shrink-0 items-center justify-center rounded-sm text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+                      onPress={close}
+                    >
+                      <Icon icon="x" />
+                    </Button>
+                  </div>
+
+                  <div className="h-full gap-2 divide-x divide-solid divide-[--hl-md] overflow-hidden [grid-template-columns:300px_1fr]">
+                    <div className="flex flex-1 flex-col gap-4 overflow-hidden">
+                      {isJSON ? <JSONPathHelp /> : <XPathHelp />}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </Dialog>
+          </Modal>
+        </ModalOverlay>
+      </DialogTrigger>
+    </>
   );
-});
-FilterHelpModal.displayName = 'FilterHelpModal';
+};

--- a/packages/insomnia/src/ui/components/modals/input-vault-key-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/input-vault-key-modal.tsx
@@ -78,9 +78,6 @@ export const InputVaultKeyModal = (props: InputVaultKeyModalProps) => {
     >
       <Modal
         className="m-24 flex max-h-[75%] w-full max-w-3xl flex-col overflow-auto rounded-md border border-solid border-[--hl-sm] bg-[--color-bg] p-[--padding-lg] text-[--color-font]"
-        onOpenChange={isOpen => {
-          !isOpen && onClose();
-        }}
         data-testid="input-vault-key-modal"
       >
         <Dialog className="flex h-full flex-1 flex-col overflow-hidden outline-none">

--- a/packages/insomnia/src/ui/modals.tsx
+++ b/packages/insomnia/src/ui/modals.tsx
@@ -7,7 +7,6 @@ import { AlertModal } from './components/modals/alert-modal';
 import { AskModal } from './components/modals/ask-modal';
 import { CodePromptModal } from './components/modals/code-prompt-modal';
 import { ErrorModal } from './components/modals/error-modal';
-import { FilterHelpModal } from './components/modals/filter-help-modal';
 import { GenerateCodeModal } from './components/modals/generate-code-modal';
 import { NunjucksModal } from './components/modals/nunjucks-modal';
 import { PromptModal } from './components/modals/prompt-modal';
@@ -32,7 +31,6 @@ const Modals = () => {
         <WrapperModal ref={instance => registerModal(instance, 'WrapperModal')} />
         <AskModal ref={instance => registerModal(instance, 'AskModal')} />
         <SelectModal ref={instance => registerModal(instance, 'SelectModal')} />
-        <FilterHelpModal ref={instance => registerModal(instance, 'FilterHelpModal')} />
         <RequestRenderErrorModal ref={instance => registerModal(instance, 'RequestRenderErrorModal')} />
 
         <CodePromptModal ref={instance => registerModal(instance, 'CodePromptModal')} />


### PR DESCRIPTION
# Overview

Currently global modals in `modals.tsx` are using a unique mechanism to render modals in the app.
This PR adds the react-aria modal to those so that they behave similarly to all other modals in the app.

Next steps:
- [ ] There is a lot of complexity in sub-components like ModalHeader/Footer etc. This logic can be simplified or even removed for now since it introduces unnecessary complexity.
- [ ] Some of the modals in `modals.tsx` are only used by one component in the app and could be inlined instead
- [ ] Truly global modals like `AlertModal` could have a much simpler API (e.g. something similar to showToast(...)) instead of the current implementation.