### PR TITLE
fix: set min height for git folder selector

### DIFF
--- a/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/new-workspace-modal.tsx
@@ -268,7 +268,7 @@ export const NewWorkspaceModal = ({
                     </Label>
 
                     <Tree
-                      className="grid max-h-52 gap-0 overflow-auto rounded-sm border border-solid border-[--hl-sm]"
+                      className="grid min-h-24 max-h-52 gap-0 overflow-auto rounded-sm border border-solid border-[--hl-sm]"
                       defaultSelectedKeys={[gitRepoTreeFetcher.data?.repositoryTree.id || '']}
                       disallowEmptySelection
                       defaultExpandedKeys={[gitRepoTreeFetcher.data?.repositoryTree.id || '']}


### PR DESCRIPTION
Fix for the git folder selector not being visible in the new create mock server modal.