### PR TITLE
chore(docs): add note on macOS entitlements for local testing of packaged app

### DIFF
--- a/packages/insomnia-smoke-test/README.md
+++ b/packages/insomnia-smoke-test/README.md
@@ -119,6 +119,11 @@ npm run app-package
 npm run test:smoke:package
 ```
 
+> Note: for local testing of the packaged app on macOS you need to change the entitlements temporarily to allow unsigned apps to run. You can do this by changing the `com.apple.security.cs.disable-library-validation` key in `entitlements.mac.inherit.plist` file to
+> to ` <key>com.apple.security.cs.disable-library-validation</key>
+
+    <false/>`
+
 Each of the above commands will automatically run the Express server, so you do not need to take any extra steps.
 
 ### Non recurring tests


### PR DESCRIPTION
# Overview

Adds documentation on how to package the app locally for macOS users