### PR TITLE
fix: the danger color is same as background then icon seems invisible

### DIFF
--- a/packages/insomnia/src/ui/components/proto-file/proto-file-list.tsx
+++ b/packages/insomnia/src/ui/components/proto-file/proto-file-list.tsx
@@ -109,7 +109,6 @@ const recursiveRender = (
           <Button
             variant="text"
             title="Delete Proto File"
-            bg="danger"
             onClick={event => {
               event.stopPropagation();
               handleDelete(f);


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->


### Change
- [x] fix: use the default color as the danger color is same as background then icon seems invisible

<img width="1792" height="976" alt="image" src="https://github.com/user-attachments/assets/5443d8cf-ced5-4997-aa93-dde6e1ae9417" />
<img width="1800" height="996" alt="image" src="https://github.com/user-attachments/assets/2be269e9-f74f-482f-9447-77dc0655218a" />
