### PR TITLE
chore(pkg): exclude source map files from build output

### DIFF
--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -20,7 +20,7 @@ const config = {
     {
       from: './build',
       to: '.',
-      filter: ['**/*'],
+      filter: ['**/*', '!**/*.map'],
     },
     './package.json',
   ],


### PR DESCRIPTION
# Overview

.map files are uploaded to sentry and do not need to be included in the final packaged app.
This reduces the package size significantly