### PR TITLE
fix: file tag returns getPath error in the elevated mode

### DIFF
--- a/packages/insomnia/src/main/secure-read-file.ts
+++ b/packages/insomnia/src/main/secure-read-file.ts
@@ -16,7 +16,8 @@ export const isPathAllowed = (filePath: string, userAllowList: string[]) => {
 };
 const securePath = (filePath: string) => path.resolve(decodeURIComponent(filePath));
 const getSecuredFolderAllowList = (userAllowList: string[]) => {
-  const userdataDirectory = process.env.INSOMNIA_DATA_PATH || electron.app.getPath('userData');
+  const userDataPath = process.type === 'renderer' ? window.app.getPath('userData') : electron.app.getPath('userData');
+  const userdataDirectory = process.env.INSOMNIA_DATA_PATH || userDataPath;
   // we use tmpdir for buildMultipart
   // we put the db in userData
   // the user can also specifiy other folders


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

### Changes
- [x] In elevated mode, call `window.app.getPath('userData')` instead of `electron.app.getPath('userData')`.

### Test
- [x] Enable elevated mode in preference -> plugins
- [x] Add a file tag and see it's output, there should be no error