### PR TITLE
feat: additional mock server event tracking

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
@@ -251,6 +251,7 @@ async function continueMockServerCreation(
   })}/mock-server`;
 
   let mockRouteGenerationError: string | undefined;
+  const generationStartTime = Date.now();
 
   if (workspaceData.mockServerCreationType === 'ai') {
     let openapiSpec: string | undefined;
@@ -287,6 +288,8 @@ async function continueMockServerCreation(
 
   await database.flushChanges(flushId);
 
+  const generationDurationMs = Date.now() - generationStartTime;
+
   showMockServerToast(mockRouteGenerationError, mockServer.name, mockServerUrl);
 
   const { id } = await models.userSession.getOrCreate();
@@ -304,6 +307,7 @@ async function continueMockServerCreation(
       generation: workspaceData.mockServerCreationType || '',
       generation_from: workspaceData.apiSpecContents ? 'design_doc' : workspaceData.mockServerSpecSource || '',
       dynamic_responses: workspaceData.mockServerDynamicResponses ? 'yes' : 'no',
+      generation_duration_seconds: generationDurationMs / 1000,
     },
   });
 }

--- a/packages/insomnia/src/ui/analytics.ts
+++ b/packages/insomnia/src/ui/analytics.ts
@@ -9,6 +9,7 @@ export enum SegmentEvent {
   importScanned = 'Import Scanned',
   importCompleted = 'Import Completed',
   documentCreate = 'Document Created',
+  mockCreateModalOpened = 'Mock Server Create Modal Opened',
   mockCreate = 'Mock Created',
   mockEdit = 'Mock Server Edited',
   mockDelete = 'Mock Server Deleted',

--- a/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
@@ -28,6 +28,7 @@ import { type ApiSpec } from '../../../models/api-spec';
 import { isGitProject, type Project } from '../../../models/project';
 import { type WorkspaceScope, WorkspaceScopeKeys } from '../../../models/workspace';
 import { safeToUseInsomniaFileName, safeToUseInsomniaFileNameWithExt } from '../../../sync/git/insomnia-filename';
+import { SegmentEvent } from '../../analytics';
 import { Icon } from '../icon';
 
 const titleByScope: Record<WorkspaceScope, string> = {
@@ -118,6 +119,14 @@ export const NewWorkspaceModal = ({
       gitRepoTreeFetcher.load({ projectId: project._id });
     }
   }, [gitRepoTreeFetcher, isOpen, project]);
+
+  useEffect(() => {
+    if (isOpen && scope === WorkspaceScopeKeys.mockServer) {
+      window.main.trackSegmentEvent({
+        event: SegmentEvent.mockCreateModalOpened,
+      });
+    }
+  }, [isOpen, scope]);
 
   const createNewWorkspace = () => {
     createNewWorkspaceFetcher.submit({


### PR DESCRIPTION
Some additional event tracking for mock server created:
- Add an event to track when the create mock server modal is opened
- Add a property to the existing event for mock creation to include the duration of the creation process