### PR TITLE
fix(deps): Move @react-router/dev to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27555,7 +27555,6 @@
         "@grpc/grpc-js": "^1.13.3",
         "@grpc/proto-loader": "^0.7.13",
         "@mismerge/core": "^1.2.1",
-        "@react-router/dev": "^7.7.0",
         "@react-router/fs-routes": "^7.7.0",
         "@react-router/node": "^7.7.0",
         "@react-router/serve": "^7.7.0",
@@ -27649,6 +27648,7 @@
       },
       "devDependencies": {
         "@develohpanda/fluent-builder": "^2.1.2",
+        "@react-router/dev": "^7.7.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -52,7 +52,6 @@ const config = {
         arch: 'universal',
       },
     ],
-    x64ArchFiles: '*',
     mergeASARs: false,
     extendInfo: {
       NSRequiresAquaSystemAppearance: false,

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -54,7 +54,6 @@
     "@grpc/grpc-js": "^1.13.3",
     "@grpc/proto-loader": "^0.7.13",
     "@mismerge/core": "^1.2.1",
-    "@react-router/dev": "^7.7.0",
     "@react-router/fs-routes": "^7.7.0",
     "@react-router/node": "^7.7.0",
     "@react-router/serve": "^7.7.0",
@@ -145,6 +144,7 @@
   },
   "devDependencies": {
     "@develohpanda/fluent-builder": "^2.1.2",
+    "@react-router/dev": "^7.7.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
# Overview

- [x] Moves @react-router/dev to dev dependencies since it shouldn't be included in the final package
- [x] Removes the `x64ArchFiles` option from electron builder since it was added to support bundling this package