### PR TITLE
fix: show statusbar top border when sidebar is toggled

### DIFF
--- a/packages/insomnia/src/routes/organization.tsx
+++ b/packages/insomnia/src/routes/organization.tsx
@@ -415,7 +415,7 @@ const Component = ({ loaderData }: Route.ComponentProps) => {
                 <Outlet />
               </RunnerProvider>
             </div>
-            <div className="relative flex items-center overflow-hidden [grid-area:Statusbar]">
+            <div className="relative flex items-center overflow-hidden border-solid border-t border-[--hl-md] [grid-area:Statusbar]">
               <div className="flex h-full w-[50px] flex-shrink-0 items-center justify-center gap-2 border-r border-solid border-r-[--hl-md]">
                 <TooltipTrigger>
                   <ToggleButton


### PR DESCRIPTION
Resolves https://github.com/Kong/insomnia/issues/9118


## Description
Fixes the statusbar top border visibility issue when toggling the organization sidebar.

**Problem**: When the organization sidebar is toggled, the statusbar's top border color disappears due to CSS Grid layout changes affecting the `divide-x` utility behavior.

**Solution**: Added conditional `border-t` styling to the statusbar 

## Changes Made
- Modified `packages/insomnia/src/routes/organization.tsx` to conditionally apply `border-solid border-t border-[--hl-md]` classes to the statusbar
- Used existing `isOrganizationSidebarOpen` state to control border visibility

## Testing
- ✅ Linting passes
- ✅ TypeScript compilation passes
- ✅ Manual testing shows border appears/disappears correctly when toggling sidebar

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Screenshots/GIFs

https://github.com/user-attachments/assets/a11f8713-78d5-46bb-b502-5ebd3a4191d5


-->
