### PR TITLE
feat: mock server gen ux improvements

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
@@ -16,7 +16,6 @@ import { safeToUseInsomniaFileNameWithExt } from '~/sync/git/insomnia-filename';
 import { initializeLocalBackendProjectAndMarkForSync } from '~/sync/vcs/initialize-backend-project';
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { SegmentEvent } from '~/ui/analytics';
-import { showError } from '~/ui/components/modals';
 import { showToast } from '~/ui/components/toast-notification';
 import { insomniaFetch } from '~/ui/insomniaFetch';
 import { invariant } from '~/utils/invariant';
@@ -108,21 +107,12 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
     }
 
     if (scope === 'mock-server') {
-      showToast(
-        {
-          icon: 'magic',
-          title: 'Creating mock server...',
-          description: `Creating "${name}" - we'll notify you when it's ready!`,
-          status: 'info',
-        },
-        { timeout: 5000 },
-      );
+      const mockServerError = await createMockServer(workspace, workspaceData, flushId, organizationId, projectId, name);
 
-      setTimeout(async () => {
-        await continueMockServerCreation(workspace, workspaceData, flushId, organizationId, projectId, name);
-      }, 100);
+      if (mockServerError) {
+        return { error: mockServerError };
+      }
 
-      // Return success response (modal will close via useEffect)
       return { error: undefined };
     }
 
@@ -220,130 +210,101 @@ export const useWorkspaceNewActionFetcher = createFetcherSubmitHook(
   clientAction,
 );
 
-async function continueMockServerCreation(
+async function createMockServer(
   workspace: any,
   workspaceData: NewWorkspaceData,
   flushId: number,
   organizationId: string,
   projectId: string,
   name: string,
-) {
-  const mockServerType = workspaceData.mockServerType!;
-  const mockServerPatch: Partial<MockServer> = {
-    name,
-  };
+): Promise<string | undefined> {
+  try {
+    const mockServerType = workspaceData.mockServerType!;
+    const mockServerPatch: Partial<MockServer> = {
+      name,
+    };
 
-  if (mockServerType === 'cloud') {
-    mockServerPatch.useInsomniaCloud = true;
-  } else {
-    mockServerPatch.useInsomniaCloud = false;
-    mockServerPatch.url = workspaceData.mockServerUrl!;
-  }
-
-  await models.environment.getOrCreateForParentId(workspace._id);
-  const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(workspace._id);
-  const mockServer = await models.mockServer.getOrCreateForParentId(workspace._id, mockServerPatch);
-
-  const mockServerUrl = `${href('/organization/:organizationId/project/:projectId/workspace/:workspaceId', {
-    organizationId,
-    projectId,
-    workspaceId: workspace._id,
-  })}/mock-server`;
-
-  let mockRouteGenerationError: string | undefined;
-  const generationStartTime = Date.now();
-
-  if (workspaceData.mockServerCreationType === 'ai') {
-    let openapiSpec: string | undefined;
-    let specUrl: string | undefined;
-    let specText: string | undefined;
-
-    if (workspaceData.apiSpecContents) {
-      openapiSpec = workspaceData.apiSpecContents;
-    } else if (workspaceData.mockServerSpecSource === 'file') {
-      openapiSpec = fs.readFileSync(workspaceData.mockServerOASFilePath!, 'utf8');
-    } else if (workspaceData.mockServerSpecSource === 'url') {
-      specUrl = workspaceData.mockServerSpecURL!;
-    } else if (workspaceData.mockServerSpecSource === 'text') {
-      specText = workspaceData.mockServerSpecText!;
+    if (mockServerType === 'cloud') {
+      mockServerPatch.useInsomniaCloud = true;
+    } else {
+      mockServerPatch.useInsomniaCloud = false;
+      mockServerPatch.url = workspaceData.mockServerUrl!;
     }
 
-    const modelConfig = await window.main.llm.getCurrentConfig();
-    const result = await window.main.generateMockRouteDataFromSpec(
-      openapiSpec,
-      specUrl,
-      specText,
-      modelConfig,
-      workspaceData.mockServerDynamicResponses ?? false,
-      workspaceData.mockServerAdditionalFiles || [],
-    );
+    await models.environment.getOrCreateForParentId(workspace._id);
+    const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(workspace._id);
+    const mockServer = await models.mockServer.getOrCreateForParentId(workspace._id, mockServerPatch);
 
-    if (result.error && result.error !== '') {
-      mockRouteGenerationError = result.error;
-    } else {
+    const mockServerUrl = `${href('/organization/:organizationId/project/:projectId/workspace/:workspaceId', {
+      organizationId,
+      projectId,
+      workspaceId: workspace._id,
+    })}/mock-server`;
+
+    const generationStartTime = Date.now();
+
+    if (workspaceData.mockServerCreationType === 'ai') {
+      let openapiSpec: string | undefined;
+      let specUrl: string | undefined;
+      let specText: string | undefined;
+
+      if (workspaceData.apiSpecContents) {
+        openapiSpec = workspaceData.apiSpecContents;
+      } else if (workspaceData.mockServerSpecSource === 'file') {
+        openapiSpec = fs.readFileSync(workspaceData.mockServerOASFilePath!, 'utf8');
+      } else if (workspaceData.mockServerSpecSource === 'url') {
+        specUrl = workspaceData.mockServerSpecURL!;
+      } else if (workspaceData.mockServerSpecSource === 'text') {
+        specText = workspaceData.mockServerSpecText!;
+      }
+
+      const modelConfig = await window.main.llm.getCurrentConfig();
+      const result = await window.main.generateMockRouteDataFromSpec(
+        openapiSpec,
+        specUrl,
+        specText,
+        modelConfig,
+        workspaceData.mockServerDynamicResponses ?? false,
+        workspaceData.mockServerAdditionalFiles || [],
+      );
+
+      if (result.error && result.error !== '') {
+        try {
+          await models.workspace.remove(workspace);
+        } catch (removeError) {
+          console.error('Failed to rollback workspace creation:', removeError);
+        }
+        return result.error;
+      }
+
       const { id: sessionId } = await userSession.getOrCreate();
       await createMockRoutes(result.routes, mockServer, sessionId, organizationId);
     }
-  }
 
-  await database.flushChanges(flushId);
+    await database.flushChanges(flushId);
 
-  const generationDurationMs = Date.now() - generationStartTime;
+    const generationDurationMs = Date.now() - generationStartTime;
 
-  showMockServerToast(mockRouteGenerationError, mockServer.name, mockServerUrl);
+    const { id } = await models.userSession.getOrCreate();
+    if (id && !workspaceMeta.gitRepositoryId) {
+      const vcs = VCSInstance();
+      await initializeLocalBackendProjectAndMarkForSync({
+        vcs,
+        workspace,
+      });
+    }
 
-  const { id } = await models.userSession.getOrCreate();
-  if (id && !workspaceMeta.gitRepositoryId) {
-    const vcs = VCSInstance();
-    await initializeLocalBackendProjectAndMarkForSync({
-      vcs,
-      workspace,
-    });
-  }
-  window.main.trackSegmentEvent({
-    event: SegmentEvent.mockCreate,
-    properties: {
-      hosting: workspaceData.mockServerType || '',
-      generation: workspaceData.mockServerCreationType || '',
-      generation_from: workspaceData.apiSpecContents ? 'design_doc' : workspaceData.mockServerSpecSource || '',
-      dynamic_responses: workspaceData.mockServerDynamicResponses ? 'yes' : 'no',
-      generation_duration_seconds: generationDurationMs / 1000,
-    },
-  });
-}
-
-function showMockServerToast(error: string | undefined, mockServerName: string, mockServerUrl: string) {
-  if (error) {
-    showToast(
-      {
-        icon: 'times-circle',
-        title: 'Mock server creation partially failed',
-        description: (
-          <>
-            <div style={{ marginBottom: '8px' }}>
-              <a href={mockServerUrl} style={{ color: '#0066cc', textDecoration: 'underline', cursor: 'pointer' }}>
-                "{mockServerName}" has been created, but mock server routes could not be fully populated from the spec.
-              </a>
-            </div>
-            <a
-              onClick={(e) => {
-                e.preventDefault();
-                showError({
-                  title: 'Mock Route Generation Error',
-                  message: error,
-                });
-              }}
-              style={{ color: '#0066cc', textDecoration: 'underline', cursor: 'pointer' }}
-            >
-              Click to view full error details.
-            </a>
-          </>
-        ),
-        status: 'error',
+    window.main.trackSegmentEvent({
+      event: SegmentEvent.mockCreate,
+      properties: {
+        hosting: workspaceData.mockServerType || '',
+        generation: workspaceData.mockServerCreationType || '',
+        generation_from: workspaceData.apiSpecContents ? 'design_doc' : workspaceData.mockServerSpecSource || '',
+        dynamic_responses: workspaceData.mockServerDynamicResponses ? 'yes' : 'no',
+        generation_duration_seconds: generationDurationMs / 1000,
       },
-      { timeout: 15000 },
-    );
-  } else {
+    });
+
     showToast(
       {
         icon: 'rocket',
@@ -351,7 +312,7 @@ function showMockServerToast(error: string | undefined, mockServerName: string, 
         description: (
           <>
             <a href={mockServerUrl} style={{ color: '#0066cc', textDecoration: 'underline', cursor: 'pointer' }}>
-              "{mockServerName}" has been created and is ready to use. Click to open.
+              "{mockServer.name}" has been created and is ready to use. Click to open.
             </a>
           </>
         ),
@@ -359,6 +320,15 @@ function showMockServerToast(error: string | undefined, mockServerName: string, 
       },
       { timeout: 10000 },
     );
+
+    return undefined;
+  } catch (error) {
+    try {
+      await models.workspace.remove(workspace);
+    } catch (removeError) {
+      console.error('Failed to rollback workspace creation:', removeError);
+    }
+    return error instanceof Error ? error.message : String(error);
   }
 }
 

--- a/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
@@ -101,7 +101,29 @@ export const NewWorkspaceModal = ({
 
   const createNewWorkspaceFetcher = useWorkspaceNewActionFetcher();
 
+  const [progressMessage, setProgressMessage] = useState(0);
+  const progressMessages = [
+    'Creating...',
+    'Working...',
+    'Building...',
+    'Still going...',
+    'Almost there...',
+  ];
+
   const gitRepoTreeFetcher = useGitProjectRepositoryTreeLoaderFetcher();
+
+  useEffect(() => {
+    if (createNewWorkspaceFetcher.state !== 'idle' && scope === WorkspaceScopeKeys.mockServer) {
+      setProgressMessage(0);
+      const interval = setInterval(() => {
+        setProgressMessage(prev => (prev + 1) % progressMessages.length);
+      }, 5000);
+      return () => clearInterval(interval);
+    } 
+      setProgressMessage(0);
+    
+    return undefined;
+  }, [createNewWorkspaceFetcher.state, scope, progressMessages.length]);
 
   useEffect(() => {
     if (
@@ -147,7 +169,7 @@ export const NewWorkspaceModal = ({
     <ModalOverlay
       isOpen={isOpen}
       onOpenChange={onOpenChange}
-      isDismissable
+      isDismissable={createNewWorkspaceFetcher.state === 'idle' && gitRepoTreeFetcher.state === 'idle'}
       className="fixed left-0 top-0 z-10 flex h-[--visual-viewport-height] w-full items-center justify-center bg-black/30"
     >
       <Modal
@@ -179,6 +201,7 @@ export const NewWorkspaceModal = ({
                     : titleByScope[workspaceData.scope]}
                 </Heading>
                 <Button
+                  isDisabled={createNewWorkspaceFetcher.state !== 'idle' || gitRepoTreeFetcher.state !== 'idle'}
                   className="flex aspect-square h-6 flex-shrink-0 items-center justify-center rounded-sm text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
                   onPress={close}
                 >
@@ -310,7 +333,11 @@ export const NewWorkspaceModal = ({
                       name="mockServerCreationType"
                       defaultValue={workspaceData.mockServerCreationType}
                       onChange={creationType => {
-                        setWorkspaceData({ ...workspaceData, mockServerCreationType: creationType as 'ai' | 'manual' });
+                        setWorkspaceData({
+                          ...workspaceData,
+                          mockServerCreationType: creationType as 'ai' | 'manual',
+                          mockServerType: creationType === 'ai' ? 'self-hosted' : workspaceData.mockServerType,
+                        });
                       }}
                       className="mb-2 flex flex-col gap-2"
                     >
@@ -520,7 +547,7 @@ export const NewWorkspaceModal = ({
                           <div className="group relative">
                             <Icon icon="info-circle" className="cursor-help text-[--hl]" />
                             <div className="absolute left-1/2 top-full z-10 mt-2 hidden w-72 -translate-x-1/2 rounded-md border border-[--hl-sm] bg-[--color-bg] p-3 text-xs text-[--color-font] shadow-lg group-hover:block">
-                              Upload additional files to provide extra context when generating your mock server. These
+                              Add files to include as additional context for the LLM when generating your mock server. These
                               files can contain example data, schemas, or other relevant information.
                             </div>
                           </div>
@@ -654,23 +681,25 @@ export const NewWorkspaceModal = ({
                 )}
               </div>
               <div className="flex items-center justify-end gap-2 p-10">
-                <div className="flex items-center gap-2">
-                  <Button
-                    onPress={close}
-                    isDisabled={createNewWorkspaceFetcher.state !== 'idle' || gitRepoTreeFetcher.state !== 'idle'}
-                    className="rounded-sm border border-solid border-[--hl-md] px-3 py-2 text-[--color-font] transition-colors hover:bg-opacity-90 hover:no-underline"
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    type="submit"
-                    isDisabled={createNewWorkspaceFetcher.state !== 'idle' || gitRepoTreeFetcher.state !== 'idle'}
-                    className="flex w-[10ch] items-center justify-center gap-2 rounded-sm border border-solid border-[--hl-md] bg-[--color-surprise] px-3 py-2 text-center text-[--color-font-surprise] transition-colors hover:bg-opacity-90 hover:no-underline"
-                  >
-                    {createNewWorkspaceFetcher.state !== 'idle' && <Icon icon="spinner" className="animate-spin" />}
-                    <span>Create</span>
-                  </Button>
-                </div>
+                <Button
+                  onPress={close}
+                  isDisabled={createNewWorkspaceFetcher.state !== 'idle' || gitRepoTreeFetcher.state !== 'idle'}
+                  className="rounded-sm border border-solid border-[--hl-md] px-3 py-2 text-[--color-font] transition-colors hover:bg-opacity-90 hover:no-underline"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  isDisabled={createNewWorkspaceFetcher.state !== 'idle' || gitRepoTreeFetcher.state !== 'idle'}
+                  className="flex min-w-[10ch] items-center justify-center gap-2 rounded-sm border border-solid border-[--hl-md] bg-[--color-surprise] px-3 py-2 text-center text-[--color-font-surprise] transition-colors hover:bg-opacity-90 hover:no-underline"
+                >
+                  {createNewWorkspaceFetcher.state !== 'idle' && <Icon icon="spinner" className="animate-spin" />}
+                  <span>
+                    {createNewWorkspaceFetcher.state !== 'idle' && scope === WorkspaceScopeKeys.mockServer
+                      ? progressMessages[progressMessage]
+                      : 'Create'}
+                  </span>
+                </Button>
               </div>
             </Form>
           )}

--- a/packages/insomnia/src/ui/components/settings/llms/claude.tsx
+++ b/packages/insomnia/src/ui/components/settings/llms/claude.tsx
@@ -57,15 +57,13 @@ export const Claude = ({
     if (configuredLLMs.length === 1) {
       setSelectedModel(configuredLLMs[0].model);
       const key = configuredLLMs[0].apiKey || '';
-      if (key && key !== apiKey) {
-        setApiKey(key);
-      }
+      setApiKey(key);
     }
-  }, [configuredLLMs, apiKey]);
+  }, [configuredLLMs]);
 
   const hasChanges = useMemo(() => {
-    return selectedModel !== currentLLM?.model;
-  }, [selectedModel, currentLLM]);
+    return selectedModel !== currentLLM?.model || apiKey !== currentLLM?.apiKey;
+  }, [selectedModel, currentLLM, apiKey]);
 
   const modelsId = useId();
   return (
@@ -115,7 +113,7 @@ export const Claude = ({
           Deactivate
         </Button>
         <Button
-          isDisabled={!hasChanges || isLoadingModels || !selectedModel || !availableModels.length}
+          isDisabled={!hasChanges || isLoadingModels || (!!apiKey && !selectedModel)}
           onClick={() => {
             saveLLMSettings(true, 'claude', { model: selectedModel, apiKey });
           }}

--- a/packages/insomnia/src/ui/components/settings/llms/gemini.tsx
+++ b/packages/insomnia/src/ui/components/settings/llms/gemini.tsx
@@ -61,15 +61,13 @@ export const Gemini = ({
     if (configuredLLMs.length === 1) {
       setSelectedModel(configuredLLMs[0].model);
       const key = configuredLLMs[0].apiKey || '';
-      if (key && key !== apiKey) {
-        setApiKey(key);
-      }
+      setApiKey(key);
     }
-  }, [configuredLLMs, apiKey]);
+  }, [configuredLLMs]);
 
   const hasChanges = useMemo(() => {
-    return selectedModel !== currentLLM?.model;
-  }, [selectedModel, currentLLM]);
+    return selectedModel !== currentLLM?.model || apiKey !== currentLLM?.apiKey;
+  }, [selectedModel, currentLLM, apiKey]);
 
   const modelsId = useId();
   return (
@@ -119,7 +117,7 @@ export const Gemini = ({
           Deactivate
         </Button>
         <Button
-          isDisabled={!hasChanges || isLoadingModels || !selectedModel || !availableModels.length}
+          isDisabled={!hasChanges || isLoadingModels || (!!apiKey && !selectedModel)}
           onClick={() => {
             saveLLMSettings(true, 'gemini', { model: selectedModel, apiKey });
           }}

--- a/packages/insomnia/src/ui/components/settings/llms/openai.tsx
+++ b/packages/insomnia/src/ui/components/settings/llms/openai.tsx
@@ -65,15 +65,13 @@ export const OpenAI = ({
     if (configuredLLMs.length === 1) {
       setSelectedModel(configuredLLMs[0].model);
       const key = configuredLLMs[0].apiKey || '';
-      if (key && key !== apiKey) {
-        setApiKey(key);
-      }
+      setApiKey(key);
     }
-  }, [configuredLLMs, apiKey]);
+  }, [configuredLLMs]);
 
   const hasChanges = useMemo(() => {
-    return selectedModel !== currentLLM?.model;
-  }, [selectedModel, currentLLM]);
+    return selectedModel !== currentLLM?.model || apiKey !== currentLLM?.apiKey;
+  }, [selectedModel, currentLLM, apiKey]);
 
   const modelsId = useId();
   return (
@@ -123,7 +121,7 @@ export const OpenAI = ({
           Deactivate
         </Button>
         <Button
-          isDisabled={!hasChanges || isLoadingModels || !selectedModel || !availableModels.length}
+          isDisabled={!hasChanges || isLoadingModels || (!!apiKey && !selectedModel)}
           onClick={() => {
             saveLLMSettings(true, 'openai', { model: selectedModel, apiKey });
           }}


### PR DESCRIPTION
A few improvements based on feedback:

- Make the mock server generation synchronous again, rather than auto-closing the modal and showing toasts. If there are errors, they are displayed at the top of the modal.
- Updates the text on the "Create" button to a different message every ~7s to show a visual indicator that the generation is still ongoing.
- Fixes an issue where it was not possible to clear out the API key for an LLM in preferences.
- Auto-select the self hosted mocks option when the AI auto gen option is selected.
- Minor updates to the text on how additional files are used.