### PR TITLE
fix: Escape tabs and new lines for CodeMirror display

### DIFF
--- a/packages/insomnia/src/ui/components/mcp/event-view.tsx
+++ b/packages/insomnia/src/ui/components/mcp/event-view.tsx
@@ -88,7 +88,10 @@ export const MessageEventView = ({ event }: Props) => {
         }
       }
     }
-    pretty = JSON.stringify(parsed, null, '\t');
+    // Escape tabs and new lines for CodeMirror display
+    pretty = JSON.stringify(parsed, null, '\t')
+      .replace(/\\n|\\r\\n|\\r/g, '\n')
+      .replace(/\\t/g, '\t');
   } catch {
     // Can't parse as JSON.
   }


### PR DESCRIPTION
Escape tabs and new lines for MCP response visual preview mode