### PR TITLE
fix: ensure data dir exists prior to reading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30558,7 +30558,6 @@
         "@getinsomnia/srp-js": "1.0.0-alpha.1",
         "@grpc/grpc-js": "^1.13.3",
         "@grpc/proto-loader": "^0.7.13",
-        "@kong/insomnia-plugin-ai": "^1.0.3",
         "@mismerge/core": "^1.2.1",
         "@react-router/dev": "^7.7.0",
         "@react-router/fs-routes": "^7.7.0",

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -149,6 +149,7 @@ const main: Window['main'] = {
   writeFile: options => ipcRenderer.invoke('writeFile', options),
   readFile: options => ipcRenderer.invoke('readFile', options),
   readDir: options => ipcRenderer.invoke('readDir', options),
+  readDataDir: options => ipcRenderer.invoke('readDataDir', options),
   lintSpec: options => ipcRenderer.invoke('lintSpec', options),
   on: (channel, listener) => {
     ipcRenderer.on(channel, listener);

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -149,7 +149,7 @@ const main: Window['main'] = {
   writeFile: options => ipcRenderer.invoke('writeFile', options),
   readFile: options => ipcRenderer.invoke('readFile', options),
   readDir: options => ipcRenderer.invoke('readDir', options),
-  readDataDir: options => ipcRenderer.invoke('readDataDir', options),
+  readOrCreateDataDir: options => ipcRenderer.invoke('readOrCreateDataDir', options),
   lintSpec: options => ipcRenderer.invoke('lintSpec', options),
   on: (channel, listener) => {
     ipcRenderer.on(channel, listener);

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -87,7 +87,7 @@ export type HandleChannels =
   | 'open-channel-to-hidden-browser-window'
   | 'openPath'
   | 'readCurlResponse'
-  | 'readDataDir'
+  | 'readOrCreateDataDir'
   | 'readDir'
   | 'readFile'
   | 'restoreBackup'

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -87,6 +87,7 @@ export type HandleChannels =
   | 'open-channel-to-hidden-browser-window'
   | 'openPath'
   | 'readCurlResponse'
+  | 'readDataDir'
   | 'readDir'
   | 'readFile'
   | 'restoreBackup'

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -96,7 +96,9 @@ export interface RendererToMainBridgeAPI {
   writeFile: (options: { path: string; content: string }) => Promise<string>;
   readFile: (options: { path: string; encoding?: string }) => Promise<{ content: string; encoding: string }>;
   readDir: (options: { path: string }) => Promise<{ type: 'file' | 'directory'; name: string; path: string }[]>;
-  readDataDir: (options: { folder: string }) => Promise<{ type: 'file' | 'directory'; name: string; path: string }[]>;
+  readOrCreateDataDir: (options: {
+    folder: string;
+  }) => Promise<{ type: 'file' | 'directory'; name: string; path: string }[]>;
   cancelCurlRequest: typeof cancelCurlRequest;
   curlRequest: typeof curlRequest;
   on: (channel: RendererOnChannels, listener: (event: IpcRendererEvent, ...args: any[]) => void) => () => void;
@@ -272,7 +274,7 @@ export function registerMainHandlers() {
 
   ipcMainHandle('readDir', readDir);
 
-  ipcMainHandle('readDataDir', async (_, options: { folder: string }) => {
+  ipcMainHandle('readOrCreateDataDir', async (_, options: { folder: string }) => {
     const dataPath = app.getPath('userData');
     const folderPath = path.join(dataPath, options.folder);
     mkdirSync(folderPath, { recursive: true });

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import fs, { mkdirSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -60,6 +60,24 @@ export const openInBrowser = (href: string) => {
   }
 };
 
+const readDir = async (_: unknown, options: { path: string }) => {
+  try {
+    const files = await fs.promises.readdir(options.path);
+    return files
+      .map(file => {
+        const filePath = path.join(options.path, file);
+        return {
+          type: fs.statSync(filePath).isDirectory() ? 'directory' : fs.statSync(filePath).isFile() ? 'file' : 'other',
+          name: file,
+          path: filePath,
+        };
+      })
+      .filter(file => file.type !== 'other');
+  } catch (err) {
+    throw new Error(`Failed to read directory: ${err}`);
+  }
+};
+
 export interface RendererToMainBridgeAPI {
   loginStateChange: () => void;
   openInBrowser: (url: string) => void;
@@ -78,6 +96,7 @@ export interface RendererToMainBridgeAPI {
   writeFile: (options: { path: string; content: string }) => Promise<string>;
   readFile: (options: { path: string; encoding?: string }) => Promise<{ content: string; encoding: string }>;
   readDir: (options: { path: string }) => Promise<{ type: 'file' | 'directory'; name: string; path: string }[]>;
+  readDataDir: (options: { folder: string }) => Promise<{ type: 'file' | 'directory'; name: string; path: string }[]>;
   cancelCurlRequest: typeof cancelCurlRequest;
   curlRequest: typeof curlRequest;
   on: (channel: RendererOnChannels, listener: (event: IpcRendererEvent, ...args: any[]) => void) => () => void;
@@ -251,22 +270,13 @@ export function registerMainHandlers() {
     };
   });
 
-  ipcMainHandle('readDir', async (_, options: { path: string }) => {
-    try {
-      const files = await fs.promises.readdir(options.path);
-      return files
-        .map(file => {
-          const filePath = path.join(options.path, file);
-          return {
-            type: fs.statSync(filePath).isDirectory() ? 'directory' : fs.statSync(filePath).isFile() ? 'file' : 'other',
-            name: file,
-            path: filePath,
-          };
-        })
-        .filter(file => file.type !== 'other');
-    } catch (err) {
-      throw new Error(`Failed to read directory: ${err}`);
-    }
+  ipcMainHandle('readDir', readDir);
+
+  ipcMainHandle('readDataDir', async (_, options: { folder: string }) => {
+    const dataPath = app.getPath('userData');
+    const folderPath = path.join(dataPath, options.folder);
+    mkdirSync(folderPath, { recursive: true });
+    return readDir(_, { path: folderPath });
   });
 
   ipcMainHandle('curlRequest', (_, options: Parameters<typeof curlRequest>[0]) => {

--- a/packages/insomnia/src/ui/components/settings/llms/gguf.tsx
+++ b/packages/insomnia/src/ui/components/settings/llms/gguf.tsx
@@ -23,6 +23,8 @@ const DEFAULT_MODEL_PARAMETERS = {
   repeatPenalty: 1.1,
 };
 
+const LLMS_FOLDER_NAME = 'llms';
+
 export const GGUF = ({
   saveLLMSettings,
   configuredLLMs,
@@ -40,18 +42,23 @@ export const GGUF = ({
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
 
   const userDataPath = resolve(window.app.getPath('userData'));
-  const llmsFolder = resolve(userDataPath, 'llms');
+  const llmsFolder = resolve(userDataPath, LLMS_FOLDER_NAME);
   const [availableLLMs, setAvailableLLMs] = useState<string[]>([]);
   const [selectedModel, setSelectedModel] = useState<string>('');
   const refreshModelsDirectory = useCallback(() => {
-    window.main.readDir({ path: llmsFolder }).then(models => {
-      const currentlyAvailableLLMs = models
-        .filter(model => model.type === 'file' && model.name.toLowerCase().endsWith('.gguf'))
-        .map(model => model.name);
+    window.main
+      .readDataDir({ folder: LLMS_FOLDER_NAME })
+      .then(models => {
+        const currentlyAvailableLLMs = models
+          .filter(model => model.type === 'file' && model.name.toLowerCase().endsWith('.gguf'))
+          .map(model => model.name);
 
-      setAvailableLLMs(currentlyAvailableLLMs);
-    });
-  }, [llmsFolder]);
+        setAvailableLLMs(currentlyAvailableLLMs);
+      })
+      .catch(() => {
+        setAvailableLLMs([]);
+      });
+  }, []);
 
   useEffect(() => {
     if (configuredLLMs.length === 1) {

--- a/packages/insomnia/src/ui/components/settings/llms/gguf.tsx
+++ b/packages/insomnia/src/ui/components/settings/llms/gguf.tsx
@@ -47,7 +47,7 @@ export const GGUF = ({
   const [selectedModel, setSelectedModel] = useState<string>('');
   const refreshModelsDirectory = useCallback(() => {
     window.main
-      .readDataDir({ folder: LLMS_FOLDER_NAME })
+      .readOrCreateDataDir({ folder: LLMS_FOLDER_NAME })
       .then(models => {
         const currentlyAvailableLLMs = models
           .filter(model => model.type === 'file' && model.name.toLowerCase().endsWith('.gguf'))


### PR DESCRIPTION
Adds a new IPC handler to read a folder within the Insomnia data directory, and catches errors thrown to produce an empty list when enumerating `.gguf` files
