### PR TITLE
fix: check clientCerts and return correct error message when accessing denied for CLI

### DIFF
--- a/packages/insomnia/src/common/misc.ts
+++ b/packages/insomnia/src/common/misc.ts
@@ -264,3 +264,10 @@ export function unescapeForwardSlash(str: string): string {
     return match;
   });
 }
+
+
+export function cannotAccessPathError(accessingPath: string): string {
+  return process.type === 'renderer' || process.type === 'browser' ?
+    `Insomnia cannot access the file "${accessingPath}". You must specify which directories Insomnia can access in Insomnia Preferences → Security` :
+    `Insomnia cannot access the file ‘${accessingPath}’. You must specify which directories Insomnia can access with one or more "--dataFolders <directory>".`;
+}

--- a/packages/insomnia/src/main/network/libcurl-promise.ts
+++ b/packages/insomnia/src/main/network/libcurl-promise.ts
@@ -23,7 +23,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { version } from '../../../package.json';
 import { type AuthTypes, CONTENT_TYPE_FORM_DATA, CONTENT_TYPE_FORM_URLENCODED } from '../../common/constants';
-import { describeByteSize, hasAuthHeader } from '../../common/misc';
+import { cannotAccessPathError, describeByteSize, hasAuthHeader } from '../../common/misc';
 import type { ClientCertificate } from '../../models/client-certificate';
 import type { RequestHeader } from '../../models/request';
 import type { ResponseHeader } from '../../models/response';
@@ -162,7 +162,7 @@ export const curlRequest = (options: CurlRequestOptions) =>
         const { isAllowed, securedPath } = isPathAllowed(requestBodyPath, settings.dataFolders);
         invariant(
           isAllowed,
-          `Insomnia cannot access the file "${securedPath}". You must specify which directories Insomnia can access in Insomnia Preferences → Security`,
+          cannotAccessPathError(securedPath),
         );
 
         // AWS IAM file upload not supported
@@ -333,16 +333,34 @@ export const createConfiguredCurlInstance = ({
   certificates.forEach(validCert => {
     const { passphrase, cert, key, pfx } = validCert;
     if (cert) {
+      const { isAllowed, securedPath } = isPathAllowed(cert, settings.dataFolders);
+      invariant(
+        isAllowed,
+        cannotAccessPathError(securedPath),
+      );
+
       curl.setOpt(Curl.option.SSLCERT, cert);
       curl.setOpt(Curl.option.SSLCERTTYPE, 'PEM');
       debugTimeline.push({ value: 'Adding SSL PEM certificate', name: 'Text', timestamp: Date.now() });
     }
     if (pfx) {
+      const { isAllowed, securedPath } = isPathAllowed(pfx, settings.dataFolders);
+      invariant(
+        isAllowed,
+        cannotAccessPathError(securedPath),
+      );
+
       curl.setOpt(Curl.option.SSLCERT, pfx);
       curl.setOpt(Curl.option.SSLCERTTYPE, 'P12');
       debugTimeline.push({ value: 'Adding SSL P12 certificate', name: 'Text', timestamp: Date.now() });
     }
     if (key) {
+      const { isAllowed, securedPath } = isPathAllowed(key, settings.dataFolders);
+      invariant(
+        isAllowed,
+        cannotAccessPathError(securedPath),
+      );
+
       curl.setOpt(Curl.option.SSLKEY, key);
       debugTimeline.push({ value: 'Adding SSL KEY certificate', name: 'Text', timestamp: Date.now() });
     }


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
In CLI:
<img width="2598" height="374" alt="image" src="https://github.com/user-attachments/assets/d56115bb-fc8d-4a6f-b96d-b2740340d58f" />

In UI:
<img width="1796" height="608" alt="image" src="https://github.com/user-attachments/assets/a708b4a4-5bd0-4d66-9d95-711d5d4a877f" />

