### PR TITLE
chore(pkg): Merge ASARs for universal builds

### DIFF
--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -52,8 +52,8 @@ const config = {
         arch: 'universal',
       },
     ],
-    x64ArchFiles: '*',
-    mergeASARs: false,
+    x64ArchFiles: '**/node_modules/**/*.node',
+    mergeASARs: true,
     extendInfo: {
       NSRequiresAquaSystemAppearance: false,
     },


### PR DESCRIPTION
# Overview

Enables the mergeASAR option in electron builder to store independent code (JavaScript, JSON, HTML) once in a shared ASAR file instead of duplicating it for both Intel and ARM builds, reducing the universal macOS app size.
For our current setup this option only affects macOS builds
- On the zip file this removes ~2mbs
- When unzipping the difference is around ~3mbs

TODO:
- [x] Test the packaged app on macOS ARM
- [ ] Test the packaged app on macOS Intel