### PR TITLE
remove libcurl from vite bundle

### DIFF
--- a/packages/insomnia/vite.config.ts
+++ b/packages/insomnia/vite.config.ts
@@ -13,7 +13,6 @@ export const externalDependencies = [
   '@bufbuild/protobuf',
   '@connectrpc/connect',
   '@connectrpc/connect-node',
-  '@getinsomnia/node-libcurl',
   '@grpc/grpc-js',
   '@grpc/proto-loader',
   '@seald-io/nedb',
@@ -91,12 +90,8 @@ export default defineConfig(({ mode }) => {
     build: {
       target: 'esnext',
       sourcemap: true,
-      rollupOptions: {
-        external: ['@getinsomnia/node-libcurl'],
-      },
     },
     optimizeDeps: {
-      exclude: ['@getinsomnia/node-libcurl'],
       force: true, // wipe vite cache
       include: ['codemirror-graphql/utils/SchemaReference', '@stoplight/spectral-core', 'isomorphic-git'],
     },


### PR DESCRIPTION
libcurl is knotted up in the import tree of the renderer which forces vite to care about it. For now...
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
