### PR TITLE
fix: get valid mcp stdio PATH env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13858,6 +13858,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-shell": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/default-shell/-/default-shell-2.2.0.tgz",
+      "integrity": "sha512-sPpMZcVhRQ0nEMDtuMJ+RtCxt7iHPAMBU+I4tAlo5dU1sjRpNax0crj6nR3qKpvVnckaQ9U38enXcwW9nZJeCw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -16281,6 +16293,53 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -18135,6 +18194,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
     "node_modules/humanize-ms": {
@@ -20520,6 +20588,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -20598,7 +20672,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -21713,6 +21786,18 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -22293,7 +22378,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -24739,6 +24823,65 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-env": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/shell-env/-/shell-env-4.0.1.tgz",
+      "integrity": "sha512-w3oeZ9qg/P6Lu6qqwavvMnB/bwfsz67gPB3WXmLd/n6zuh7TWQZtGa3iMEdmua0kj8rivkwl+vUjgLWlqZOMPw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-shell": "^2.0.0",
+        "execa": "^5.1.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shell-env/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/shell-env/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/shell-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/shell-path/-/shell-path-3.1.0.tgz",
+      "integrity": "sha512-s/9q9PEtcRmDTz69+cJ3yYBAe9yGrL7e46gm2bU4pQ9N48ecPK9QrGFnLwYgb4smOHskx4PL7wCNMktW2AoD+g==",
+      "license": "MIT",
+      "dependencies": {
+        "shell-env": "^4.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/shell-quote": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
@@ -24901,7 +25044,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/simple-concat": {
@@ -25608,6 +25750,15 @@
       "license": "MIT",
       "dependencies": {
         "is-natural-number": "^4.0.1"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/strip-indent": {
@@ -28224,6 +28375,7 @@
         "react-router": "^7.7.0",
         "react-stately": "3.41.0",
         "react-use": "^17.6.0",
+        "shell-path": "^3.1.0",
         "shell-quote": "^1.8.2",
         "socket.io-client": "^4.8.1",
         "swagger-ui-dist": "^5.21.0",

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -52,6 +52,7 @@ const config = {
         arch: 'universal',
       },
     ],
+    x64ArchFiles: '*',
     mergeASARs: false,
     extendInfo: {
       NSRequiresAquaSystemAppearance: false,

--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -52,7 +52,6 @@ const config = {
         arch: 'universal',
       },
     ],
-    x64ArchFiles: '*',
     mergeASARs: false,
     extendInfo: {
       NSRequiresAquaSystemAppearance: false,

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -132,6 +132,7 @@
     "react-stately": "3.41.0",
     "react-use": "^17.6.0",
     "react": "^18.3.1",
+    "shell-path": "^3.1.0",
     "shell-quote": "^1.8.2",
     "socket.io-client": "^4.8.1",
     "swagger-ui-dist": "^5.21.0",

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -764,9 +764,11 @@ const createStdioTransport = async (
     timestamp: Date.now(),
   });
   const pathEnv = (await shellPath()) || process.env.PATH || '';
+  // Filter out empty keys from env
+  const filteredEnv = Object.fromEntries(Object.entries(env).filter(([key]) => key.trim().length));
   const finalEnv = {
     PATH: pathEnv,
-    ...env,
+    ...filteredEnv,
   };
   const stringifiedEnv = Object.entries(finalEnv)
     .map(([key, value]) => `${key}=${value}`)
@@ -781,10 +783,6 @@ const createStdioTransport = async (
   }
   initialTimelines.map(t => timelineFileStreams.get(requestId)?.write(JSON.stringify(t) + '\n'));
 
-  console.log('----MCP STDIO Transport Command----');
-  console.log(process.env);
-  console.log(process.env['PATH']);
-  console.log(JSON.stringify(getDefaultEnvironment()));
   const start = performance.now();
   const transport = new StdioClientTransport({
     command,

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -746,8 +746,8 @@ function resolveShellPath(): Promise<string> {
     // 3. Prepare the command to get PATH
     // -l: Start the shell as a login shell to ensure it loads profile scripts
     // -c: Run the following command
-    // "echo -n $PATH": Print the full PATH variable, -n avoids trailing newline
-    const command = `"${shell}" -l -c "echo -n $PATH"`;
+    // "echo -n \$PATH": Print the full PATH variable, -n avoids trailing newline, escape $ to avoid early interpolation
+    const command = `"${shell}" -l -c "echo -n \$PATH"`;
 
     // 4. Execute the command
     exec(command, (error, stdout, stderr) => {

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -1,3 +1,4 @@
+import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -731,7 +732,43 @@ const createStreamableHTTPTransport = async (
   return transport;
 };
 
-const createStdioTransport = (
+function resolveShellPath(): Promise<string> {
+  return new Promise(resolve => {
+    const defaultPath = process.env.PATH || '';
+    // 1. For Windows, we just return the existing PATH
+    if (process.platform === 'win32') {
+      return resolve(defaultPath);
+    }
+
+    // 2. Get the user's default shell
+    const shell = process.env.SHELL || '/bin/bash'; // Fallback to /bin/bash if SHELL is not set
+
+    // 3. Prepare the command to get PATH
+    // -l: Start the shell as a login shell to ensure it loads profile scripts
+    // -c: Run the following command
+    // "echo -n $PATH": Print the full PATH variable, -n avoids trailing newline
+    const command = `"${shell}" -l -c "echo -n $PATH"`;
+
+    // 4. Execute the command
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        console.warn(`[PATH Resolver] Unresolved shell PATH: ${stderr}`);
+        return resolve(defaultPath);
+      }
+
+      const resolvedPath = stdout.trim();
+      if (resolvedPath) {
+        console.log(`[PATH Resolver] Resolved Shell PATH: ${resolvedPath}`);
+        resolve(resolvedPath);
+      } else {
+        console.warn(`[PATH Resolver] Shell returned an empty PATH.`);
+        resolve(defaultPath); // Return defaultPath if empty
+      }
+    });
+  });
+}
+
+const createStdioTransport = async (
   options: OpenMcpStdioClientConnectionOptions,
   {
     responseId,
@@ -780,10 +817,12 @@ const createStdioTransport = (
   console.log(process.env['PATH']);
   console.log(JSON.stringify(getDefaultEnvironment()));
   const start = performance.now();
+  const shellPath = await resolveShellPath();
   const transport = new StdioClientTransport({
     command,
     args,
     env: {
+      PATH: shellPath || process.env.PATH || '',
       ...env,
     },
     stderr: 'pipe',

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -39,6 +39,7 @@ import {
   type UnsubscribeRequest,
 } from '@modelcontextprotocol/sdk/types.js';
 import electron, { BrowserWindow, ipcMain } from 'electron';
+import { shellPath } from 'shell-path';
 import { parse } from 'shell-quote';
 import { v4 as uuidV4 } from 'uuid';
 import type { z } from 'zod';
@@ -732,42 +733,6 @@ const createStreamableHTTPTransport = async (
   return transport;
 };
 
-function resolveShellPath(): Promise<string> {
-  return new Promise(resolve => {
-    const defaultPath = process.env.PATH || '';
-    // 1. For Windows, we just return the existing PATH
-    if (process.platform === 'win32') {
-      return resolve(defaultPath);
-    }
-
-    // 2. Get the user's default shell
-    const shell = process.env.SHELL || '/bin/bash'; // Fallback to /bin/bash if SHELL is not set
-
-    // 3. Prepare the command to get PATH
-    // -l: Start the shell as a login shell to ensure it loads profile scripts
-    // -c: Run the following command
-    // "echo -n \$PATH": Print the full PATH variable, -n avoids trailing newline, escape $ to avoid early interpolation
-    const command = `"${shell}" -l -c "echo -n \$PATH"`;
-
-    // 4. Execute the command
-    exec(command, (error, stdout, stderr) => {
-      if (error) {
-        console.warn(`[PATH Resolver] Unresolved shell PATH: ${stderr}`);
-        return resolve(defaultPath);
-      }
-
-      const resolvedPath = stdout.trim();
-      if (resolvedPath) {
-        console.log(`[PATH Resolver] Resolved Shell PATH: ${resolvedPath}`);
-        resolve(resolvedPath);
-      } else {
-        console.warn(`[PATH Resolver] Shell returned an empty PATH.`);
-        resolve(defaultPath); // Return defaultPath if empty
-      }
-    });
-  });
-}
-
 const createStdioTransport = async (
   options: OpenMcpStdioClientConnectionOptions,
   {
@@ -799,7 +764,12 @@ const createStdioTransport = async (
     name: 'HeaderOut',
     timestamp: Date.now(),
   });
-  const stringifiedEnv = Object.entries(env)
+  const pathEnv = (await shellPath()) || process.env.PATH || '';
+  const finalEnv = {
+    PATH: pathEnv,
+    ...env,
+  };
+  const stringifiedEnv = Object.entries(finalEnv)
     .map(([key, value]) => `${key}=${value}`)
     .join(' ')
     .trim();
@@ -817,14 +787,10 @@ const createStdioTransport = async (
   console.log(process.env['PATH']);
   console.log(JSON.stringify(getDefaultEnvironment()));
   const start = performance.now();
-  const shellPath = await resolveShellPath();
   const transport = new StdioClientTransport({
     command,
     args,
-    env: {
-      PATH: shellPath || process.env.PATH || '',
-      ...env,
-    },
+    env: finalEnv,
     stderr: 'pipe',
   });
 

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -1,4 +1,3 @@
-import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -775,12 +775,13 @@ const createStdioTransport = (
   }
   initialTimelines.map(t => timelineFileStreams.get(requestId)?.write(JSON.stringify(t) + '\n'));
 
+  console.log('----MCP STDIO Transport Command----');
+  console.log(JSON.stringify(getDefaultEnvironment()));
   const start = performance.now();
   const transport = new StdioClientTransport({
     command,
     args,
     env: {
-      ...getDefaultEnvironment(),
       ...env,
     },
     stderr: 'pipe',

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -9,7 +9,7 @@ import {
   UnauthorizedError,
 } from '@modelcontextprotocol/sdk/client/auth.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {
   type OAuthClientInformationFull,

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -776,6 +776,8 @@ const createStdioTransport = (
   initialTimelines.map(t => timelineFileStreams.get(requestId)?.write(JSON.stringify(t) + '\n'));
 
   console.log('----MCP STDIO Transport Command----');
+  console.log(process.env);
+  console.log(process.env['PATH']);
   console.log(JSON.stringify(getDefaultEnvironment()));
   const start = performance.now();
   const transport = new StdioClientTransport({


### PR DESCRIPTION
[INS-1576](https://konghq.atlassian.net/browse/INS-1576)

## Background

In macOS or other Unix-like OS, when an Electron app is launched via CLI, it inherits the env. But if it's launched via launchpad, it only has the basic env. This makes the MCP SDK impossible to get the real PATH.

## Change

- Get the default env from the default shell by shell-path.
- Remove the getDefaultEnv call since it's already in the SDK: https://github.com/modelcontextprotocol/typescript-sdk/blob/c54309598505007c4467f78fa7dfb3e7c763679c/src/client/stdio.ts#L123-L125

[INS-1576]: https://konghq.atlassian.net/browse/INS-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ