### PR TITLE
wip: use memoize to cache rendercontext

### DIFF
--- a/packages/insomnia/src/templating/types.ts
+++ b/packages/insomnia/src/templating/types.ts
@@ -63,8 +63,6 @@ export interface RenderContextAndKeys {
   }[];
 }
 
-export type HandleRender = <T>(whatever: T, contextCacheKey?: string | null) => Promise<T>;
-
 export interface BaseRenderContextOptions {
   environment?: string | Environment;
   baseEnvironment?: Environment;

--- a/packages/insomnia/src/ui/components/.client/codemirror/extensions/nunjucks-tags.ts
+++ b/packages/insomnia/src/ui/components/.client/codemirror/extensions/nunjucks-tags.ts
@@ -2,7 +2,7 @@ import CodeMirror, { type Token } from 'codemirror';
 
 import * as misc from '~/common/misc';
 import { getTagDefinitions } from '~/templating/index';
-import type { HandleRender, RenderContextAndKeys } from '~/templating/types';
+import type { RenderContextAndKeys } from '~/templating/types';
 import { tokenizeTag } from '~/templating/utils';
 import { showModal } from '~/ui/components/modals/index';
 import { NunjucksModal } from '~/ui/components/modals/nunjucks-modal';
@@ -11,8 +11,8 @@ CodeMirror.defineExtension(
   'enableNunjucksTags',
   function (
     this: CodeMirror.Editor,
-    handleRender: HandleRender,
-    handleGetRenderContext: (contextCacheKey?: string) => Promise<RenderContextAndKeys>,
+    handleRender: (input: string) => Promise<string>,
+    handleGetRenderContext: () => Promise<RenderContextAndKeys>,
     showVariableSourceAndValue = false,
     editorId = '',
   ) {
@@ -51,16 +51,11 @@ CodeMirror.defineExtension(
 
 async function _highlightNunjucksTags(
   this: CodeMirror.Editor,
-  render: HandleRender,
-  renderContext: (contextCacheKey?: string) => Promise<RenderContextAndKeys>,
+  render: (input: string) => Promise<string>,
+  renderContext: () => Promise<RenderContextAndKeys>,
   showVariableSourceAndValue: boolean,
   editorId: string,
 ) {
-  const renderCacheKey = Math.random() + '';
-
-  const renderString = (text: any) => render(text, renderCacheKey);
-  const renderContextWithCacheKey = () => renderContext(renderCacheKey);
-
   const activeMarks: CodeMirror.TextMarker[] = [];
   const doc: CodeMirror.Doc = this.getDoc();
 
@@ -147,12 +142,12 @@ async function _highlightNunjucksTags(
       });
 
       (async function () {
-        await _updateElementText(renderString, mark, tok.string, renderContextWithCacheKey, showVariableSourceAndValue);
+        await _updateElementText(render, mark, tok.string, renderContext, showVariableSourceAndValue);
       })();
 
       // Update it every mouseenter because it may generate a new value every time
       el.addEventListener('mouseenter', async () => {
-        await _updateElementText(renderString, mark, tok.string, renderContextWithCacheKey, showVariableSourceAndValue);
+        await _updateElementText(render, mark, tok.string, renderContext, showVariableSourceAndValue);
       });
       activeMarks.push(mark);
       el.addEventListener('click', async () => {
@@ -262,10 +257,10 @@ async function _highlightNunjucksTags(
 }
 
 async function _updateElementText(
-  render: HandleRender,
+  render: (input: string) => Promise<string>,
   mark: CodeMirror.TextMarker<CodeMirror.MarkerRange>,
   text: string,
-  renderContext: (contextCacheKey?: string) => Promise<RenderContextAndKeys>,
+  renderContext: () => Promise<RenderContextAndKeys>,
   showVariableSourceAndValue: boolean,
 ) {
   const el = mark.replacedWith!;

--- a/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
+++ b/packages/insomnia/src/ui/context/nunjucks/use-nunjucks.ts
@@ -1,13 +1,13 @@
-import { useCallback } from 'react';
+import { memoize } from '@formatjs/fast-memoize';
 
-import { getRenderContext, getRenderContextAncestors, render } from '~/common/render';
+import { getRenderContext, render } from '~/common/render';
+import type { RequestGroup } from '~/models/request-group';
 import { useWorkspaceLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { useRequestLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId';
 import { useRequestGroupLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request-group.$requestGroupId';
 import { NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME } from '~/templating';
-import type { HandleRender, RenderContextOptions } from '~/templating/types';
+import type { BaseRenderContext, RenderContextOptions } from '~/templating/types';
 import { getKeys } from '~/templating/utils';
-
 let getRenderContextPromiseCache: any = {};
 
 export interface UseNunjucksOptions {
@@ -19,6 +19,24 @@ export const initializeNunjucksRenderPromiseCache = () => {
 
 initializeNunjucksRenderPromiseCache();
 
+const getMemoizedRenderContext = memoize(
+  async ({
+    requestData,
+    workspaceData,
+    options,
+  }: {
+    requestData: ReturnType<typeof useRequestLoaderData>;
+    workspaceData: ReturnType<typeof useWorkspaceLoaderData>;
+    activeRequestGroup?: RequestGroup;
+    options?: { renderContext: RenderContextOptions };
+  }): Promise<BaseRenderContext> =>
+    await getRenderContext({
+      request: requestData?.activeRequest || undefined,
+      environment: workspaceData?.activeEnvironment._id,
+      ...options?.renderContext,
+    }),
+);
+
 /**
  * Access to functions useful for Nunjucks rendering
  */
@@ -29,63 +47,25 @@ export const useNunjucks = (options?: UseNunjucksOptions) => {
   const { activeRequestGroup } = useRequestGroupLoaderData() || {};
   const workspaceData = useWorkspaceLoaderData();
 
-  const fetchRenderContext = useCallback(async () => {
-    const ancestors = await getRenderContextAncestors(
-      requestData?.activeRequest || activeRequestGroup || workspaceData?.activeWorkspace,
-    );
-    return getRenderContext({
-      request: requestData?.activeRequest || undefined,
-      environment: workspaceData?.activeEnvironment._id,
-      ancestors,
-      ...options?.renderContext,
-    });
-  }, [
-    requestData?.activeRequest,
-    workspaceData?.activeWorkspace,
-    workspaceData?.activeEnvironment._id,
-    options?.renderContext,
-    activeRequestGroup,
-  ]);
-
-  const handleGetRenderContext = useCallback(
-    async (contextCacheKey?: string) => {
-      const context =
-        contextCacheKey && getRenderContextPromiseCache[contextCacheKey]
-          ? await getRenderContextPromiseCache[contextCacheKey]
-          : await fetchRenderContext();
+  return {
+    handleRender: async (input: string) => {
+      const context = await getMemoizedRenderContext({
+        requestData,
+        workspaceData,
+        activeRequestGroup,
+        options,
+      });
+      return render(input, context);
+    },
+    handleGetRenderContext: async () => {
+      const context = await getMemoizedRenderContext({
+        requestData,
+        workspaceData,
+        activeRequestGroup,
+        options,
+      });
       const keys = getKeys(context, NUNJUCKS_TEMPLATE_GLOBAL_PROPERTY_NAME);
       return { context, keys };
     },
-    [fetchRenderContext],
-  );
-  /**
-   * Heavily optimized render function
-   *
-   * @param text - template to render
-   * @param contextCacheKey - if rendering multiple times in parallel, set this
-   * @returns {Promise}
-   * @private
-   */
-  const handleRender: HandleRender = useCallback(
-    async <T>(obj: T, contextCacheKey: string | null = null) => {
-      if (!contextCacheKey || !getRenderContextPromiseCache[contextCacheKey]) {
-        // NOTE: We're caching promises here to avoid race conditions
-        // @ts-expect-error -- TSCONVERSION contextCacheKey being null used as object index
-        getRenderContextPromiseCache[contextCacheKey] = fetchRenderContext();
-      }
-
-      // Set timeout to delete the key eventually
-      // @ts-expect-error -- TSCONVERSION contextCacheKey being null used as object index
-      setTimeout(() => delete getRenderContextPromiseCache[contextCacheKey], 5000);
-      // @ts-expect-error -- TSCONVERSION contextCacheKey being null used as object index
-      const context = await getRenderContextPromiseCache[contextCacheKey];
-      return render(obj, context);
-    },
-    [fetchRenderContext],
-  );
-
-  return {
-    handleRender,
-    handleGetRenderContext,
   };
 };

--- a/packages/insomnia/types/codemirror.d.ts
+++ b/packages/insomnia/types/codemirror.d.ts
@@ -4,7 +4,7 @@ import { GraphQLInfoOptions } from 'codemirror-graphql/info';
 import { ModifiedGraphQLJumpOptions } from 'codemirror-graphql/jump';
 import { GraphQLSchema } from 'graphql';
 
-import { HandleRender } from '../src/common/render';
+import { RenderContextAndKeys } from '../src/templating/types';
 import { Settings } from '../src/models/settings';
 import { NunjucksParsedTag } from '../src/templating/utils';
 
@@ -13,8 +13,8 @@ type LinkClickCallback = (url: string) => void;
 interface InsomniaExtensions {
   closeHintDropdown: () => void;
   enableNunjucksTags: (
-    handleRender: HandleRender,
-    handleGetRenderContext?: (contextCacheKey?: string) => Promise<RenderContextAndKeys>,
+    handleRender: (input: string) => Promise<string>,
+    handleGetRenderContext?: () => Promise<RenderContextAndKeys>,
     showVariableSourceAndValue?: boolean,
     editorId?: string,
   ) => void;


### PR DESCRIPTION
- need to decide when to re-render templates
- previously rerenderer every 5 seconds
- good example is timestamp or uuid

related: #9051
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
