### PR TITLE
feat: MCP message loading status refinement and elicitation support

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/socket-io.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/socket-io.test.ts
@@ -22,7 +22,7 @@ test('can make socket.io connection', async ({ app, page }) => {
   await page.getByLabel('Request Collection').getByTestId('Socket.IO Request').press('Enter');
   await expect.soft(page.locator('.app')).toContainText('http://localhost:4020');
   await page.click('text=Connect');
-  await expect.soft(statusTag).toContainText('Connected');
+  await expect.soft(statusTag).toContainText('Connected', { ignoreCase: true });
   await page.getByRole('tab', { name: 'Console' }).click();
   await expect.soft(responseBody).toContainText('Connected to http://localhost:4020');
   await page.click('text=Disconnect');

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -551,4 +551,5 @@ export const INSOMNIA_FETCH_TIME_OUT = 30_000;
 export const REALTIME_EVENTS_CHANNELS = {
   READY_STATE: 'readyState',
   NEW_EVENT: 'newEventReceived',
+  MCP_NOTIFICATION: 'mcpNotification',
 };

--- a/packages/insomnia/src/common/mcp-utils.ts
+++ b/packages/insomnia/src/common/mcp-utils.ts
@@ -138,11 +138,11 @@ export const getMcpMethodFromMessage = (message: JSONRPCMessage): McpMessageEven
     }
   } else if (ServerRequestSchema.safeParse(message).success) {
     const requestMethod = ServerRequestSchema.parse(message).method;
-    if (requestMethod === METHOD_LIST_ROOTS) {
-      method = METHOD_LIST_ROOTS;
+    if (requestMethod === METHOD_LIST_ROOTS || requestMethod === METHOD_ELICITATION_CREATE_MESSAGE) {
+      method = requestMethod;
     } else {
       // Do not support any server requests to client including ping, elicitation and sampling
-      method = `${unsupportedMethodPrefix}${ServerRequestSchema.parse(message).method}`;
+      method = `${unsupportedMethodPrefix}${requestMethod}`;
     }
   }
   return method;

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -74,8 +74,13 @@ const mcp: McpBridgeAPI = {
   readyState: {
     getCurrent: options => ipcRenderer.invoke('mcp.readyState', options),
   },
+  client: {
+    responseElicitationRequest: options => ipcRenderer.send('mcp.client.responseElicitationRequest', options),
+    hasRequestResponded: options => ipcRenderer.invoke('mcp.client.hasRequestResponded', options),
+  },
   event: {
     findMany: options => ipcRenderer.invoke('mcp.event.findMany', options),
+    findNotifications: options => ipcRenderer.invoke('mcp.event.findNotifications', options),
   },
 };
 

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -125,6 +125,9 @@ export type HandleChannels =
   | 'mcp.notification.rootListChange'
   | 'mcp.readyState'
   | 'mcp.event.findMany'
+  | 'mcp.event.findNotifications'
+  | 'mcp.notification.rootListChange'
+  | 'mcp.client.hasRequestResponded'
   | 'mcp.close';
 
 export const ipcMainHandle = (
@@ -169,6 +172,7 @@ export type MainOnChannels =
   | 'webSocket.close'
   | 'webSocket.closeAll'
   | 'mcp.closeAll'
+  | 'mcp.client.responseElicitationRequest'
   | 'mcp.sendMCPRequest'
   | 'writeText';
 
@@ -193,7 +197,8 @@ export type RendererOnChannels =
   | 'toggle-sidebar'
   | 'show-oauth-authorization-modal'
   | 'hide-oauth-authorization-modal'
-  | 'mcp-auth-confirmation';
+  | 'mcp-auth-confirmation'
+  | 'updaterStatus';
 
 export const ipcMainOn = (
   channel: MainOnChannels,

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -197,8 +197,7 @@ export type RendererOnChannels =
   | 'toggle-sidebar'
   | 'show-oauth-authorization-modal'
   | 'hide-oauth-authorization-modal'
-  | 'mcp-auth-confirmation'
-  | 'updaterStatus';
+  | 'mcp-auth-confirmation';
 
 export const ipcMainOn = (
   channel: MainOnChannels,

--- a/packages/insomnia/src/main/mcp/client-requests.ts
+++ b/packages/insomnia/src/main/mcp/client-requests.ts
@@ -1,0 +1,170 @@
+import {
+  type CallToolRequest,
+  CompatibilityCallToolResultSchema,
+  type GetPromptRequest,
+  type ListPromptsRequest,
+  type ListResourcesRequest,
+  type ReadResourceRequest,
+  type SubscribeRequest,
+  type UnsubscribeRequest,
+} from '@modelcontextprotocol/sdk/types.js';
+
+import { METHOD_SUBSCRIBE_RESOURCE, METHOD_UNSUBSCRIBE_RESOURCE } from '~/common/mcp-utils';
+import { SegmentEvent, trackSegmentEvent } from '~/main/analytics';
+import { getMcpClient, mcpServerElicitationRequests, writeEventLogAndNotify } from '~/main/mcp/common';
+import type { CommonMcpOptions, McpMessageEventWithoutBase } from '~/main/mcp/types';
+
+export const listTools = async (options: CommonMcpOptions) => {
+  const mcpClient = getMcpClient(options.requestId);
+  if (mcpClient) {
+    const tools = await mcpClient.listTools();
+    return tools;
+  }
+  return null;
+};
+
+export const callTool = async (options: CommonMcpOptions & CallToolRequest['params']) => {
+  const { requestId, ...params } = options;
+  const mcpClient = getMcpClient(requestId);
+  if (mcpClient) {
+    const response = await mcpClient.callTool(params, CompatibilityCallToolResultSchema);
+    trackSegmentEvent(SegmentEvent.mcpToolCalled);
+    return response.content;
+  }
+  return null;
+};
+
+export const listPrompts = async (options: CommonMcpOptions & ListPromptsRequest['params']) => {
+  const mcpClient = getMcpClient(options.requestId);
+  if (mcpClient) {
+    const prompts = await mcpClient.listPrompts();
+    return prompts;
+  }
+  return null;
+};
+
+export const getPrompt = async (options: CommonMcpOptions & GetPromptRequest['params']) => {
+  const { requestId, ...params } = options;
+  const mcpClient = getMcpClient(options.requestId);
+  if (mcpClient) {
+    const prompt = await mcpClient.getPrompt(params);
+    trackSegmentEvent(SegmentEvent.mcpPromptCalled);
+    return prompt;
+  }
+  return null;
+};
+
+export const listResources = async (options: CommonMcpOptions & ListResourcesRequest['params']) => {
+  const { requestId, ...params } = options;
+  const mcpClient = getMcpClient(options.requestId);
+  if (mcpClient) {
+    const resources = await mcpClient.listResources(params);
+    return resources;
+  }
+  return null;
+};
+
+export const listResourceTemplates = async (options: CommonMcpOptions & ListResourcesRequest['params']) => {
+  const { requestId, ...params } = options;
+  const mcpClient = getMcpClient(requestId);
+  if (mcpClient) {
+    const resourceTemplates = await mcpClient.listResourceTemplates(params);
+    return resourceTemplates;
+  }
+  return null;
+};
+
+export const readResource = async (options: CommonMcpOptions & ReadResourceRequest['params']) => {
+  const { requestId, ...params } = options;
+  const mcpClient = getMcpClient(requestId);
+  if (mcpClient) {
+    const resource = await mcpClient.readResource(params);
+    trackSegmentEvent(SegmentEvent.mcpResourceRead);
+    return resource;
+  }
+  return null;
+};
+
+export const subscribeResource = async (options: CommonMcpOptions & SubscribeRequest['params']) => {
+  const { requestId, ...params } = options;
+  const mcpClient = getMcpClient(options.requestId);
+  if (mcpClient) {
+    const result = await mcpClient.subscribeResource(params);
+    // Subscribe resource do not have a formal response schema, so we log it manually
+    const messageEvent: Omit<McpMessageEventWithoutBase, 'data'> & { data: {} } = {
+      type: 'message',
+      method: METHOD_SUBSCRIBE_RESOURCE,
+      data: {
+        ...result,
+        // @ts-expect-error - workaround to add the json rpc request id to the logged data
+        id: mcpClient._requestMessageId - 1,
+      },
+      direction: 'INCOMING',
+    };
+    writeEventLogAndNotify(requestId, messageEvent);
+    return result;
+  }
+  return null;
+};
+
+export const unsubscribeResource = async (options: CommonMcpOptions & UnsubscribeRequest['params']) => {
+  const { requestId, ...params } = options;
+  const mcpClient = getMcpClient(options.requestId);
+  if (mcpClient) {
+    const result = await mcpClient.unsubscribeResource(params);
+    // Unsubscribe resource do not have a formal response schema, so we log it manually
+    const messageEvent: Omit<McpMessageEventWithoutBase, 'data'> & { data: {} } = {
+      type: 'message',
+      method: METHOD_UNSUBSCRIBE_RESOURCE,
+      data: {
+        ...result,
+        // @ts-expect-error - workaround to add the json rpc request id to the logged data
+        id: mcpClient._requestMessageId - 1,
+      },
+      direction: 'INCOMING',
+    };
+    writeEventLogAndNotify(requestId, messageEvent);
+    return result;
+  }
+  return null;
+};
+
+export const sendRootListChangeNotification = async (options: CommonMcpOptions) => {
+  const mcpClient = getMcpClient(options.requestId);
+  if (mcpClient) {
+    const result = await mcpClient.sendRootsListChanged();
+    return result;
+  }
+  return null;
+};
+
+export const responseElicitationRequest = (
+  options: CommonMcpOptions & {
+    serverRequestId: string;
+    type: 'submit' | 'decline' | 'cancel';
+    content?: Record<string, any>;
+  },
+) => {
+  const pendingServerRequestResolvers = mcpServerElicitationRequests.get(options.requestId);
+  if (pendingServerRequestResolvers) {
+    const serverRequestResolver = pendingServerRequestResolvers.get(options.serverRequestId);
+    switch (options.type) {
+      case 'decline': {
+        serverRequestResolver?.resolve({ action: 'decline' });
+        break;
+      }
+      case 'cancel': {
+        serverRequestResolver?.resolve({ action: 'cancel' });
+        break;
+      }
+      case 'submit': {
+        serverRequestResolver?.resolve({ action: 'accept', content: options.content });
+        break;
+      }
+      default: {
+        throw new Error(`Unknown server request response type: ${options.type}`);
+      }
+    }
+    pendingServerRequestResolvers.delete(options.serverRequestId);
+  }
+};

--- a/packages/insomnia/src/main/mcp/common.ts
+++ b/packages/insomnia/src/main/mcp/common.ts
@@ -94,21 +94,19 @@ export const writeEventLogAndNotify = (
   const dataToWrite = newLine ? stringifiedData + '\n' : stringifiedData;
   eventLogFileStreams.get(requestId)?.write(dataToWrite, () => {
     // notify all renderers of new event has been received
-    for (const window of BrowserWindow.getAllWindows()) {
-      const resId = requestIdToResponseIdMap.get(requestId);
-      if (resId) {
-        const notifyChannel = `${protocol}.${resId}.${channel}`;
-        notifyChannel && window.webContents.send(notifyChannel);
-        if (clearRequestIdMap) {
-          // clean up maps after last event has been written to file
-          requestIdToResponseIdMap.delete(requestId);
-        }
+    const resId = requestIdToResponseIdMap.get(requestId);
+    if (resId) {
+      const notifyChannel = `${protocol}.${resId}.${channel}`;
+      notifyMcpClientStateChange(notifyChannel);
+      if (clearRequestIdMap) {
+        // clean up maps after last event has been written to file
+        requestIdToResponseIdMap.delete(requestId);
       }
     }
   });
 };
 
-export const notifyMcpClientStateChange = (channel: string, value: McpReadyState) => {
+export const notifyMcpClientStateChange = (channel: string, value?: McpReadyState) => {
   for (const window of BrowserWindow.getAllWindows()) {
     window.webContents.send(channel, value);
   }

--- a/packages/insomnia/src/main/mcp/common.ts
+++ b/packages/insomnia/src/main/mcp/common.ts
@@ -17,13 +17,26 @@ import type {
   McpEvent,
   McpEventWithoutBase,
   McpNotificationEvent,
+  McpReadyState,
   McpRequestEventWithoutBase,
 } from '~/main/mcp/types';
 import * as models from '~/models';
 import { invariant } from '~/utils/invariant';
 
+interface ConnectingState {
+  status: 'connecting';
+  client: McpClient | null;
+}
+interface ConnectedState {
+  status: 'connected';
+  client: McpClient;
+}
+interface DisconnectedState {
+  status: 'disconnected';
+}
+
 export const protocol = 'mcp';
-export const mcpConnections = new Map<string, McpClient>();
+export const mcpConnections = new Map<string, ConnectingState | ConnectedState>();
 export const eventLogFileStreams = new Map<string, fs.WriteStream>();
 export const timelineFileStreams = new Map<string, fs.WriteStream>();
 export const requestIdToResponseIdMap = new Map<string, string>();
@@ -38,13 +51,25 @@ export const getMcpStateChannel = (requestId: string) =>
   `${protocol}.${requestId}.${REALTIME_EVENTS_CHANNELS.READY_STATE}`;
 
 export const getMcpClient = (id: string) => {
-  const mcpClient = mcpConnections.get(id);
+  const mcpConnection = mcpConnections.get(id);
   invariant(
-    mcpClient,
+    mcpConnection,
     `No existing MCP client connection found for requestId: ${id}. It might have been disconnected.`,
   );
-  return mcpClient;
+  return mcpConnection.client;
 };
+
+export function updateMcpConnectionState(
+  requestId: string,
+  state: ConnectingState | ConnectedState | DisconnectedState,
+) {
+  if (state.status === 'disconnected') {
+    mcpConnections.delete(requestId);
+  } else {
+    mcpConnections.set(requestId, state);
+  }
+  notifyMcpClientStateChange(getMcpStateChannel(requestId), state.status);
+}
 
 export const writeEventLogAndNotify = (
   requestId: string,
@@ -83,7 +108,7 @@ export const writeEventLogAndNotify = (
   });
 };
 
-export const notifyMcpClientStateChange = (channel: string, value: any) => {
+export const notifyMcpClientStateChange = (channel: string, value: McpReadyState) => {
   for (const window of BrowserWindow.getAllWindows()) {
     window.webContents.send(channel, value);
   }
@@ -127,7 +152,6 @@ export const clearMcpMaps = (requestId: string, timelineMessage: string, event?:
     ?.write(JSON.stringify({ value: timelineMessage, name: 'Text', timestamp: Date.now() }) + '\n');
   timelineFileStreams.get(requestId)?.end();
   timelineFileStreams.delete(requestId);
-  mcpConnections.delete(requestId);
   mcpServerElicitationRequests.delete(requestId);
 };
 
@@ -159,11 +183,10 @@ export const findNotifications = async (options: { responseId: string }): Promis
 
 export const getMcpReadyState = async (options: CommonMcpOptions) => {
   try {
-    const mcpClient = getMcpClient(options.requestId);
-    // if no mcp client, it means it's disconnected
-    return !!mcpClient;
+    const mcpConnection = mcpConnections.get(options.requestId);
+    return mcpConnection ? mcpConnection.status : 'disconnected';
   } catch (error) {
-    return false;
+    return 'disconnected';
   }
 };
 

--- a/packages/insomnia/src/main/mcp/common.ts
+++ b/packages/insomnia/src/main/mcp/common.ts
@@ -1,0 +1,180 @@
+import fs from 'node:fs';
+
+import {
+  type ElicitResult,
+  ElicitResultSchema,
+  JSONRPCErrorSchema,
+  ListRootsResultSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { BrowserWindow } from 'electron';
+import { v4 as uuidV4 } from 'uuid';
+
+import { REALTIME_EVENTS_CHANNELS } from '~/common/constants';
+import { METHOD_ELICITATION_CREATE_MESSAGE, METHOD_LIST_ROOTS, METHOD_UNKNOWN } from '~/common/mcp-utils';
+import type {
+  CommonMcpOptions,
+  McpClient,
+  McpEvent,
+  McpEventWithoutBase,
+  McpNotificationEvent,
+  McpRequestEventWithoutBase,
+} from '~/main/mcp/types';
+import * as models from '~/models';
+import { invariant } from '~/utils/invariant';
+
+export const protocol = 'mcp';
+export const mcpConnections = new Map<string, McpClient>();
+export const eventLogFileStreams = new Map<string, fs.WriteStream>();
+export const timelineFileStreams = new Map<string, fs.WriteStream>();
+export const requestIdToResponseIdMap = new Map<string, string>();
+// map to save server elicitation requests
+export const mcpServerElicitationRequests = new Map<
+  string,
+  Map<string | number, { resolve: (value: ElicitResult) => void; reject: (reason?: any) => void }>
+>();
+
+const mcpEventIdGenerator = () => `mcp-${uuidV4()}`;
+export const getMcpStateChannel = (requestId: string) =>
+  `${protocol}.${requestId}.${REALTIME_EVENTS_CHANNELS.READY_STATE}`;
+
+export const getMcpClient = (id: string) => {
+  const mcpClient = mcpConnections.get(id);
+  invariant(
+    mcpClient,
+    `No existing MCP client connection found for requestId: ${id}. It might have been disconnected.`,
+  );
+  return mcpClient;
+};
+
+export const writeEventLogAndNotify = (
+  requestId: string,
+  data: McpEventWithoutBase,
+  {
+    clearRequestIdMap = false,
+    newLine = true,
+    channel = REALTIME_EVENTS_CHANNELS.NEW_EVENT,
+  }: {
+    clearRequestIdMap?: boolean;
+    newLine?: boolean;
+    channel?: string;
+  } = {},
+) => {
+  const eventData: McpEvent = {
+    ...data,
+    _id: mcpEventIdGenerator(),
+    requestId,
+    timestamp: Date.now(),
+  };
+  const stringifiedData = JSON.stringify(eventData);
+  const dataToWrite = newLine ? stringifiedData + '\n' : stringifiedData;
+  eventLogFileStreams.get(requestId)?.write(dataToWrite, () => {
+    // notify all renderers of new event has been received
+    for (const window of BrowserWindow.getAllWindows()) {
+      const resId = requestIdToResponseIdMap.get(requestId);
+      if (resId) {
+        const notifyChannel = `${protocol}.${resId}.${channel}`;
+        notifyChannel && window.webContents.send(notifyChannel);
+        if (clearRequestIdMap) {
+          // clean up maps after last event has been written to file
+          requestIdToResponseIdMap.delete(requestId);
+        }
+      }
+    }
+  });
+};
+
+export const notifyMcpClientStateChange = (channel: string, value: any) => {
+  for (const window of BrowserWindow.getAllWindows()) {
+    window.webContents.send(channel, value);
+  }
+};
+
+export const parseAndLogMcpRequest = (requestId: string, message: any) => {
+  if (message) {
+    // Add request event
+    let requestMethod = message?.method;
+    if (!requestMethod) {
+      if (ListRootsResultSchema.safeParse(message?.result).success) {
+        requestMethod = METHOD_LIST_ROOTS;
+      } else if (ElicitResultSchema.safeParse(message?.result).success) {
+        requestMethod = METHOD_ELICITATION_CREATE_MESSAGE;
+      } else if (JSONRPCErrorSchema.safeParse(message).success) {
+        requestMethod = 'JSON-RPC Error';
+      } else {
+        requestMethod = METHOD_UNKNOWN;
+      }
+    }
+    const requestEvent: McpRequestEventWithoutBase = {
+      method: requestMethod,
+      type: 'message',
+      direction: 'OUTGOING',
+      data: message,
+    };
+    writeEventLogAndNotify(requestId, requestEvent);
+  }
+};
+
+export const clearMcpMaps = (requestId: string, timelineMessage: string, event?: McpEventWithoutBase) => {
+  if (event) {
+    writeEventLogAndNotify(requestId, event, {
+      clearRequestIdMap: true,
+    });
+  }
+  eventLogFileStreams.get(requestId)?.end();
+  eventLogFileStreams.delete(requestId);
+  timelineFileStreams
+    .get(requestId)
+    ?.write(JSON.stringify({ value: timelineMessage, name: 'Text', timestamp: Date.now() }) + '\n');
+  timelineFileStreams.get(requestId)?.end();
+  timelineFileStreams.delete(requestId);
+  mcpConnections.delete(requestId);
+  mcpServerElicitationRequests.delete(requestId);
+};
+
+const getAllEvents = async (options: { responseId: string }): Promise<McpEvent[]> => {
+  const response = await models.mcpResponse.getById(options.responseId);
+  if (!response || !response.eventLogPath) {
+    return [];
+  }
+  const body = await fs.promises.readFile(response.eventLogPath);
+  return (
+    body
+      .toString()
+      .split('\n')
+      .filter(e => e?.trim())
+      // Parse the message
+      .map(e => JSON.parse(e))
+      // Reverse the list of messages so that we get the latest message first
+      .reverse() || []
+  );
+};
+
+export const findMany = async (options: { responseId: string }): Promise<McpEvent[]> => {
+  return (await getAllEvents(options)).filter(e => e.type !== 'notification');
+};
+
+export const findNotifications = async (options: { responseId: string }): Promise<McpNotificationEvent[]> => {
+  return (await getAllEvents(options)).filter(e => e.type === 'notification') as McpNotificationEvent[];
+};
+
+export const getMcpReadyState = async (options: CommonMcpOptions) => {
+  try {
+    const mcpClient = getMcpClient(options.requestId);
+    // if no mcp client, it means it's disconnected
+    return !!mcpClient;
+  } catch (error) {
+    return false;
+  }
+};
+
+export const hasRequestResponded = async ({
+  requestId,
+  serverRequestId,
+}: CommonMcpOptions & { serverRequestId: string }) => {
+  const hasResponded = true;
+  const pendingServerRequestResolvers = mcpServerElicitationRequests.get(requestId);
+  if (pendingServerRequestResolvers) {
+    return !pendingServerRequestResolvers.has(serverRequestId);
+  }
+  return hasResponded;
+};

--- a/packages/insomnia/src/main/mcp/oauth-client-provider.ts
+++ b/packages/insomnia/src/main/mcp/oauth-client-provider.ts
@@ -1,0 +1,176 @@
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+import {
+  type OAuthClientInformationFull,
+  OAuthClientInformationSchema,
+  type OAuthClientMetadata,
+  type OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import { BrowserWindow, ipcMain } from 'electron';
+
+import { getOauthRedirectUrl } from '~/common/constants';
+import { authorizeUserInDefaultBrowser } from '~/main/authorizeUserInDefaultBrowser';
+import * as models from '~/models';
+import type { McpRequest } from '~/models/mcp-request';
+import type { RequestAuthentication } from '~/models/request';
+import { encryptOAuthUrl } from '~/network/o-auth-2/utils';
+import { invariant } from '~/utils/invariant';
+
+export class McpOAuthClientProvider implements OAuthClientProvider {
+  private _codeVerifier?: string;
+  private _resourceMetadataUrl?: URL;
+  private _redirectEndListener: ((authorizationCode: string) => void) | null = null;
+  constructor(private mcpRequest: McpRequest) {}
+  get redirectUrl() {
+    return getOauthRedirectUrl();
+  }
+  get clientMetadata(): OAuthClientMetadata {
+    return {
+      redirect_uris: [this.redirectUrl],
+      token_endpoint_auth_method: 'none',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      client_name: 'Insomnia MCP Client',
+      client_uri: 'https://github.com/Kong/insomnia',
+      scope: 'scope' in this.mcpRequest.authentication ? this.mcpRequest.authentication.scope : undefined,
+    };
+  }
+  private async refreshMcpRequest() {
+    const _mcpRequest = await models.mcpRequest.getById(this.mcpRequest._id);
+    invariant(_mcpRequest, 'MCP Request not found');
+    this.mcpRequest = _mcpRequest;
+  }
+  private isUsingMcpAuthFlow() {
+    const { authentication } = this.mcpRequest;
+    return 'grantType' in authentication && authentication.grantType === 'mcp_auth_flow' && !authentication.disabled;
+  }
+  private async updateAuthentication(auth: Partial<RequestAuthentication>) {
+    await models.mcpRequest.update(this.mcpRequest, {
+      authentication: {
+        ...this.mcpRequest.authentication,
+        ...auth,
+      },
+    });
+    await this.refreshMcpRequest();
+  }
+  // It's called when auth tries to get client information for authorization, use as a starting point for MCP Auth Flow
+  // See: https://github.com/modelcontextprotocol/typescript-sdk/blob/1d475bb3f75674a46d81dba881ea743a763cbc12/src/client/auth.ts#L349
+  async clientInformation() {
+    // If not using MCP Auth Flow, wait for user to confirm in the app UI
+    if (!this.isUsingMcpAuthFlow()) {
+      BrowserWindow.getAllWindows().forEach(window => {
+        window.webContents.send('mcp-auth-confirmation');
+      });
+      await new Promise<void>((resolve, reject) => {
+        ipcMain.once('mcp.authConfirmed', async (_, confirmed: boolean) => {
+          if (!confirmed) {
+            reject(new Error('MCP authorization cancelled by user'));
+          } else {
+            await this.updateAuthentication({
+              type: 'oauth2',
+              grantType: 'mcp_auth_flow',
+              disabled: false,
+            });
+            resolve();
+          }
+        });
+      });
+    }
+
+    if ('clientId' in this.mcpRequest.authentication && this.mcpRequest.authentication.clientId) {
+      return {
+        client_id: this.mcpRequest.authentication.clientId,
+        client_secret: this.mcpRequest.authentication.clientSecret,
+        client_id_issued_at: this.mcpRequest.authentication.clientIdIssuedAt,
+        client_secret_expires_at: this.mcpRequest.authentication.clientSecretExpiresAt,
+      };
+    }
+    return undefined;
+  }
+  async saveClientInformation(clientInformation: OAuthClientInformationFull) {
+    const parsedClientInformation = OAuthClientInformationSchema.parse(clientInformation);
+    await models.mcpRequest.update(this.mcpRequest, {
+      authentication: {
+        ...this.mcpRequest.authentication,
+        clientId: parsedClientInformation.client_id,
+        clientSecret: parsedClientInformation.client_secret,
+        clientIdIssuedAt: parsedClientInformation.client_id_issued_at,
+        clientSecretExpiresAt: parsedClientInformation.client_secret_expires_at,
+      },
+    });
+    await this.refreshMcpRequest();
+  }
+  async tokens(): Promise<OAuthTokens | undefined> {
+    const { authentication } = this.mcpRequest;
+    // Don't return tokens if not using MCP Auth Flow or if disabled
+    if (this.isUsingMcpAuthFlow()) {
+      const token = await models.oAuth2Token.getOrCreateByParentId(this.mcpRequest._id);
+      if (token.accessToken) {
+        return {
+          access_token: token.accessToken,
+          refresh_token: token.refreshToken,
+          id_token: token.identityToken,
+          expires_in: token.expiresAt ? Math.floor(token.expiresAt / 1000) : undefined,
+          token_type: ('tokenPrefix' in authentication && authentication.tokenPrefix) || 'Bearer',
+        };
+      }
+    }
+    return undefined;
+  }
+  async saveTokens(tokens: OAuthTokens) {
+    const token = await models.oAuth2Token.getOrCreateByParentId(this.mcpRequest._id);
+    await models.oAuth2Token.update(token, {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token || '',
+      identityToken: tokens.id_token || '',
+      expiresAt: tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : null,
+    });
+    await models.mcpRequest.update(this.mcpRequest, {
+      authentication: {
+        ...this.mcpRequest.authentication,
+        scope: tokens.scope,
+        tokenPrefix: tokens.token_type,
+      },
+    });
+    await this.refreshMcpRequest();
+  }
+  saveResourceMetadataUrl(url: URL | undefined) {
+    this._resourceMetadataUrl = url;
+  }
+  get resourceMetadataUrl() {
+    return this._resourceMetadataUrl;
+  }
+  async redirectToAuthorization(authorizationUrl: URL) {
+    const { relayUrl, decryptOAuthResult } = encryptOAuthUrl(authorizationUrl.toString());
+    BrowserWindow.getAllWindows().forEach(window => {
+      window.webContents.send('show-oauth-authorization-modal', relayUrl);
+    });
+    const redirectedResult = await authorizeUserInDefaultBrowser({
+      url: relayUrl,
+    });
+    BrowserWindow.getAllWindows().forEach(window => {
+      window.webContents.send('hide-oauth-authorization-modal');
+    });
+    const redirectedTo = decryptOAuthResult(redirectedResult);
+    const redirectParams = Object.fromEntries(new URL(redirectedTo).searchParams);
+    const authorizationCode = redirectParams.code;
+    if (!authorizationCode) {
+      throw new Error('Authorization code not found');
+    }
+    await this._redirectEndListener?.(authorizationCode);
+  }
+  onRedirectEnd(listener: (authorizationCode: string) => void) {
+    this._redirectEndListener = listener;
+    return () => {
+      this._redirectEndListener = null;
+    };
+  }
+  async saveCodeVerifier(codeVerifier: string) {
+    this._codeVerifier = codeVerifier;
+  }
+  async codeVerifier() {
+    if (!this._codeVerifier) {
+      throw new Error('Code verifier not set');
+    }
+    return this._codeVerifier;
+  }
+}

--- a/packages/insomnia/src/main/mcp/oauth-client-provider.ts
+++ b/packages/insomnia/src/main/mcp/oauth-client-provider.ts
@@ -147,9 +147,6 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     const redirectedResult = await authorizeUserInDefaultBrowser({
       url: relayUrl,
     });
-    BrowserWindow.getAllWindows().forEach(window => {
-      window.webContents.send('hide-oauth-authorization-modal');
-    });
     const redirectedTo = decryptOAuthResult(redirectedResult);
     const redirectParams = Object.fromEntries(new URL(redirectedTo).searchParams);
     const authorizationCode = redirectParams.code;

--- a/packages/insomnia/src/main/mcp/transport-stdio.ts
+++ b/packages/insomnia/src/main/mcp/transport-stdio.ts
@@ -1,0 +1,114 @@
+import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { InitializeRequestSchema, type JSONRPCRequest } from '@modelcontextprotocol/sdk/types.js';
+import { parse } from 'shell-quote';
+
+import { timelineFileStreams } from '~/main/mcp/common';
+import type { OpenMcpStdioClientConnectionOptions } from '~/main/mcp/types';
+import * as models from '~/models';
+import { TRANSPORT_TYPES } from '~/models/mcp-request';
+import type { McpResponse } from '~/models/mcp-response';
+
+export const createStdioTransport = (
+  options: OpenMcpStdioClientConnectionOptions,
+  {
+    responseId,
+    responseEnvironmentId,
+    timelinePath,
+    eventLogPath,
+  }: {
+    responseId: string;
+    responseEnvironmentId: string | null;
+    timelinePath: string;
+    eventLogPath: string;
+  },
+) => {
+  const { url, requestId, env } = options;
+  if (!url) {
+    throw new Error('Command is required for STDIO transport');
+  }
+  const parseResult = parse(url);
+  if (parseResult.find(arg => typeof arg !== 'string')) {
+    throw new Error('Invalid command format');
+  }
+  const [command, ...args] = parseResult as string[];
+
+  const initialTimelines = [
+    { value: `Preparing request to STDIO: ${url}`, name: 'Text', timestamp: Date.now() },
+    { value: `Current time is ${new Date().toISOString()}`, name: 'Text', timestamp: Date.now() },
+  ];
+  // Add stdio-specific timeline info
+  initialTimelines.push({
+    value: `Run command: ${url}`,
+    name: 'HeaderOut',
+    timestamp: Date.now(),
+  });
+  const stringifiedEnv = Object.entries(env)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(' ')
+    .trim();
+  if (stringifiedEnv) {
+    initialTimelines.push({
+      value: `With env: ${stringifiedEnv}`,
+      name: 'HeaderOut',
+      timestamp: Date.now(),
+    });
+  }
+  initialTimelines.map(t => timelineFileStreams.get(requestId)?.write(JSON.stringify(t) + '\n'));
+
+  const start = performance.now();
+  const transport = new StdioClientTransport({
+    command,
+    args,
+    env: {
+      ...getDefaultEnvironment(),
+      ...env,
+    },
+    stderr: 'pipe',
+  });
+
+  // Capture stderr logs for debugging
+  const stderrStream = transport.stderr;
+  stderrStream?.on('data', (chunk: Buffer) => {
+    const stderrData = chunk.toString().trim();
+    if (!stderrData) return; // Skip empty lines
+
+    // Log stderr output to timeline with appropriate categorization
+    timelineFileStreams.get(requestId)?.write(
+      JSON.stringify({
+        value: stderrData,
+        name: 'HeaderIn',
+        timestamp: Date.now(),
+      }) + '\n',
+    );
+  });
+  // Wrap the original send method to log outgoing requests for stdio transport
+  const originalSend = transport.send.bind(transport);
+  transport.send = async (message: JSONRPCRequest) => {
+    const isInitializedMessage = InitializeRequestSchema.safeParse(message).success;
+    // Create response model for initialize message and add process status timeline
+    if (isInitializedMessage) {
+      // Add process started timeline (similar to HTTP response timeline)
+      timelineFileStreams
+        .get(requestId)
+        ?.write(JSON.stringify({ value: 'Process started and ready', name: 'Text', timestamp: Date.now() }) + '\n');
+
+      const responsePatch: Partial<McpResponse> = {
+        _id: responseId,
+        parentId: requestId,
+        environmentId: responseEnvironmentId,
+        url,
+        status: 'success',
+        elapsedTime: performance.now() - start,
+        timelinePath,
+        eventLogPath,
+        transportType: TRANSPORT_TYPES.STDIO,
+      };
+      const settings = await models.settings.get();
+      const res = await models.mcpResponse.updateOrCreate(responsePatch, settings.maxHistoryResponses);
+      models.requestMeta.updateOrCreateByParentId(requestId, { activeResponseId: res._id });
+    }
+
+    return originalSend(message);
+  };
+  return transport;
+};

--- a/packages/insomnia/src/main/mcp/transport-streamable-http.ts
+++ b/packages/insomnia/src/main/mcp/transport-streamable-http.ts
@@ -6,6 +6,7 @@ import {
 } from '@modelcontextprotocol/sdk/client/auth.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { BrowserWindow } from 'electron';
 
 import { timelineFileStreams, writeEventLogAndNotify } from '~/main/mcp/common';
 import type { McpOAuthClientProvider } from '~/main/mcp/oauth-client-provider';
@@ -236,6 +237,10 @@ const wrappedFetch = async (
           fetchFn: authFetchFn,
         });
       }
+      // Close the oauth authorization modal after authorization is complete
+      BrowserWindow.getAllWindows().forEach(window => {
+        window.webContents.send('hide-oauth-authorization-modal');
+      });
       if (authResult !== 'AUTHORIZED') {
         throw new UnauthorizedError();
       }

--- a/packages/insomnia/src/main/mcp/transport-streamable-http.ts
+++ b/packages/insomnia/src/main/mcp/transport-streamable-http.ts
@@ -1,0 +1,248 @@
+import {
+  auth,
+  type AuthResult,
+  extractResourceMetadataUrl,
+  UnauthorizedError,
+} from '@modelcontextprotocol/sdk/client/auth.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+
+import { timelineFileStreams, writeEventLogAndNotify } from '~/main/mcp/common';
+import type { McpOAuthClientProvider } from '~/main/mcp/oauth-client-provider';
+import type { McpAuthEventWithoutBase, OpenMcpHTTPClientConnectionOptions } from '~/main/mcp/types';
+import * as models from '~/models';
+import { TRANSPORT_TYPES } from '~/models/mcp-request';
+import type { McpResponse } from '~/models/mcp-response';
+import type { RequestHeader } from '~/models/request';
+
+interface ResponseEventOptions {
+  responseId: string;
+  requestId: string;
+  environmentId: string | null;
+  timelinePath: string;
+  eventLogPath: string;
+  authProvider: McpOAuthClientProvider;
+}
+
+export const createStreamableHTTPTransport = async (
+  options: OpenMcpHTTPClientConnectionOptions,
+  {
+    responseId,
+    responseEnvironmentId,
+    timelinePath,
+    eventLogPath,
+    authProvider,
+  }: {
+    responseId: string;
+    responseEnvironmentId: string | null;
+    timelinePath: string;
+    eventLogPath: string;
+    authProvider: McpOAuthClientProvider;
+  },
+) => {
+  const { url, requestId } = options;
+  if (!url) {
+    throw new Error('MCP server url is required');
+  }
+
+  const reduceArrayToLowerCaseKeyedDictionary = (acc: Record<string, string>, { name, value }: RequestHeader) => ({
+    ...acc,
+    [name.toLowerCase() || '']: value || '',
+  });
+  const lowerCasedEnabledHeaders = options.headers
+    .filter(({ name, disabled }) => Boolean(name) && !disabled)
+    .reduce(reduceArrayToLowerCaseKeyedDictionary, {});
+
+  const mcpServerUrl = new URL(url);
+  const transport = new StreamableHTTPClientTransport(mcpServerUrl, {
+    requestInit: {
+      headers: lowerCasedEnabledHeaders,
+    },
+    fetch: (url, init) =>
+      wrappedFetch(url, init || {}, {
+        requestId,
+        responseId,
+        environmentId: responseEnvironmentId,
+        timelinePath,
+        eventLogPath,
+        authProvider,
+      }),
+    reconnectionOptions: {
+      maxReconnectionDelay: 30000,
+      initialReconnectionDelay: 1000,
+      reconnectionDelayGrowFactor: 1.5,
+      maxRetries: 2,
+    },
+  });
+  // transport.onmessage = message => _handleMcpMessage(message, requestId);
+  return transport;
+};
+
+const parseResponseAndBuildTimeline = (requestHeaderLogs: string, response: Response) => {
+  const statusMessage = response.statusText || '';
+  const statusCode = response.status || 0;
+  const responseHeaders: { name: string; value: string }[] = [...response.headers.entries()].map(([name, value]) => ({
+    name,
+    value,
+  }));
+
+  const headersIn = responseHeaders.map(({ name, value }) => `${name}: ${value}`).join('\n');
+  const timeline = [
+    { value: requestHeaderLogs, name: 'HeaderOut', timestamp: Date.now() },
+    { value: `${statusCode} ${statusMessage}`, name: 'HeaderIn', timestamp: Date.now() },
+    { value: headersIn, name: 'HeaderIn', timestamp: Date.now() },
+  ];
+  return { timeline, responseHeaders, statusCode, statusMessage };
+};
+
+// A wrapped fetch method for streamable http to log request and response detail
+const wrappedFetch = async (
+  url: string | URL,
+  init: RequestInit,
+  options: ResponseEventOptions,
+  calledByAuth?: boolean,
+) => {
+  const { requestId, responseId, environmentId, timelinePath, eventLogPath, authProvider } = options;
+  const { method = 'GET' } = init;
+
+  const reqHeader = new Headers(init?.headers || {});
+  const tokens = await authProvider.tokens();
+  if (tokens) {
+    // Keep the same header case as the mcp-ts-sdk: https://github.com/modelcontextprotocol/typescript-sdk/blob/1d475bb3f75674a46d81dba881ea743a763cbc12/src/client/streamableHttp.ts#L175-L178
+    reqHeader.set('Authorization', `Bearer ${tokens.access_token}`);
+    init.headers = reqHeader;
+  }
+
+  const isJsonRequest = reqHeader.get('content-type')?.toLowerCase().includes('application/json');
+  const requestBody = isJsonRequest ? JSON.parse(init.body?.toString() || '{}') : init.body?.toString() || '';
+  const isMcpInitializeRequest = isJsonRequest && isInitializeRequest(requestBody);
+  if (isMcpInitializeRequest) {
+    // Add initial timeline
+    const initialTimelines = [
+      { value: `Preparing request to ${url.toString()}`, name: 'Text', timestamp: Date.now() },
+      { value: `Current time is ${new Date().toISOString()}`, name: 'Text', timestamp: Date.now() },
+    ];
+    initialTimelines.map(t => timelineFileStreams.get(requestId)?.write(JSON.stringify(t) + '\n'));
+  }
+  const requestHeaders: { name: string; value: string }[] = [...reqHeader.entries()].map(([name, value]) => ({
+    name,
+    value,
+  }));
+  const requestMethodLine = `${method.toUpperCase()} ${url} ${isJsonRequest && requestBody?.method ? `\nJSON-RPC Method: ${requestBody.method}` : ''}`;
+  const headersOut = requestHeaders.map(({ name, value }) => `${name}: ${value}`).join('\n');
+  const start = performance.now();
+  const response = await fetch(url, init);
+  const { timeline, responseHeaders, statusCode, statusMessage } = parseResponseAndBuildTimeline(
+    `${requestMethodLine}\n${headersOut}`,
+    response,
+  );
+  timeline.map(t => timelineFileStreams.get(requestId)?.write(JSON.stringify(t) + '\n'));
+
+  if (isMcpInitializeRequest) {
+    // Create response model only for initialize response
+    const responsePatch: Partial<McpResponse> = {
+      _id: responseId,
+      parentId: requestId,
+      environmentId,
+      headers: responseHeaders,
+      url: url.toString(),
+      statusCode,
+      statusMessage,
+      elapsedTime: performance.now() - start,
+      timelinePath,
+      eventLogPath,
+      transportType: TRANSPORT_TYPES.HTTP,
+    };
+    const settings = await models.settings.get();
+    const res = await models.mcpResponse.updateOrCreate(responsePatch, settings.maxHistoryResponses);
+    models.requestMeta.updateOrCreateByParentId(requestId, { activeResponseId: res._id });
+  }
+
+  // Avoid infinite loop, only call auth flow once per request
+  // DELETE method is used to terminate the MCP request, it should not trigger auth flow to keep consistent with the SDK behavior.
+  // See: https://github.com/modelcontextprotocol/typescript-sdk/blob/058b87c163996b31d5cda744085ecf3c13c5c56a/src/client/streamableHttp.ts#L529-L537
+  if (!calledByAuth && statusCode === 401 && method !== 'DELETE') {
+    const resourceMetadataUrl = extractResourceMetadataUrl(response);
+    if (resourceMetadataUrl) {
+      authProvider.saveResourceMetadataUrl(resourceMetadataUrl);
+    }
+
+    const authEvent: McpAuthEventWithoutBase = {
+      type: 'message',
+      method: 'MCP Auth',
+      direction: 'INCOMING',
+      data: {
+        statusCode,
+        statusMessage,
+        resourceMetadataUrl: resourceMetadataUrl?.toString() || null,
+      },
+    };
+    writeEventLogAndNotify(requestId, authEvent);
+
+    let authResult: AuthResult;
+
+    let authPromiseResolve: (authorizationCode: string) => void = () => {};
+    const redirectPromise = new Promise<string>(res => (authPromiseResolve = res));
+    const unsubscribe = authProvider.onRedirectEnd(async (authorizationCode: string) => {
+      // Resolve the promise to continue the auth flow after user has completed authorization in default browser
+      authPromiseResolve(authorizationCode);
+    });
+
+    const authFetchFn = async (url: string | URL, init?: RequestInit) => {
+      const authRequestEvent: McpAuthEventWithoutBase = {
+        type: 'message',
+        method: 'MCP Auth',
+        direction: 'OUTGOING',
+        data: {
+          url: typeof url === 'string' ? url : url.toString(),
+          method: init?.method || 'GET',
+          headers: init?.headers || {},
+          body: init?.body || null,
+        },
+      };
+      writeEventLogAndNotify(requestId, authRequestEvent);
+      const response = await fetch(url, init);
+
+      const authResponseEvent: McpAuthEventWithoutBase = {
+        type: 'message',
+        method: 'MCP Auth',
+        direction: 'INCOMING',
+        data: {
+          statusCode: response.status,
+          statusMessage: response.statusText,
+          body: await response.clone().text(),
+        },
+      };
+      writeEventLogAndNotify(requestId, authResponseEvent);
+
+      return response;
+    };
+
+    try {
+      // Start auth flow
+      authResult = await auth(authProvider, {
+        serverUrl: url,
+        resourceMetadataUrl,
+        fetchFn: authFetchFn,
+      });
+      if (authResult === 'REDIRECT') {
+        // Wait for oauth authorization flow to complete in default browser
+        const authorizationCode = await redirectPromise;
+        // Exchange authorization code for tokens
+        authResult = await auth(authProvider, {
+          serverUrl: url,
+          resourceMetadataUrl,
+          authorizationCode,
+          fetchFn: authFetchFn,
+        });
+      }
+      if (authResult !== 'AUTHORIZED') {
+        throw new UnauthorizedError();
+      }
+      return await wrappedFetch(url, init, options, calledByAuth);
+    } finally {
+      unsubscribe();
+    }
+  }
+  return response;
+};

--- a/packages/insomnia/src/main/mcp/types.ts
+++ b/packages/insomnia/src/main/mcp/types.ts
@@ -89,3 +89,5 @@ export interface OpenMcpHTTPClientConnectionOptions extends CommonMcpOptions {
 }
 
 export type OpenMcpClientConnectionOptions = OpenMcpHTTPClientConnectionOptions | OpenMcpStdioClientConnectionOptions;
+
+export type McpReadyState = 'disconnected' | 'connecting' | 'connected';

--- a/packages/insomnia/src/main/mcp/types.ts
+++ b/packages/insomnia/src/main/mcp/types.ts
@@ -1,0 +1,91 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import type { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { ClientRequest, JSONRPCResponse, Notification } from '@modelcontextprotocol/sdk/types.js';
+import type z from 'zod';
+
+import type { TRANSPORT_TYPES } from '~/models/mcp-request';
+import type { RequestAuthentication, RequestHeader } from '~/models/request';
+
+// Refer the SDK: https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/shared/protocol.ts#L504
+// The Client type has missing transport property
+export type McpClient = Client & { transport: StreamableHTTPClientTransport | StdioClientTransport };
+
+export interface McpRequestOptions {
+  requestId: string;
+  request: ClientRequest;
+  schema: z.ZodType;
+  signal?: AbortSignal;
+}
+
+export interface McpEventBase {
+  _id: string;
+  requestId: string;
+  timestamp: number;
+}
+export interface McpCloseEventWithoutBase {
+  type: 'close';
+  reason: string;
+}
+export interface McpMessageEventWithoutBase {
+  type: 'message';
+  direction: 'INCOMING';
+  data: JSONRPCResponse | {};
+  method: string;
+}
+export type McpMessageEvent = McpEventBase & McpMessageEventWithoutBase;
+export interface McpErrorEventWithoutBase {
+  type: 'error';
+  message: string;
+  error: any;
+}
+export interface McpRequestEventWithoutBase {
+  type: 'message';
+  direction: 'OUTGOING';
+  method: string;
+  data: any;
+}
+export interface McpNotificationEventWithoutBase {
+  type: 'notification';
+  method: string;
+  direction: 'INCOMING';
+  data: Notification;
+}
+export interface McpAuthEventWithoutBase {
+  type: 'message';
+  method: 'MCP Auth';
+  direction: 'OUTGOING' | 'INCOMING';
+  data: Record<string, any>;
+}
+
+export type McpNotificationEvent = McpEventBase & McpNotificationEventWithoutBase;
+export type McpEventWithoutBase =
+  | McpMessageEventWithoutBase
+  | McpRequestEventWithoutBase
+  | McpCloseEventWithoutBase
+  | McpErrorEventWithoutBase
+  | McpNotificationEventWithoutBase
+  | McpAuthEventWithoutBase;
+export type McpEvent = McpEventBase & McpEventWithoutBase;
+
+export interface CommonMcpOptions {
+  requestId: string;
+}
+
+export interface OpenMcpStdioClientConnectionOptions extends CommonMcpOptions {
+  workspaceId: string;
+  // TODO: should rename to command or urlOrCommand
+  url: string;
+  transportType: typeof TRANSPORT_TYPES.STDIO;
+  env: Record<string, string>;
+}
+
+export interface OpenMcpHTTPClientConnectionOptions extends CommonMcpOptions {
+  workspaceId: string;
+  url: string;
+  transportType: typeof TRANSPORT_TYPES.HTTP;
+  headers: RequestHeader[];
+  authentication: RequestAuthentication;
+}
+
+export type OpenMcpClientConnectionOptions = OpenMcpHTTPClientConnectionOptions | OpenMcpStdioClientConnectionOptions;

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -42,14 +42,13 @@ import {
   findNotifications,
   getMcpClient,
   getMcpReadyState,
-  getMcpStateChannel,
   hasRequestResponded,
   mcpConnections,
   mcpServerElicitationRequests,
-  notifyMcpClientStateChange,
   parseAndLogMcpRequest,
   requestIdToResponseIdMap,
   timelineFileStreams,
+  updateMcpConnectionState,
   writeEventLogAndNotify,
 } from '~/main/mcp/common';
 import { McpOAuthClientProvider } from '~/main/mcp/oauth-client-provider';
@@ -83,9 +82,8 @@ const _handleCloseMcpConnection = (requestId: string) => {
   // clear in-memory store
   clearMcpMaps(requestId, 'Closed MCP connection', closeEvent);
 
-  const mcpStateChannel = getMcpStateChannel(requestId);
   // notify renderer process about state change
-  notifyMcpClientStateChange(mcpStateChannel, false);
+  updateMcpConnectionState(requestId, { status: 'disconnected' });
 };
 
 const _handleMcpMessage = (message: JSONRPCMessage, requestId: string) => {
@@ -298,6 +296,20 @@ const createTransportAndConnect = async (
 const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) => {
   const { requestId, workspaceId } = options;
 
+  const currentConnectionState = mcpConnections.get(requestId);
+  if (currentConnectionState) {
+    if (currentConnectionState.status === 'connected') {
+      // close existing connection if any, avoid multiple connections with same requestId
+      await closeMcpConnection({ requestId });
+    } else if (currentConnectionState.status === 'connecting') {
+      // if connecting, should not attempt to create another connection
+      // TODO: should find a way to close the pending connection safely and create a new one instead
+      console.error(`MCP client is already connecting for requestId: ${requestId}`);
+      return;
+    }
+  }
+  updateMcpConnectionState(requestId, { status: 'connecting', client: null });
+
   // create response model and file streams
   const responseId = generateId(mcpResponsePrefix);
   const responsesDir = path.join(process.env['INSOMNIA_DATA_PATH'] || electron.app.getPath('userData'), 'responses');
@@ -336,7 +348,11 @@ const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) 
       },
     },
   );
-  const mcpStateChannel = getMcpStateChannel(requestId);
+  // const mcpStateChannel = getMcpStateChannel(requestId);
+  updateMcpConnectionState(requestId, {
+    status: 'connecting',
+    client: mcpClient as McpClient,
+  });
 
   try {
     await createTransportAndConnect(mcpClient, options, {
@@ -389,11 +405,6 @@ const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) 
     }
   });
 
-  if (mcpConnections.has(requestId)) {
-    // close existing connection if any, avoid multiple connections with same requestId
-    await closeMcpConnection({ requestId });
-  }
-  mcpConnections.set(requestId, mcpClient as McpClient);
   const serverCapabilities = mcpClient.getServerCapabilities();
   const primitivePromises: Promise<any>[] = [];
   // get server primitives if supported
@@ -413,7 +424,7 @@ const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) 
     console.warn('Failed to fetch one or more primitive types from MCP server', error);
   }
   // notify connection ready after capabilities and primitives are fetched
-  notifyMcpClientStateChange(mcpStateChannel, true);
+  updateMcpConnectionState(requestId, { status: 'connected', client: mcpClient as McpClient });
 };
 
 const closeMcpConnection = async (options: CommonMcpOptions) => {

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -1,317 +1,143 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import {
-  auth,
-  type AuthResult,
-  extractResourceMetadataUrl,
-  type OAuthClientProvider,
-  UnauthorizedError,
-} from '@modelcontextprotocol/sdk/client/auth.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {
-  type OAuthClientInformationFull,
-  OAuthClientInformationSchema,
-  type OAuthClientMetadata,
-  type OAuthTokens,
-} from '@modelcontextprotocol/sdk/shared/auth.js';
-import type {
-  CallToolRequest,
-  GetPromptRequest,
-  Notification,
-  ReadResourceRequest,
-} from '@modelcontextprotocol/sdk/types.js';
-import {
-  type ClientRequest,
-  CompatibilityCallToolResultSchema,
-  ElicitResultSchema,
+  CancelledNotificationSchema,
+  ElicitRequestSchema,
   EmptyResultSchema,
-  InitializeRequestSchema,
-  isInitializeRequest,
   JSONRPCErrorSchema,
   type JSONRPCMessage,
   type JSONRPCRequest,
   type JSONRPCResponse,
-  type ListPromptsRequest,
-  type ListResourcesRequest,
   ListRootsRequestSchema,
-  ListRootsResultSchema,
   ServerNotificationSchema,
-  type SubscribeRequest,
-  type UnsubscribeRequest,
 } from '@modelcontextprotocol/sdk/types.js';
-import electron, { BrowserWindow, ipcMain } from 'electron';
-import { shellPath } from 'shell-path';
-import { parse } from 'shell-quote';
+import electron from 'electron';
 import { v4 as uuidV4 } from 'uuid';
-import type { z } from 'zod';
 
-import { getAppVersion, getOauthRedirectUrl, getProductName, REALTIME_EVENTS_CHANNELS } from '~/common/constants';
-import {
-  getMcpMethodFromMessage,
-  METHOD_ELICITATION_CREATE_MESSAGE,
-  METHOD_LIST_ROOTS,
-  METHOD_SUBSCRIBE_RESOURCE,
-  METHOD_UNKNOWN,
-  METHOD_UNSUBSCRIBE_RESOURCE,
-} from '~/common/mcp-utils';
+import { getAppVersion, getProductName, REALTIME_EVENTS_CHANNELS } from '~/common/constants';
+import { getMcpMethodFromMessage, METHOD_NOTIFICATION_CANCELLED } from '~/common/mcp-utils';
 import { generateId } from '~/common/misc';
 import { SegmentEvent, trackSegmentEvent } from '~/main/analytics';
-import { authorizeUserInDefaultBrowser } from '~/main/authorizeUserInDefaultBrowser';
+import {
+  callTool,
+  getPrompt,
+  listPrompts,
+  listResources,
+  listResourceTemplates,
+  listTools,
+  readResource,
+  responseElicitationRequest,
+  sendRootListChangeNotification,
+  subscribeResource,
+  unsubscribeResource,
+} from '~/main/mcp/client-requests';
+import {
+  clearMcpMaps,
+  eventLogFileStreams,
+  findMany,
+  findNotifications,
+  getMcpClient,
+  getMcpReadyState,
+  getMcpStateChannel,
+  hasRequestResponded,
+  mcpConnections,
+  mcpServerElicitationRequests,
+  notifyMcpClientStateChange,
+  parseAndLogMcpRequest,
+  requestIdToResponseIdMap,
+  timelineFileStreams,
+  writeEventLogAndNotify,
+} from '~/main/mcp/common';
+import { McpOAuthClientProvider } from '~/main/mcp/oauth-client-provider';
+import { createStdioTransport } from '~/main/mcp/transport-stdio';
+import { createStreamableHTTPTransport } from '~/main/mcp/transport-streamable-http';
+import type {
+  McpClient,
+  McpErrorEventWithoutBase,
+  McpEventWithoutBase,
+  McpNotificationEventWithoutBase,
+  OpenMcpClientConnectionOptions,
+  OpenMcpHTTPClientConnectionOptions,
+} from '~/main/mcp/types';
 import * as models from '~/models';
-import { type McpRequest, TRANSPORT_TYPES, type TransportType } from '~/models/mcp-request';
-import { type McpResponse, prefix as mcpResponsePrefix } from '~/models/mcp-response';
-import type { RequestAuthentication, RequestHeader } from '~/models/request';
-import { encryptOAuthUrl } from '~/network/o-auth-2/utils';
+import { TRANSPORT_TYPES, type TransportType } from '~/models/mcp-request';
+import { prefix as mcpResponsePrefix } from '~/models/mcp-response';
 import { invariant } from '~/utils/invariant';
 
 import { ipcMainHandle, ipcMainOn } from '../ipc/electron';
 
-// Refer the SDK: https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/shared/protocol.ts#L504
-// The Client type has missing transport property
-type McpClient = Client & { transport: StreamableHTTPClientTransport | StdioClientTransport };
 // Mcp connection and request options
 interface CommonMcpOptions {
   requestId: string;
 }
-type OpenMcpHTTPClientConnectionOptions = CommonMcpOptions & {
-  workspaceId: string;
-  url: string;
-  transportType: typeof TRANSPORT_TYPES.HTTP;
-  headers: RequestHeader[];
-  authentication: RequestAuthentication;
-};
-type OpenMcpStdioClientConnectionOptions = CommonMcpOptions & {
-  workspaceId: string;
-  // TODO: should rename to command or urlOrCommand
-  url: string;
-  transportType: typeof TRANSPORT_TYPES.STDIO;
-  env: Record<string, string>;
-};
-export type OpenMcpClientConnectionOptions = OpenMcpHTTPClientConnectionOptions | OpenMcpStdioClientConnectionOptions;
-const isOpenMcpHTTPClientConnectionOptions = (
-  options: OpenMcpClientConnectionOptions,
-): options is OpenMcpHTTPClientConnectionOptions => {
-  return options.transportType === TRANSPORT_TYPES.HTTP;
-};
-export interface McpRequestOptions {
-  requestId: string;
-  request: ClientRequest;
-  schema: z.ZodType;
-  signal?: AbortSignal;
-}
-interface McpEventBase {
-  _id: string;
-  requestId: string;
-  timestamp: number;
-}
-interface McpCloseEventWithoutBase {
-  type: 'close';
-  reason: string;
-}
-interface McpMessageEventWithoutBase {
-  type: 'message';
-  direction: 'INCOMING';
-  data: JSONRPCResponse | {};
-  method: string;
-}
-export type McpMessageEvent = McpEventBase & McpMessageEventWithoutBase;
-interface McpErrorEventWithoutBase {
-  type: 'error';
-  message: string;
-  error: any;
-}
-interface McpRequestEventWithoutBase {
-  type: 'message';
-  direction: 'OUTGOING';
-  method: string;
-  data: any;
-}
-interface McpNotificationEventWithoutBase {
-  type: 'notification';
-  method: string;
-  direction: 'INCOMING';
-  data: Notification;
-}
-interface McpAuthEventWithoutBase {
-  type: 'message';
-  method: 'MCP Auth';
-  direction: 'OUTGOING' | 'INCOMING';
-  data: Record<string, any>;
-}
-export type McpNotificationEvent = McpEventBase & McpNotificationEventWithoutBase;
-type McpEventWithoutBase =
-  | McpMessageEventWithoutBase
-  | McpRequestEventWithoutBase
-  | McpCloseEventWithoutBase
-  | McpErrorEventWithoutBase
-  | McpNotificationEventWithoutBase
-  | McpAuthEventWithoutBase;
-export type McpEvent = McpEventBase & McpEventWithoutBase;
-interface ResponseEventOptions {
-  responseId: string;
-  requestId: string;
-  environmentId: string | null;
-  timelinePath: string;
-  eventLogPath: string;
-  authProvider: McpOAuthClientProvider;
-}
-
-const eventLogFileStreams = new Map<string, fs.WriteStream>();
-const timelineFileStreams = new Map<string, fs.WriteStream>();
-const requestIdToResponseIdMap = new Map<string, string>();
-
-const protocol = 'mcp';
-const getMcpStateChannel = (requestId: string) => `${protocol}.${requestId}.${REALTIME_EVENTS_CHANNELS.READY_STATE}`;
-const mcpEventIdGenerator = () => `mcp-${uuidV4()}`;
-
-const writeEventLogAndNotify = (
-  requestId: string,
-  data: McpEventWithoutBase,
-  {
-    clearRequestIdMap = false,
-    newLine = true,
-  }: {
-    clearRequestIdMap?: boolean;
-    newLine?: boolean;
-  } = {},
-) => {
-  const eventData: McpEvent = {
-    ...data,
-    _id: mcpEventIdGenerator(),
-    requestId,
-    timestamp: Date.now(),
-  };
-  const stringifiedData = JSON.stringify(eventData);
-  const dataToWrite = newLine ? stringifiedData + '\n' : stringifiedData;
-  eventLogFileStreams.get(requestId)?.write(dataToWrite, () => {
-    // notify all renderers of new event has been received
-    for (const window of BrowserWindow.getAllWindows()) {
-      const resId = requestIdToResponseIdMap.get(requestId);
-      if (resId) {
-        const notifyChannel = `${protocol}.${resId}.${REALTIME_EVENTS_CHANNELS.NEW_EVENT}`;
-        notifyChannel && window.webContents.send(notifyChannel);
-        if (clearRequestIdMap) {
-          // clean up maps after last event has been written to file
-          requestIdToResponseIdMap.delete(requestId);
-        }
-      }
-    }
-  });
-};
-
-export type McpReadyState = 'disconnected' | 'connecting' | 'connected';
-interface ConnectingState {
-  status: 'connecting';
-  client: McpClient | null;
-}
-interface ConnectedState {
-  status: 'connected';
-  client: McpClient;
-}
-interface DisconnectedState {
-  status: 'disconnected';
-}
-
-const mcpConnections = new Map<string, ConnectingState | ConnectedState>();
-
-function _updateMcpConnectionState(
-  requestId: string,
-  state: ConnectingState | ConnectedState | DisconnectedState,
-): void {
-  if (state.status === 'disconnected') {
-    mcpConnections.delete(requestId);
-  } else {
-    mcpConnections.set(requestId, state);
-  }
-  _notifyMcpClientStateChange(getMcpStateChannel(requestId), state.status);
-}
-
-const _getMcpClient = (id: string) => {
-  const mcpConnection = mcpConnections.get(id);
-  invariant(
-    mcpConnection,
-    `No existing MCP client connection found for requestId: ${id}. It might have been disconnected.`,
-  );
-  return mcpConnection.client;
-};
-
-const _getMcpConnectionStatus = (requestId: string): McpReadyState => {
-  const mcpConnection = mcpConnections.get(requestId);
-  return mcpConnection ? mcpConnection.status : 'disconnected';
-};
-
-const _notifyMcpClientStateChange = (channel: string, readyState: McpReadyState) => {
-  for (const window of BrowserWindow.getAllWindows()) {
-    window.webContents.send(channel, readyState);
-  }
-};
-
-const _clearMcpMaps = (requestId: string, timelineMessage: string, event?: McpEventWithoutBase) => {
-  if (event) {
-    writeEventLogAndNotify(requestId, event, {
-      clearRequestIdMap: true,
-    });
-  }
-  eventLogFileStreams.get(requestId)?.end();
-  eventLogFileStreams.delete(requestId);
-  timelineFileStreams
-    .get(requestId)
-    ?.write(JSON.stringify({ value: timelineMessage, name: 'Text', timestamp: Date.now() }) + '\n');
-  timelineFileStreams.get(requestId)?.end();
-  timelineFileStreams.delete(requestId);
-};
 
 const _handleCloseMcpConnection = (requestId: string) => {
-  const closeEvent: McpCloseEventWithoutBase = {
+  const closeEvent: McpEventWithoutBase = {
     type: 'close',
     reason: 'Mcp connection closed',
   };
   // clear in-memory store
-  _clearMcpMaps(requestId, 'Closed MCP connection', closeEvent);
-  _updateMcpConnectionState(requestId, { status: 'disconnected' });
-};
+  clearMcpMaps(requestId, 'Closed MCP connection', closeEvent);
 
-const _handleMcpClientError = (requestId: string, error: Error, prefix?: string) => {
-  const messageEvent: McpErrorEventWithoutBase = {
-    type: 'error',
-    message: prefix || 'Unknown error',
-    error: error.message,
-  };
-  writeEventLogAndNotify(requestId, messageEvent);
-  console.error(`MCP client error for ${requestId}`, error);
+  const mcpStateChannel = getMcpStateChannel(requestId);
+  // notify renderer process about state change
+  notifyMcpClientStateChange(mcpStateChannel, false);
 };
 
 const _handleMcpMessage = (message: JSONRPCMessage, requestId: string) => {
-  let messageEvent: McpMessageEventWithoutBase | McpErrorEventWithoutBase | McpNotificationEventWithoutBase;
+  let messageEvent: McpEventWithoutBase | McpErrorEventWithoutBase | McpNotificationEventWithoutBase;
+  let channel = REALTIME_EVENTS_CHANNELS.NEW_EVENT;
   if (JSONRPCErrorSchema.safeParse(message).success) {
     // Error message
-    const errorDetail = JSONRPCErrorSchema.parse(message).error;
-    let errorMessage = errorDetail.message;
+    const parsedError = JSONRPCErrorSchema.parse(message);
+    const { code: errorCode, message: originErrorMessage, data: errorData } = parsedError.error;
+    let errorMessage = originErrorMessage;
     try {
       // Try to parse error message to JSON if possible
-      errorMessage = JSON.parse(errorMessage);
+      errorMessage = JSON.parse(originErrorMessage);
     } catch (error) {}
-
     messageEvent = {
       type: 'error',
-      error: errorMessage,
-      message: `MCP Error ${errorDetail.code}`,
+      error: {
+        code: errorCode,
+        requestId: parsedError.id,
+        message: errorMessage,
+      },
+      message: `MCP Error ${errorCode}`,
     };
+    if (errorData) {
+      messageEvent.error.data = errorData;
+    }
   } else if (ServerNotificationSchema.safeParse(message).success) {
+    const notificationMethod = getMcpMethodFromMessage(message);
     // Server notification message
     messageEvent = {
       type: 'notification',
       direction: 'INCOMING',
-      method: getMcpMethodFromMessage(message),
+      method: notificationMethod,
       data: ServerNotificationSchema.parse(message),
     };
+    if (notificationMethod === METHOD_NOTIFICATION_CANCELLED) {
+      // Write cancelled notification event to both event and notification channel
+      // This is used to terminate pending server requests waiting for elicitation response
+      writeEventLogAndNotify(
+        requestId,
+        {
+          ...messageEvent,
+          type: 'message',
+        },
+        { channel },
+      );
+    }
+    channel = REALTIME_EVENTS_CHANNELS.MCP_NOTIFICATION;
   } else {
     if ('result' in message && EmptyResultSchema.safeParse(message.result).success) {
       console.info('Ignoring empty result message');
-      // ignore empty result message
+      // ignore empty result message, this is used for resources subscribe and unsubscribe without a formal response schema
       return;
     }
     const method = getMcpMethodFromMessage(message);
@@ -322,32 +148,31 @@ const _handleMcpMessage = (message: JSONRPCMessage, requestId: string) => {
       direction: 'INCOMING',
     };
   }
-  writeEventLogAndNotify(requestId, messageEvent);
+  writeEventLogAndNotify(requestId, messageEvent, { channel });
 };
 
-const parseAndLogMcpRequest = (requestId: string, message: any) => {
-  if (message) {
-    // Add request event
-    let requestMethod = message?.method;
-    if (!requestMethod) {
-      if (ListRootsResultSchema.safeParse(message?.result).success) {
-        requestMethod = METHOD_LIST_ROOTS;
-      } else if (ElicitResultSchema.safeParse(message?.result).success) {
-        requestMethod = METHOD_ELICITATION_CREATE_MESSAGE;
-      } else if (JSONRPCErrorSchema.safeParse(message).success) {
-        requestMethod = 'JSON-RPC Error';
-      } else {
-        requestMethod = METHOD_UNKNOWN;
-      }
-    }
-    const requestEvent: McpRequestEventWithoutBase = {
-      method: requestMethod,
-      type: 'message',
-      direction: 'OUTGOING',
-      data: message,
-    };
-    writeEventLogAndNotify(requestId, requestEvent);
-  }
+const _handleTransportError = (message: JSONRPCRequest, requestId: string, error: Error) => {
+  const messageEvent: McpErrorEventWithoutBase = {
+    type: 'error',
+    message: error.message || 'Transport Error',
+    error: {
+      requestId: message.id,
+      message: error.message || 'Transport Error',
+    },
+  };
+  writeEventLogAndNotify(requestId, messageEvent);
+  console.error(`Transport error for ${requestId}`, error);
+};
+
+const _handleMcpClientError = (requestId: string, error: Error, prefix?: string) => {
+  const errorMessage = error.message || '';
+  const messageEvent: McpEventWithoutBase = {
+    type: 'error',
+    message: prefix || 'Unknown error',
+    error: errorMessage,
+  };
+  writeEventLogAndNotify(requestId, messageEvent);
+  console.error(`MCP client error for ${requestId}`, error);
 };
 
 const createErrorResponse = async ({
@@ -357,7 +182,14 @@ const createErrorResponse = async ({
   timelinePath,
   message,
   transportType,
-}: Omit<ResponseEventOptions, 'authProvider'> & { message: string; transportType: TransportType }) => {
+}: {
+  responseId: string;
+  requestId: string;
+  environmentId: string | null;
+  timelinePath: string;
+  message: string;
+  transportType: TransportType;
+}) => {
   const settings = await models.settings.get();
   const responsePatch = {
     _id: responseId,
@@ -374,506 +206,10 @@ const createErrorResponse = async ({
   models.requestMeta.updateOrCreateByParentId(requestId, { activeResponseId: res._id });
 };
 
-const getInitialTimeline = (url: string) => {
-  return [
-    { value: `Preparing request to ${url}`, name: 'Text', timestamp: Date.now() },
-    { value: `Current time is ${new Date().toISOString()}`, name: 'Text', timestamp: Date.now() },
-  ];
-};
-const parseResponseAndBuildTimeline = (requestHeaderLogs: string, response: Response) => {
-  const statusMessage = response.statusText || '';
-  const statusCode = response.status || 0;
-  const responseHeaders: { name: string; value: string }[] = [...response.headers.entries()].map(([name, value]) => ({
-    name,
-    value,
-  }));
-
-  const headersIn = responseHeaders.map(({ name, value }) => `${name}: ${value}`).join('\n');
-  const timeline = [
-    { value: requestHeaderLogs, name: 'HeaderOut', timestamp: Date.now() },
-    { value: `${statusCode} ${statusMessage}`, name: 'HeaderIn', timestamp: Date.now() },
-    { value: headersIn, name: 'HeaderIn', timestamp: Date.now() },
-  ];
-  return { timeline, responseHeaders, statusCode, statusMessage };
-};
-
-// A wrapped fetch to log request and response details
-const fetchWithLogging = async (
-  url: string | URL,
-  init: RequestInit,
-  options: ResponseEventOptions,
-  calledByAuth?: boolean,
-) => {
-  const { requestId, responseId, environmentId, timelinePath, eventLogPath, authProvider } = options;
-  const { method = 'GET' } = init;
-
-  const reqHeader = new Headers(init?.headers || {});
-  const tokens = await authProvider.tokens();
-  if (tokens) {
-    // Keep the same header case as the mcp-ts-sdk: https://github.com/modelcontextprotocol/typescript-sdk/blob/1d475bb3f75674a46d81dba881ea743a763cbc12/src/client/streamableHttp.ts#L175-L178
-    reqHeader.set('Authorization', `Bearer ${tokens.access_token}`);
-    init.headers = reqHeader;
-  }
-
-  const isJsonRequest = reqHeader.get('content-type')?.toLowerCase().includes('application/json');
-  const requestBody = isJsonRequest ? JSON.parse(init.body?.toString() || '{}') : init.body?.toString() || '';
-  const isMcpInitializeRequest = isJsonRequest && isInitializeRequest(requestBody);
-  if (isMcpInitializeRequest) {
-    // Add initial timeline
-    const initialTimelines = getInitialTimeline(url.toString());
-    initialTimelines.map(t => timelineFileStreams.get(requestId)?.write(JSON.stringify(t) + '\n'));
-  }
-  const requestHeaders: { name: string; value: string }[] = [...reqHeader.entries()].map(([name, value]) => ({
-    name,
-    value,
-  }));
-  const requestMethodLine = `${method.toUpperCase()} ${url} ${isJsonRequest && requestBody?.method ? `\nJSON-RPC Method: ${requestBody.method}` : ''}`;
-  const headersOut = requestHeaders.map(({ name, value }) => `${name}: ${value}`).join('\n');
-  // Log outgoing request
-  parseAndLogMcpRequest(requestId, requestBody);
-
-  const start = performance.now();
-  const response = await fetch(url, init);
-  const { timeline, responseHeaders, statusCode, statusMessage } = parseResponseAndBuildTimeline(
-    `${requestMethodLine}\n${headersOut}`,
-    response,
-  );
-  timeline.map(t => timelineFileStreams.get(requestId)?.write(JSON.stringify(t) + '\n'));
-  if (isMcpInitializeRequest) {
-    // Create response model only for initialize response
-    const responsePatch: Partial<McpResponse> = {
-      _id: responseId,
-      parentId: requestId,
-      environmentId,
-      headers: responseHeaders,
-      url: url.toString(),
-      statusCode,
-      statusMessage,
-      elapsedTime: performance.now() - start,
-      timelinePath,
-      eventLogPath,
-      transportType: TRANSPORT_TYPES.HTTP,
-    };
-    const settings = await models.settings.get();
-    const res = await models.mcpResponse.updateOrCreate(responsePatch, settings.maxHistoryResponses);
-    models.requestMeta.updateOrCreateByParentId(requestId, { activeResponseId: res._id });
-  }
-
-  // Avoid infinite loop, only call auth flow once per request
-  // DELETE method is used to terminate the MCP request, it should not trigger auth flow to keep consistent with the SDK behavior.
-  // See: https://github.com/modelcontextprotocol/typescript-sdk/blob/058b87c163996b31d5cda744085ecf3c13c5c56a/src/client/streamableHttp.ts#L529-L537
-  if (!calledByAuth && statusCode === 401 && method !== 'DELETE') {
-    const resourceMetadataUrl = extractResourceMetadataUrl(response);
-    if (resourceMetadataUrl) {
-      authProvider.saveResourceMetadataUrl(resourceMetadataUrl);
-    }
-
-    const authEvent: McpAuthEventWithoutBase = {
-      type: 'message',
-      method: 'MCP Auth',
-      direction: 'INCOMING',
-      data: {
-        statusCode,
-        statusMessage,
-        resourceMetadataUrl: resourceMetadataUrl?.toString() || null,
-      },
-    };
-    writeEventLogAndNotify(requestId, authEvent);
-
-    let authResult: AuthResult;
-
-    let authPromiseResolve: (authorizationCode: string) => void = () => {};
-    const redirectPromise = new Promise<string>(res => (authPromiseResolve = res));
-    const unsubscribe = authProvider.onRedirectEnd(async (authorizationCode: string) => {
-      // Resolve the promise to continue the auth flow after user has completed authorization in default browser
-      authPromiseResolve(authorizationCode);
-    });
-
-    const authFetchFn = async (url: string | URL, init?: RequestInit) => {
-      const authRequestEvent: McpAuthEventWithoutBase = {
-        type: 'message',
-        method: 'MCP Auth',
-        direction: 'OUTGOING',
-        data: {
-          url: typeof url === 'string' ? url : url.toString(),
-          method: init?.method || 'GET',
-          headers: init?.headers || {},
-          body: init?.body || null,
-        },
-      };
-      writeEventLogAndNotify(requestId, authRequestEvent);
-      const response = await fetch(url, init);
-
-      const authResponseEvent: McpAuthEventWithoutBase = {
-        type: 'message',
-        method: 'MCP Auth',
-        direction: 'INCOMING',
-        data: {
-          statusCode: response.status,
-          statusMessage: response.statusText,
-          body: await response.clone().text(),
-        },
-      };
-      writeEventLogAndNotify(requestId, authResponseEvent);
-
-      return response;
-    };
-
-    try {
-      // Start auth flow
-      authResult = await auth(authProvider, {
-        serverUrl: url,
-        resourceMetadataUrl,
-        fetchFn: authFetchFn,
-      });
-      if (authResult === 'REDIRECT') {
-        // Wait for oauth authorization flow to complete in default browser
-        const authorizationCode = await redirectPromise;
-        // Exchange authorization code for tokens
-        authResult = await auth(authProvider, {
-          serverUrl: url,
-          resourceMetadataUrl,
-          authorizationCode,
-          fetchFn: authFetchFn,
-        });
-
-        // Close the oauth authorization modal after authorization is complete
-        BrowserWindow.getAllWindows().forEach(window => {
-          window.webContents.send('hide-oauth-authorization-modal');
-        });
-      }
-      if (authResult !== 'AUTHORIZED') {
-        throw new UnauthorizedError();
-      }
-      return await fetchWithLogging(url, init, options, calledByAuth);
-    } finally {
-      unsubscribe();
-    }
-  }
-
-  return response;
-};
-
-class McpOAuthClientProvider implements OAuthClientProvider {
-  private _codeVerifier?: string;
-  private _resourceMetadataUrl?: URL;
-  private _redirectEndListener: ((authorizationCode: string) => void) | null = null;
-  constructor(private mcpRequest: McpRequest) {}
-  get redirectUrl() {
-    return getOauthRedirectUrl();
-  }
-  get clientMetadata(): OAuthClientMetadata {
-    return {
-      redirect_uris: [this.redirectUrl],
-      token_endpoint_auth_method: 'none',
-      grant_types: ['authorization_code', 'refresh_token'],
-      response_types: ['code'],
-      client_name: 'Insomnia MCP Client',
-      client_uri: 'https://github.com/Kong/insomnia',
-      scope: 'scope' in this.mcpRequest.authentication ? this.mcpRequest.authentication.scope : undefined,
-    };
-  }
-  private async refreshMcpRequest() {
-    const _mcpRequest = await models.mcpRequest.getById(this.mcpRequest._id);
-    invariant(_mcpRequest, 'MCP Request not found');
-    this.mcpRequest = _mcpRequest;
-  }
-  private isUsingMcpAuthFlow() {
-    const { authentication } = this.mcpRequest;
-    return 'grantType' in authentication && authentication.grantType === 'mcp_auth_flow' && !authentication.disabled;
-  }
-  private async updateAuthentication(auth: Partial<RequestAuthentication>) {
-    await models.mcpRequest.update(this.mcpRequest, {
-      authentication: {
-        ...this.mcpRequest.authentication,
-        ...auth,
-      },
-    });
-    await this.refreshMcpRequest();
-  }
-  // It's called when auth tries to get client information for authorization, use as a starting point for MCP Auth Flow
-  // See: https://github.com/modelcontextprotocol/typescript-sdk/blob/1d475bb3f75674a46d81dba881ea743a763cbc12/src/client/auth.ts#L349
-  async clientInformation() {
-    // If not using MCP Auth Flow, wait for user to confirm in the app UI
-    if (!this.isUsingMcpAuthFlow()) {
-      BrowserWindow.getAllWindows().forEach(window => {
-        window.webContents.send('mcp-auth-confirmation');
-      });
-      await new Promise<void>((resolve, reject) => {
-        ipcMain.once('mcp.authConfirmed', async (_, confirmed: boolean) => {
-          if (!confirmed) {
-            reject(new Error('MCP authorization cancelled by user'));
-          } else {
-            await this.updateAuthentication({
-              type: 'oauth2',
-              grantType: 'mcp_auth_flow',
-              disabled: false,
-            });
-            resolve();
-          }
-        });
-      });
-    }
-
-    if ('clientId' in this.mcpRequest.authentication && this.mcpRequest.authentication.clientId) {
-      return {
-        client_id: this.mcpRequest.authentication.clientId,
-        client_secret: this.mcpRequest.authentication.clientSecret,
-        client_id_issued_at: this.mcpRequest.authentication.clientIdIssuedAt,
-        client_secret_expires_at: this.mcpRequest.authentication.clientSecretExpiresAt,
-      };
-    }
-    return undefined;
-  }
-  async saveClientInformation(clientInformation: OAuthClientInformationFull) {
-    const parsedClientInformation = OAuthClientInformationSchema.parse(clientInformation);
-    await models.mcpRequest.update(this.mcpRequest, {
-      authentication: {
-        ...this.mcpRequest.authentication,
-        clientId: parsedClientInformation.client_id,
-        clientSecret: parsedClientInformation.client_secret,
-        clientIdIssuedAt: parsedClientInformation.client_id_issued_at,
-        clientSecretExpiresAt: parsedClientInformation.client_secret_expires_at,
-      },
-    });
-    await this.refreshMcpRequest();
-  }
-  async tokens(): Promise<OAuthTokens | undefined> {
-    const { authentication } = this.mcpRequest;
-    // Don't return tokens if not using MCP Auth Flow or if disabled
-    if (this.isUsingMcpAuthFlow()) {
-      const token = await models.oAuth2Token.getOrCreateByParentId(this.mcpRequest._id);
-      if (token.accessToken) {
-        return {
-          access_token: token.accessToken,
-          refresh_token: token.refreshToken,
-          id_token: token.identityToken,
-          expires_in: token.expiresAt ? Math.floor(token.expiresAt / 1000) : undefined,
-          token_type: ('tokenPrefix' in authentication && authentication.tokenPrefix) || 'Bearer',
-        };
-      }
-    }
-    return undefined;
-  }
-  async saveTokens(tokens: OAuthTokens) {
-    const token = await models.oAuth2Token.getOrCreateByParentId(this.mcpRequest._id);
-    await models.oAuth2Token.update(token, {
-      accessToken: tokens.access_token,
-      refreshToken: tokens.refresh_token || '',
-      identityToken: tokens.id_token || '',
-      expiresAt: tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : null,
-    });
-    await models.mcpRequest.update(this.mcpRequest, {
-      authentication: {
-        ...this.mcpRequest.authentication,
-        scope: tokens.scope,
-        tokenPrefix: tokens.token_type,
-      },
-    });
-    await this.refreshMcpRequest();
-  }
-  saveResourceMetadataUrl(url: URL | undefined) {
-    this._resourceMetadataUrl = url;
-  }
-  get resourceMetadataUrl() {
-    return this._resourceMetadataUrl;
-  }
-  async redirectToAuthorization(authorizationUrl: URL) {
-    const { relayUrl, decryptOAuthResult } = encryptOAuthUrl(authorizationUrl.toString());
-    BrowserWindow.getAllWindows().forEach(window => {
-      window.webContents.send('show-oauth-authorization-modal', relayUrl);
-    });
-    const redirectedResult = await authorizeUserInDefaultBrowser({
-      url: relayUrl,
-    });
-    const redirectedTo = decryptOAuthResult(redirectedResult);
-    const redirectParams = Object.fromEntries(new URL(redirectedTo).searchParams);
-    const authorizationCode = redirectParams.code;
-    if (!authorizationCode) {
-      throw new Error('Authorization code not found');
-    }
-    await this._redirectEndListener?.(authorizationCode);
-  }
-  onRedirectEnd(listener: (authorizationCode: string) => void) {
-    this._redirectEndListener = listener;
-    return () => {
-      this._redirectEndListener = null;
-    };
-  }
-  async saveCodeVerifier(codeVerifier: string) {
-    this._codeVerifier = codeVerifier;
-  }
-  async codeVerifier() {
-    if (!this._codeVerifier) {
-      throw new Error('Code verifier not set');
-    }
-    return this._codeVerifier;
-  }
-}
-
-const createStreamableHTTPTransport = async (
-  options: OpenMcpHTTPClientConnectionOptions,
-  {
-    responseId,
-    responseEnvironmentId,
-    timelinePath,
-    eventLogPath,
-    authProvider,
-  }: {
-    responseId: string;
-    responseEnvironmentId: string | null;
-    timelinePath: string;
-    eventLogPath: string;
-    authProvider: McpOAuthClientProvider;
-  },
-) => {
-  const { url, requestId } = options;
-  if (!url) {
-    throw new Error('MCP server url is required');
-  }
-
-  const reduceArrayToLowerCaseKeyedDictionary = (acc: Record<string, string>, { name, value }: RequestHeader) => ({
-    ...acc,
-    [name.toLowerCase() || '']: value || '',
-  });
-  const lowerCasedEnabledHeaders = options.headers
-    .filter(({ name, disabled }) => Boolean(name) && !disabled)
-    .reduce(reduceArrayToLowerCaseKeyedDictionary, {});
-
-  const mcpServerUrl = new URL(url);
-  const transport = new StreamableHTTPClientTransport(mcpServerUrl, {
-    requestInit: {
-      headers: lowerCasedEnabledHeaders,
-    },
-    fetch: (url, init) =>
-      fetchWithLogging(url, init || {}, {
-        requestId,
-        responseId,
-        environmentId: responseEnvironmentId,
-        timelinePath,
-        eventLogPath,
-        authProvider,
-      }),
-    reconnectionOptions: {
-      maxReconnectionDelay: 30000,
-      initialReconnectionDelay: 1000,
-      reconnectionDelayGrowFactor: 1.5,
-      maxRetries: 2,
-    },
-  });
-  transport.onmessage = message => _handleMcpMessage(message, requestId);
-  return transport;
-};
-
-const createStdioTransport = async (
-  options: OpenMcpStdioClientConnectionOptions,
-  {
-    responseId,
-    responseEnvironmentId,
-    timelinePath,
-    eventLogPath,
-  }: {
-    responseId: string;
-    responseEnvironmentId: string | null;
-    timelinePath: string;
-    eventLogPath: string;
-  },
-) => {
-  const { url, requestId, env } = options;
-  if (!url) {
-    throw new Error('Command is required for STDIO transport');
-  }
-  const parseResult = parse(url);
-  if (parseResult.find(arg => typeof arg !== 'string')) {
-    throw new Error('Invalid command format');
-  }
-  const [command, ...args] = parseResult as string[];
-
-  const initialTimelines = getInitialTimeline(`STDIO: ${url}`);
-  // Add stdio-specific timeline info
-  initialTimelines.push({
-    value: `Run command: ${url}`,
-    name: 'HeaderOut',
-    timestamp: Date.now(),
-  });
-  const pathEnv = (await shellPath()) || process.env.PATH || '';
-  // Filter out empty keys from env
-  const filteredEnv = Object.fromEntries(Object.entries(env).filter(([key]) => key.trim().length));
-  const finalEnv = {
-    PATH: pathEnv,
-    ...filteredEnv,
-  };
-  const stringifiedEnv = Object.entries(finalEnv)
-    .map(([key, value]) => `${key}=${value}`)
-    .join(' ')
-    .trim();
-  if (stringifiedEnv) {
-    initialTimelines.push({
-      value: `With env: ${stringifiedEnv}`,
-      name: 'HeaderOut',
-      timestamp: Date.now(),
-    });
-  }
-  initialTimelines.map(t => timelineFileStreams.get(requestId)?.write(JSON.stringify(t) + '\n'));
-
-  const start = performance.now();
-  const transport = new StdioClientTransport({
-    command,
-    args,
-    env: finalEnv,
-    stderr: 'pipe',
-  });
-
-  // Capture stderr logs for debugging
-  const stderrStream = transport.stderr;
-  stderrStream?.on('data', (chunk: Buffer) => {
-    const stderrData = chunk.toString().trim();
-    if (!stderrData) return; // Skip empty lines
-
-    // Log stderr output to timeline with appropriate categorization
-    timelineFileStreams.get(requestId)?.write(
-      JSON.stringify({
-        value: stderrData,
-        name: 'HeaderIn',
-        timestamp: Date.now(),
-      }) + '\n',
-    );
-  });
-
-  // Wrap the original send method to log outgoing requests for stdio transport
-  const originalSend = transport.send.bind(transport);
-  transport.send = async (message: JSONRPCRequest) => {
-    const isInitializedMessage = InitializeRequestSchema.safeParse(message).success;
-    // Create response model for initialize message and add process status timeline
-    if (isInitializedMessage) {
-      // Add process started timeline (similar to HTTP response timeline)
-      timelineFileStreams
-        .get(requestId)
-        ?.write(JSON.stringify({ value: 'Process started and ready', name: 'Text', timestamp: Date.now() }) + '\n');
-
-      const responsePatch: Partial<McpResponse> = {
-        _id: responseId,
-        parentId: requestId,
-        environmentId: responseEnvironmentId,
-        url,
-        status: 'success',
-        elapsedTime: performance.now() - start,
-        timelinePath,
-        eventLogPath,
-        transportType: TRANSPORT_TYPES.STDIO,
-      };
-      const settings = await models.settings.get();
-      const res = await models.mcpResponse.updateOrCreate(responsePatch, settings.maxHistoryResponses);
-      models.requestMeta.updateOrCreateByParentId(requestId, { activeResponseId: res._id });
-    }
-    // Log outgoing request
-    parseAndLogMcpRequest(requestId, message);
-
-    return originalSend(message);
-  };
-
-  transport.onmessage = message => _handleMcpMessage(message, requestId);
-  return transport;
+export const isOpenMcpHTTPClientConnectionOptions = (
+  options: OpenMcpClientConnectionOptions,
+): options is OpenMcpHTTPClientConnectionOptions => {
+  return options.transportType === TRANSPORT_TYPES.HTTP;
 };
 
 const createTransportAndConnect = async (
@@ -886,21 +222,50 @@ const createTransportAndConnect = async (
     eventLogPath: string;
   },
 ) => {
+  let transport: StdioClientTransport | StreamableHTTPClientTransport;
+  // Wrap the transport to log messages and errors, must be called before connecting the transport
+  const wrapTransport = () => {
+    const isStdioTransport = connectionOptions.transportType === TRANSPORT_TYPES.STDIO;
+    // Add message handler
+    transport.onmessage = message => _handleMcpMessage(message, connectionOptions.requestId);
+    // Add error handler
+    transport.onerror = _error =>
+      _handleMcpClientError(
+        connectionOptions.requestId,
+        _error,
+        `${isStdioTransport ? 'STDIO' : 'StreamableHTTP '} Transport Error`,
+      );
+    const originalSend = transport.send.bind(transport);
+    transport.send = (message: JSONRPCRequest) => {
+      // Log outgoing request
+      parseAndLogMcpRequest(connectionOptions.requestId, message);
+      return originalSend(message).catch(err => {
+        // Capture transport send error and log as MCP error event
+        _handleTransportError(message, connectionOptions.requestId, err);
+        // Re-throw the error to propagate it to the client caller
+        throw err;
+      });
+    };
+  };
+
   if (!isOpenMcpHTTPClientConnectionOptions(connectionOptions)) {
-    const transport = await createStdioTransport(connectionOptions, options);
+    transport = await createStdioTransport(connectionOptions, options);
+    wrapTransport();
     await mcpClient.connect(transport);
   } else {
     const mcpRequest = await models.mcpRequest.getById(connectionOptions.requestId);
     invariant(mcpRequest, 'MCP Request not found');
 
     const authProvider = new McpOAuthClientProvider(mcpRequest);
-    const transport = await createStreamableHTTPTransport(connectionOptions, {
+    transport = await createStreamableHTTPTransport(connectionOptions, {
       ...options,
       authProvider,
     });
+    wrapTransport();
     // Use a longer timeout for initial connection to allow for auth flow to complete
     await mcpClient.connect(transport, { timeout: 3 * 60 * 1000 });
   }
+
   const mcpRequest = await models.mcpRequest.getById(connectionOptions.requestId);
   invariant(mcpRequest, 'MCP Request not found');
 
@@ -933,21 +298,6 @@ const createTransportAndConnect = async (
 const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) => {
   const { requestId, workspaceId } = options;
 
-  const currentConnectionState = mcpConnections.get(requestId);
-  if (currentConnectionState) {
-    if (currentConnectionState.status === 'connected') {
-      // close existing connection if any, avoid multiple connections with same requestId
-      await closeMcpConnection({ requestId });
-    } else if (currentConnectionState.status === 'connecting') {
-      // if connecting, should not attempt to create another connection
-      // TODO: should find a way to close the pending connection safely and create a new one instead
-      console.error(`MCP client is already connecting for requestId: ${requestId}`);
-      return;
-    }
-  }
-
-  _updateMcpConnectionState(requestId, { status: 'connecting', client: null });
-
   // create response model and file streams
   const responseId = generateId(mcpResponsePrefix);
   const responsesDir = path.join(process.env['INSOMNIA_DATA_PATH'] || electron.app.getPath('userData'), 'responses');
@@ -965,7 +315,7 @@ const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) 
   invariant(environment, 'failed to find environment ' + activeEnvironmentId);
   const responseEnvironmentId = environment ? environment._id : null;
 
-  // create MCP paylod model if not exists
+  // create MCP payload model if not exists
   await models.mcpPayload.getOrCreateByParentIdAndUrl(requestId, options.url);
 
   // create connection
@@ -980,15 +330,13 @@ const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) 
           // declare the client to support list roots
           listChanged: true,
         },
+
+        // declare the client to support elicitation
+        elicitation: {},
       },
     },
   );
-  mcpClient.onerror = _error => _handleMcpClientError(requestId, _error, 'MCP Client Error');
-
-  _updateMcpConnectionState(requestId, {
-    status: 'connecting',
-    client: mcpClient as McpClient,
-  });
+  const mcpStateChannel = getMcpStateChannel(requestId);
 
   try {
     await createTransportAndConnect(mcpClient, options, {
@@ -1005,7 +353,6 @@ const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) 
       responseId,
       environmentId: responseEnvironmentId,
       timelinePath,
-      eventLogPath,
       message: error.message || 'Something went wrong',
       transportType: options.transportType,
     });
@@ -1013,13 +360,40 @@ const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) 
     _handleCloseMcpConnection(requestId);
     return;
   }
-  // Support listing roots
+  // Add roots request handler to indicate the client supports it
   mcpClient.setRequestHandler(ListRootsRequestSchema, async () => {
     const mcpRequest = await models.mcpRequest.getById(requestId);
     invariant(mcpRequest, 'MCP request not found');
     return { roots: mcpRequest.roots };
   });
 
+  // Add elicitation request handler to indicate the client supports it
+  mcpClient.setRequestHandler(ElicitRequestSchema, async (_request, extra) => {
+    return new Promise((resolve, reject) => {
+      const serverRequestId = extra.requestId;
+      const pendingServerRequestResolvers = mcpServerElicitationRequests.get(requestId) || new Map();
+      if (!mcpServerElicitationRequests.has(requestId)) {
+        mcpServerElicitationRequests.set(requestId, pendingServerRequestResolvers);
+      }
+      pendingServerRequestResolvers.set(serverRequestId, { resolve, reject });
+    });
+  });
+
+  mcpClient.setNotificationHandler(CancelledNotificationSchema, notification => {
+    const serverRequestId = notification.params.requestId;
+    // handle server request cancellation
+    const pendingServerRequestResolvers = mcpServerElicitationRequests.get(requestId);
+    if (pendingServerRequestResolvers && pendingServerRequestResolvers.has(serverRequestId)) {
+      console.log('Received server request cancellation notification', serverRequestId);
+      pendingServerRequestResolvers.delete(serverRequestId);
+    }
+  });
+
+  if (mcpConnections.has(requestId)) {
+    // close existing connection if any, avoid multiple connections with same requestId
+    await closeMcpConnection({ requestId });
+  }
+  mcpConnections.set(requestId, mcpClient as McpClient);
   const serverCapabilities = mcpClient.getServerCapabilities();
   const primitivePromises: Promise<any>[] = [];
   // get server primitives if supported
@@ -1039,12 +413,12 @@ const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) 
     console.warn('Failed to fetch one or more primitive types from MCP server', error);
   }
   // notify connection ready after capabilities and primitives are fetched
-  _updateMcpConnectionState(requestId, { status: 'connected', client: mcpClient as McpClient });
+  notifyMcpClientStateChange(mcpStateChannel, true);
 };
 
 const closeMcpConnection = async (options: CommonMcpOptions) => {
   const { requestId } = options;
-  const mcpClient = _getMcpClient(requestId);
+  const mcpClient = getMcpClient(requestId);
   if (mcpClient) {
     try {
       // Only terminate session if transport is StreamableHTTPClientTransport
@@ -1070,148 +444,6 @@ const closeAllMcpConnections = () => {
   }
 };
 
-const findMany = async (options: { responseId: string }): Promise<McpEvent[]> => {
-  const response = await models.mcpResponse.getById(options.responseId);
-  if (!response || !response.eventLogPath) {
-    return [];
-  }
-  const body = await fs.promises.readFile(response.eventLogPath);
-  return (
-    body
-      .toString()
-      .split('\n')
-      .filter(e => e?.trim())
-      // Parse the message
-      .map(e => JSON.parse(e))
-      // Reverse the list of messages so that we get the latest message first
-      .reverse() || []
-  );
-};
-
-const listTools = async (options: CommonMcpOptions) => {
-  const mcpClient = _getMcpClient(options.requestId);
-  if (mcpClient) {
-    const tools = await mcpClient.listTools();
-    return tools;
-  }
-  return null;
-};
-
-const callTool = async (options: CommonMcpOptions & CallToolRequest['params']) => {
-  const { requestId, ...params } = options;
-  const mcpClient = _getMcpClient(requestId);
-  if (mcpClient) {
-    const response = await mcpClient.callTool(params, CompatibilityCallToolResultSchema);
-    trackSegmentEvent(SegmentEvent.mcpToolCalled);
-    return response.content;
-  }
-  return null;
-};
-
-const listPrompts = async (options: CommonMcpOptions & ListPromptsRequest['params']) => {
-  const mcpClient = _getMcpClient(options.requestId);
-  if (mcpClient) {
-    const prompts = await mcpClient.listPrompts();
-    return prompts;
-  }
-  return null;
-};
-
-const getPrompt = async (options: CommonMcpOptions & GetPromptRequest['params']) => {
-  const { requestId, ...params } = options;
-  const mcpClient = _getMcpClient(options.requestId);
-  if (mcpClient) {
-    const prompt = await mcpClient.getPrompt(params);
-    trackSegmentEvent(SegmentEvent.mcpPromptCalled);
-    return prompt;
-  }
-  return null;
-};
-
-const listResources = async (options: CommonMcpOptions & ListResourcesRequest['params']) => {
-  const { requestId, ...params } = options;
-  const mcpClient = _getMcpClient(options.requestId);
-  if (mcpClient) {
-    const resources = await mcpClient.listResources(params);
-    return resources;
-  }
-  return null;
-};
-
-const subscribeResource = async (options: CommonMcpOptions & SubscribeRequest['params']) => {
-  const { requestId, ...params } = options;
-  const mcpClient = _getMcpClient(options.requestId);
-  if (mcpClient) {
-    const result = await mcpClient.subscribeResource(params);
-    // Subscribe resource do not have a formal response schema, so we log it manually
-    const messageEvent: Omit<McpMessageEventWithoutBase, 'data'> & { data: {} } = {
-      type: 'message',
-      method: METHOD_SUBSCRIBE_RESOURCE,
-      data: result,
-      direction: 'INCOMING',
-    };
-    writeEventLogAndNotify(requestId, messageEvent);
-    return result;
-  }
-  return null;
-};
-
-const unsubscribeResource = async (options: CommonMcpOptions & UnsubscribeRequest['params']) => {
-  const { requestId, ...params } = options;
-  const mcpClient = _getMcpClient(options.requestId);
-  if (mcpClient) {
-    const result = await mcpClient.unsubscribeResource(params);
-    // Unsubscribe resource do not have a formal response schema, so we log it manually
-    const messageEvent: Omit<McpMessageEventWithoutBase, 'data'> & { data: {} } = {
-      type: 'message',
-      method: METHOD_UNSUBSCRIBE_RESOURCE,
-      data: result,
-      direction: 'INCOMING',
-    };
-    writeEventLogAndNotify(requestId, messageEvent);
-    return result;
-  }
-  return null;
-};
-
-const listResourceTemplates = async (options: CommonMcpOptions & ListResourcesRequest['params']) => {
-  const { requestId, ...params } = options;
-  const mcpClient = _getMcpClient(requestId);
-  if (mcpClient) {
-    const resourceTemplates = await mcpClient.listResourceTemplates(params);
-    return resourceTemplates;
-  }
-  return null;
-};
-
-const getMcpReadyState = async (options: CommonMcpOptions): Promise<McpReadyState> => {
-  try {
-    return _getMcpConnectionStatus(options.requestId);
-  } catch (error) {
-    return 'disconnected';
-  }
-};
-
-const readResource = async (options: CommonMcpOptions & ReadResourceRequest['params']) => {
-  const { requestId, ...params } = options;
-  const mcpClient = _getMcpClient(requestId);
-  if (mcpClient) {
-    const resource = await mcpClient.readResource(params);
-    trackSegmentEvent(SegmentEvent.mcpResourceRead);
-    return resource;
-  }
-  return null;
-};
-
-const sendRootListChangeNotification = async (options: CommonMcpOptions) => {
-  const mcpClient = _getMcpClient(options.requestId);
-  if (mcpClient) {
-    const result = await mcpClient.sendRootsListChanged();
-    return result;
-  }
-  return null;
-};
-
 export interface McpBridgeAPI {
   connect: typeof openMcpClientConnection;
   close: typeof closeMcpConnection;
@@ -1228,6 +460,10 @@ export interface McpBridgeAPI {
     subscribeResource: typeof subscribeResource;
     unsubscribeResource: typeof unsubscribeResource;
   };
+  client: {
+    responseElicitationRequest: typeof responseElicitationRequest;
+    hasRequestResponded: typeof hasRequestResponded;
+  };
   readyState: {
     getCurrent: typeof getMcpReadyState;
   };
@@ -1236,6 +472,7 @@ export interface McpBridgeAPI {
   };
   event: {
     findMany: typeof findMany;
+    findNotifications: typeof findNotifications;
   };
 }
 
@@ -1266,8 +503,17 @@ export const registerMcpHandlers = () => {
   ipcMainOn('mcp.closeAll', closeAllMcpConnections);
   ipcMainHandle('mcp.readyState', (_, options: Parameters<typeof getMcpReadyState>[0]) => getMcpReadyState(options));
   ipcMainHandle('mcp.event.findMany', (_, options: Parameters<typeof findMany>[0]) => findMany(options));
+  ipcMainHandle('mcp.event.findNotifications', (_, options: Parameters<typeof findNotifications>[0]) =>
+    findNotifications(options),
+  );
   ipcMainHandle('mcp.notification.rootListChange', (_, options: Parameters<typeof sendRootListChangeNotification>[0]) =>
     sendRootListChangeNotification(options),
+  );
+  ipcMainOn('mcp.client.responseElicitationRequest', (_, options: Parameters<typeof responseElicitationRequest>[0]) =>
+    responseElicitationRequest(options),
+  );
+  ipcMainHandle('mcp.client.hasRequestResponded', (_, options: Parameters<typeof hasRequestResponded>[0]) =>
+    hasRequestResponded(options),
   );
 };
 

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -223,16 +223,8 @@ const createTransportAndConnect = async (
   let transport: StdioClientTransport | StreamableHTTPClientTransport;
   // Wrap the transport to log messages and errors, must be called before connecting the transport
   const wrapTransport = () => {
-    const isStdioTransport = connectionOptions.transportType === TRANSPORT_TYPES.STDIO;
     // Add message handler
     transport.onmessage = message => _handleMcpMessage(message, connectionOptions.requestId);
-    // Add error handler
-    transport.onerror = _error =>
-      _handleMcpClientError(
-        connectionOptions.requestId,
-        _error,
-        `${isStdioTransport ? 'STDIO' : 'StreamableHTTP '} Transport Error`,
-      );
     const originalSend = transport.send.bind(transport);
     transport.send = (message: JSONRPCRequest) => {
       // Log outgoing request

--- a/packages/insomnia/src/ui/components/mcp/event-view.tsx
+++ b/packages/insomnia/src/ui/components/mcp/event-view.tsx
@@ -1,9 +1,12 @@
 import fs from 'node:fs';
 
-import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
-import React, { useCallback, useRef } from 'react';
-import { Button } from 'react-aria-components';
+import { CallToolResultSchema, ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { type RJSFSchema, type UiSchema } from '@rjsf/utils';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Button, Toolbar } from 'react-aria-components';
 import { useParams } from 'react-router';
+
+import { InsomniaRjsfForm, type InsomniaRjsfFormHandle } from '~/ui/components/rjsf';
 
 import {
   getPreviewModeName,
@@ -13,7 +16,7 @@ import {
   PREVIEW_MODES,
 } from '../../../common/constants';
 import { METHOD_CALL_TOOL } from '../../../common/mcp-utils';
-import type { McpEvent } from '../../../main/network/mcp';
+import type { McpEvent } from '../../../main/mcp/types';
 import * as models from '../../../models';
 import {
   type McpRequestLoaderData,
@@ -28,17 +31,28 @@ interface Props {
   event: McpEvent;
 }
 
+const uiSchema: UiSchema = {
+  'ui:submitButtonOptions': {
+    norender: true,
+  },
+};
+
 export const MessageEventView = ({ event }: Props) => {
   const { activeRequestMeta, activeResponse } = useRequestLoaderData() as McpRequestLoaderData;
-  const { requestId } = useParams() as { requestId: string };
-  const editorRef = useRef<CodeEditorHandle>(null);
   const filterHistory = activeRequestMeta.responseFilterHistory || [];
   const filter = activeRequestMeta.responseFilter || '';
+  const [formData, setFormData] = useState({});
+  const [isServerRequestResponded, setIsServerRequestResponded] = useState(true);
+  const rjsfFormRef = useRef<InsomniaRjsfFormHandle>(null);
+  const editorRef = useRef<CodeEditorHandle>(null);
+  const { requestId } = useParams() as { requestId: string };
 
   const isErrorEvent = event.type === 'error';
   const isCallToolEvent = event.type === 'message' && event.method === METHOD_CALL_TOOL;
   const eventData = isErrorEvent ? event.error : 'data' in event ? event.data : '';
   const raw = JSON.stringify(eventData);
+  const isElicitationRequest = ElicitRequestSchema.safeParse(eventData).success;
+  const [viewMode, setViewMode] = useState<'raw' | 'form'>('raw');
 
   const handleDownloadResponseBody = useCallback(async () => {
     const { canceled, filePath: outputPath } = await window.dialog.showSaveDialog({
@@ -90,6 +104,19 @@ export const MessageEventView = ({ event }: Props) => {
     patchRequestMeta(requestId, { responseFilterHistory });
   };
 
+  const getElicitationFormSchema = () => {
+    if (ElicitRequestSchema.safeParse(eventData).success) {
+      const parsedElicitRequest = ElicitRequestSchema.parse(eventData);
+      const requestSchema = parsedElicitRequest.params.requestedSchema;
+      return requestSchema;
+    }
+    return {};
+  };
+
+  const handleRjsfFormChange = (formData: any) => {
+    setFormData(formData);
+  };
+
   let pretty = raw;
   try {
     const parsed = JSON.parse(raw);
@@ -122,11 +149,33 @@ export const MessageEventView = ({ event }: Props) => {
     // Can't parse as JSON.
   }
   const previewMode = ('previewMode' in activeRequestMeta && activeRequestMeta.previewMode) || PREVIEW_MODE_SOURCE;
+
+  useEffect(() => {
+    const checkRequestCompleted = async () => {
+      // check if the server request has been responded
+      const hasRequestResponded = await window.main.mcp.client.hasRequestResponded({
+        requestId,
+        serverRequestId: eventData?.id,
+      });
+      if (hasRequestResponded) {
+        setIsServerRequestResponded(true);
+        setViewMode('raw');
+      } else {
+        setIsServerRequestResponded(false);
+        setViewMode('form');
+      }
+    };
+    if (isElicitationRequest) {
+      checkRequestCompleted();
+    }
+  }, [requestId, eventData?.id, isElicitationRequest]);
+
   return (
     <div className="flex h-full flex-col">
-      <div className="box-border flex h-8 flex-row border-b border-gray-300 p-2">
+      <div className="box-border flex h-8 flex-row border-b border-gray-300">
         <Dropdown
           aria-label="Websocket Preview Mode Dropdown"
+          className="p-2"
           triggerButton={
             <Button className="tall">
               {getPreviewModeName(previewMode)}
@@ -142,6 +191,7 @@ export const MessageEventView = ({ event }: Props) => {
                   label={getPreviewModeName(mode, true)}
                   onClick={() => {
                     patchRequestMeta(requestId, { previewMode: mode });
+                    setViewMode('raw');
                     editorRef.current?.setValue(mode === PREVIEW_MODE_FRIENDLY ? pretty : raw);
                   }}
                 />
@@ -157,22 +207,89 @@ export const MessageEventView = ({ event }: Props) => {
             </DropdownItem>
           </DropdownSection>
         </Dropdown>
+        {isElicitationRequest && !isServerRequestResponded && (
+          <Button
+            className={`mx-2 mt-2 px-2 text-[--color-font] outline-none transition-colors duration-300 hover:bg-[--hl-sm] hover:text-[--color-font] focus:bg-[--hl-sm] ${
+              viewMode === 'form' ? 'bg-[--hl-xs] text-[--color-font]' : ''
+            }`}
+            onPress={() => setViewMode('form')}
+          >
+            Elicitation Form
+          </Button>
+        )}
       </div>
-      <div className="flex-grow p-4">
-        <CodeEditor
-          id="mcp-data-preview"
-          hideLineNumbers
-          mode={previewMode === PREVIEW_MODE_RAW ? 'text/plain' : 'text/json'}
-          defaultValue={previewMode === PREVIEW_MODE_FRIENDLY ? pretty : raw}
-          uniquenessKey={event._id}
-          ref={editorRef}
-          filter={filter}
-          updateFilter={handleSetFilter}
-          filterHistory={filterHistory}
-          readOnly
-          autoPrettify
-        />
-      </div>
+      {viewMode === 'raw' ? (
+        <div className="h-full flex-grow p-4">
+          <CodeEditor
+            id="mcp-data-preview"
+            hideLineNumbers
+            mode={previewMode === PREVIEW_MODE_RAW ? 'text/plain' : 'text/json'}
+            defaultValue={previewMode === PREVIEW_MODE_FRIENDLY ? pretty : raw}
+            uniquenessKey={event._id}
+            ref={editorRef}
+            filter={filter}
+            updateFilter={handleSetFilter}
+            filterHistory={filterHistory}
+            readOnly
+            autoPrettify
+          />
+        </div>
+      ) : (
+        <div className="flex flex-grow flex-col overflow-hidden">
+          <div className="h-[calc(100%-var(--line-height-sm))] overflow-auto bg-inherit px-5 py-1">
+            <InsomniaRjsfForm
+              formData={formData}
+              onChange={handleRjsfFormChange}
+              schema={getElicitationFormSchema() as RJSFSchema}
+              uiSchema={uiSchema}
+              ref={rjsfFormRef}
+              showErrorList={false}
+              focusOnFirstError
+            />
+          </div>
+          <Toolbar className="content-box sticky bottom-0 z-10 flex h-[var(--line-height-sm)] flex-shrink-0 gap-3 border-b border-[var(--hl-md)] bg-[var(--color-bg)] px-5 py-2 text-[var(--font-size-sm)]">
+            <Button
+              onPress={() => {
+                if (rjsfFormRef.current?.validate()) {
+                  window.main.mcp.client.responseElicitationRequest({
+                    requestId,
+                    serverRequestId: eventData?.id,
+                    type: 'submit',
+                    content: formData,
+                  });
+                }
+              }}
+              className="rounded-sm bg-[--color-surprise] px-[--padding-md] text-center text-[--color-font-surprise] hover:brightness-75"
+            >
+              Submit
+            </Button>
+            <Button
+              onPress={() =>
+                window.main.mcp.client.responseElicitationRequest({
+                  requestId,
+                  serverRequestId: eventData?.id,
+                  type: 'decline',
+                })
+              }
+              className="rounded-[var(--radius-md)] border border-solid border-[var(--hl-lg)] bg-[var(--color-bg)] px-[var(--padding-md)] text-center"
+            >
+              Decline
+            </Button>
+            <Button
+              onPress={() =>
+                window.main.mcp.client.responseElicitationRequest({
+                  requestId,
+                  serverRequestId: eventData?.id,
+                  type: 'cancel',
+                })
+              }
+              className="rounded-[var(--radius-md)] border border-solid border-[var(--hl-lg)] bg-[var(--color-bg)] px-[var(--padding-md)] text-center"
+            >
+              Cancel
+            </Button>
+          </Toolbar>
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/insomnia/src/ui/components/mcp/mcp-notification-tab.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-notification-tab.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { Button, Input, SearchField } from 'react-aria-components';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 
-import type { McpNotificationEvent } from '~/main/network/mcp';
+import type { McpNotificationEvent } from '~/main/mcp/types';
 import { Icon } from '~/ui/components/icon';
 import { McpEventView } from '~/ui/components/mcp/event-view';
 import { EventLogView } from '~/ui/components/websockets/event-log-view';

--- a/packages/insomnia/src/ui/components/mcp/mcp-pane.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-pane.tsx
@@ -28,7 +28,7 @@ import {
   METHOD_LIST_TOOLS,
 } from '~/common/mcp-utils';
 import { fuzzyMatchAll } from '~/common/misc';
-import type { McpEvent, McpMessageEvent } from '~/main/network/mcp';
+import type { McpEvent, McpMessageEvent } from '~/main/mcp/types';
 import type { McpRequest, McpServerPrimitiveTypes } from '~/models/mcp-request';
 import { useRootLoaderData } from '~/root';
 import { useWorkspaceLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';

--- a/packages/insomnia/src/ui/components/mcp/mcp-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-request-pane.tsx
@@ -7,7 +7,7 @@ import { useLatest } from 'react-use';
 
 import { docsMcpClient } from '~/common/documentation';
 import { buildResourceJsonSchema, fillUriTemplate } from '~/common/mcp-utils';
-import type { McpReadyState } from '~/main/network/mcp';
+import type { McpReadyState } from '~/main/mcp/types';
 import { useWorkspaceLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { Link } from '~/ui/components/base/link';
 import { EnvironmentKVEditor } from '~/ui/components/editors/environment-key-value-editor/key-value-editor';

--- a/packages/insomnia/src/ui/components/mcp/mcp-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-request-pane.tsx
@@ -11,7 +11,6 @@ import type { McpReadyState } from '~/main/network/mcp';
 import { useWorkspaceLoaderData } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { Link } from '~/ui/components/base/link';
 import { EnvironmentKVEditor } from '~/ui/components/editors/environment-key-value-editor/key-value-editor';
-import { Icon } from '~/ui/components/icon';
 import { InsomniaRjsfForm, type InsomniaRjsfFormHandle } from '~/ui/components/rjsf';
 
 import { type AuthTypes } from '../../../common/constants';
@@ -67,7 +66,6 @@ export const McpRequestPane: FC<Props> = ({
 }) => {
   const primitiveId = `${selectedPrimitiveItem?.type}_${selectedPrimitiveItem?.name}`;
   const { activeRequest, activeRequestMeta, requestPayload } = useRequestLoaderData()! as McpRequestLoaderData;
-  const [isCalling, setIsCalling] = useState(false);
   const latestRequestPayloadRef = useLatest(requestPayload);
 
   const { activeProject } = useWorkspaceLoaderData()!;
@@ -135,36 +133,34 @@ export const McpRequestPane: FC<Props> = ({
   );
 
   const handleSend = async () => {
-    rjsfFormRef.current?.validate();
-    try {
-      setIsCalling(true);
-      if (selectedPrimitiveItem?.type === 'tools') {
-        await window.main.mcp.primitive.callTool({
-          name: selectedPrimitiveItem?.name || '',
-          arguments: mcpParams[primitiveId],
-          requestId: requestId,
-        });
-      } else if (selectedPrimitiveItem?.type === 'resources') {
-        await window.main.mcp.primitive.readResource({
-          requestId,
-          uri: selectedPrimitiveItem?.uri || '',
-        });
-      } else if (selectedPrimitiveItem?.type === 'resourceTemplates') {
-        await window.main.mcp.primitive.readResource({
-          requestId,
-          uri: fillUriTemplate(selectedPrimitiveItem.uriTemplate, mcpParams[primitiveId] || {}),
-        });
-      } else if (selectedPrimitiveItem?.type === 'prompts') {
-        await window.main.mcp.primitive.getPrompt({
-          requestId,
-          name: selectedPrimitiveItem?.name || '',
-          arguments: mcpParams[primitiveId],
-        });
+    if (rjsfFormRef.current?.validate()) {
+      try {
+        if (selectedPrimitiveItem?.type === 'tools') {
+          await window.main.mcp.primitive.callTool({
+            name: selectedPrimitiveItem?.name || '',
+            arguments: mcpParams[primitiveId],
+            requestId: requestId,
+          });
+        } else if (selectedPrimitiveItem?.type === 'resources') {
+          await window.main.mcp.primitive.readResource({
+            requestId,
+            uri: selectedPrimitiveItem?.uri || '',
+          });
+        } else if (selectedPrimitiveItem?.type === 'resourceTemplates') {
+          await window.main.mcp.primitive.readResource({
+            requestId,
+            uri: fillUriTemplate(selectedPrimitiveItem.uriTemplate, mcpParams[primitiveId] || {}),
+          });
+        } else if (selectedPrimitiveItem?.type === 'prompts') {
+          await window.main.mcp.primitive.getPrompt({
+            requestId,
+            name: selectedPrimitiveItem?.name || '',
+            arguments: mcpParams[primitiveId],
+          });
+        }
+      } catch (err) {
+        console.warn('MCP primitive call error', err);
       }
-    } catch (err) {
-      console.warn('MCP primitive call error', err);
-    } finally {
-      setIsCalling(false);
     }
   };
 
@@ -308,7 +304,6 @@ export const McpRequestPane: FC<Props> = ({
                           onClick={handleSend}
                           className="rounded bg-[--color-surprise] px-[--padding-md] text-center text-[--color-font-surprise]"
                         >
-                          {isCalling && <Icon className="mr-1 animate-spin" icon="spinner" />}
                           {sendButtonText}
                         </Button>
                       </div>

--- a/packages/insomnia/src/ui/components/mcp/mcp-roots-panel.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-roots-panel.tsx
@@ -2,7 +2,7 @@ import type { Root } from '@modelcontextprotocol/sdk/types.js';
 import { useState } from 'react';
 import { Button, Heading, ListBox, ListBoxItem, Toolbar } from 'react-aria-components';
 
-import type { McpReadyState } from '~/main/network/mcp';
+import type { McpReadyState } from '~/main/mcp/types';
 import type { McpRequest } from '~/models/mcp-request';
 import { PromptButton } from '~/ui/components/base/prompt-button';
 import { useRequestPatcher } from '~/ui/hooks/use-request';

--- a/packages/insomnia/src/ui/components/mcp/mcp-url-bar.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-url-bar.tsx
@@ -4,7 +4,7 @@ import { Button as RaButton, Heading, Radio, RadioGroup } from 'react-aria-compo
 import { useParams } from 'react-router';
 import { useLatest } from 'react-use';
 
-import type { McpReadyState } from '~/main/network/mcp';
+import type { McpReadyState } from '~/main/mcp/types';
 import { type Project } from '~/models/project';
 import type { AuthTypeOAuth2 } from '~/models/request';
 import { _buildBearerHeader } from '~/network/authentication';

--- a/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
@@ -1,13 +1,20 @@
+import type { CancelledNotification } from '@modelcontextprotocol/sdk/types.js';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { format } from 'date-fns';
 import React, { type FC, useEffect, useRef } from 'react';
 import { Cell, Column, Row, Table, TableBody, TableHeader } from 'react-aria-components';
 
 import { HelpTooltip } from '~/ui/components/help-tooltip';
+import { Icon } from '~/ui/components/icon';
 
-import { METHOD_UNKNOWN, NOTIFICATIONS_LIST_CHANGED, unsupportedMethodPrefix } from '../../../common/mcp-utils';
+import {
+  METHOD_NOTIFICATION_CANCELLED,
+  METHOD_UNKNOWN,
+  NOTIFICATIONS_LIST_CHANGED,
+  unsupportedMethodPrefix,
+} from '../../../common/mcp-utils';
+import type { McpEvent, McpMessageEvent } from '../../../main/mcp/types';
 import type { CurlEvent } from '../../../main/network/curl';
-import type { McpEvent } from '../../../main/network/mcp';
 import type { SocketIOEvent } from '../../../main/network/socket-io';
 import type { WebSocketEvent } from '../../../main/network/websocket';
 import { type IconId, SvgIcon } from '../svg-icon';
@@ -23,6 +30,8 @@ interface Props {
   selectionId?: string;
   onSelect: (event: EventTypes) => void;
   autoSelectLatestEvent?: boolean;
+  readyState?: boolean;
+  protocol?: 'curl' | 'webSocket' | 'socketIO' | 'mcp';
 }
 
 const isSocketIOEvent = (event: EventTypes): event is SocketIOEvent => {
@@ -66,7 +75,7 @@ function getIcon(event: EventTypes): IconId {
   }
 }
 
-const getMessage = (event: EventTypes): string | JSX.Element => {
+const getMessage = (event: EventTypes, isLoading: boolean): string | JSX.Element => {
   switch (event.type) {
     case 'message': {
       if (isSocketIOEvent(event)) {
@@ -87,6 +96,7 @@ const getMessage = (event: EventTypes): string | JSX.Element => {
         const isUnsupportedMethod = eventMethod.startsWith(unsupportedMethodPrefix);
         return (
           <div className="flex items-center">
+            {isLoading && <Icon className="mr-2 animate-spin" icon="spinner" />}
             {isUnsupportedMethod && <span className="bg-warning mr-2 rounded-sm px-2 py-1">Unsupported</span>}
             <span className="flex-shrink">{eventMethod.replace(`${unsupportedMethodPrefix}`, '')}</span>
           </div>
@@ -138,7 +148,14 @@ const getMessage = (event: EventTypes): string | JSX.Element => {
   }
 };
 
-export const EventLogView: FC<Props> = ({ events, onSelect, selectionId, autoSelectLatestEvent = false }) => {
+export const EventLogView: FC<Props> = ({
+  events,
+  onSelect,
+  selectionId,
+  autoSelectLatestEvent = false,
+  protocol,
+  readyState,
+}) => {
   const parentRef = useRef<HTMLTableSectionElement>(null);
 
   const virtualizer = useVirtualizer({
@@ -148,6 +165,7 @@ export const EventLogView: FC<Props> = ({ events, onSelect, selectionId, autoSel
     overscan: 30,
     getItemKey: index => events[index]._id,
   });
+  const isMcpEvents = protocol === 'mcp';
 
   useEffect(() => {
     // re-measure the virtualizer when EventLogView mounted, especially when switched in a tab
@@ -189,6 +207,7 @@ export const EventLogView: FC<Props> = ({ events, onSelect, selectionId, autoSel
             items={virtualizer.getVirtualItems()}
           >
             {item => {
+              let isLoading = false;
               const event = events[item.index];
               const isSelectedRow = event._id === selectionId;
               // add focus style when autoSelectLatestEvent is true for the first row
@@ -196,13 +215,41 @@ export const EventLogView: FC<Props> = ({ events, onSelect, selectionId, autoSel
                 isSelectedRow && autoSelectLatestEvent
                   ? 'bg-[--hl-sm] outline-none'
                   : 'focus-within:bg-[--hl-sm] focus:outline-none';
+              if (isMcpEvents && event.type === 'message' && readyState) {
+                // Adding loading indicator if the message has not been responded by the server from json-rpc id
+                const { direction, data } = event;
+                const jsonRPCId = 'id' in data && data.id;
+                const method = (event as McpMessageEvent).method;
+                const isUnsupportedMethod = method.startsWith(unsupportedMethodPrefix);
+                const isErrorRequest = event.data.error;
+                if (jsonRPCId && !isUnsupportedMethod && !isErrorRequest) {
+                  isLoading = !events.find(e => {
+                    if (e.type === 'message') {
+                      const eventMethod = (e as McpMessageEvent).method;
+                      if (eventMethod === METHOD_NOTIFICATION_CANCELLED) {
+                        const eventData = e.data as CancelledNotification;
+                        // find the cancelled notification message indicates cancellation of the request
+                        return e.direction === direction && eventData.params.requestId === jsonRPCId;
+                      }
+                      // find the response message from server with the same json-rpc id but different direction
+                      return (
+                        eventMethod === method && e.direction !== direction && 'id' in e.data && e.data.id === jsonRPCId
+                      );
+                    } else if (e.type === 'error' && e.error && direction === 'OUTGOING') {
+                      // find the error message with the same json-rpc id for all outgoing requests
+                      return e.error?.requestId === jsonRPCId;
+                    }
+                    return false;
+                  });
+                }
+              }
               return (
                 <Row className={`group transition-colors ${rowExtraClasses}`}>
                   <Cell className="whitespace-nowrap border-b border-solid border-[--hl-sm] p-2 text-sm font-medium focus:outline-none group-last-of-type:border-none">
                     <SvgIcon icon={getIcon(event)} />
                   </Cell>
                   <Cell className="whitespace-nowrap border-b border-solid border-[--hl-sm] text-sm font-medium focus:outline-none group-last-of-type:border-none">
-                    {getMessage(event)}
+                    {getMessage(event, isLoading)}
                   </Cell>
                   <Cell className="whitespace-nowrap border-b border-solid border-[--hl-sm] text-sm font-medium focus:outline-none group-last-of-type:border-none">
                     <Timestamp time={event.timestamp} />

--- a/packages/insomnia/src/ui/components/websockets/event-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-view.tsx
@@ -1,9 +1,9 @@
 import fs from 'node:fs';
 
-import React, { type FC, useCallback } from 'react';
+import React, { type FC, useCallback, useRef } from 'react';
 import { useParams } from 'react-router';
 
-import { CodeEditor } from '~/ui/components/.client/codemirror/code-editor';
+import { CodeEditor, type CodeEditorHandle } from '~/ui/components/.client/codemirror/code-editor';
 
 import { PREVIEW_MODE_FRIENDLY, PREVIEW_MODE_RAW, PREVIEW_MODE_SOURCE } from '../../../common/constants';
 import type { CurlEvent, CurlMessageEvent } from '../../../main/network/curl';
@@ -20,6 +20,8 @@ interface Props<T> {
 
 export const MessageEventView: FC<Props<CurlMessageEvent | WebSocketMessageEvent>> = ({ event }) => {
   const { requestId } = useParams() as { requestId: string };
+  const editorRef = useRef<CodeEditorHandle>(null);
+
   let raw = event.data.toString();
   // Best effort to parse the binary data as a string
   try {
@@ -78,7 +80,10 @@ export const MessageEventView: FC<Props<CurlMessageEvent | WebSocketMessageEvent
           download={handleDownloadResponseBody}
           copyToClipboard={handleCopyResponseToClipboard}
           previewMode={previewMode}
-          setPreviewMode={previewMode => patchRequestMeta(requestId, { previewMode })}
+          setPreviewMode={previewMode => {
+            patchRequestMeta(requestId, { previewMode });
+            editorRef.current?.setValue(previewMode === PREVIEW_MODE_FRIENDLY ? pretty : raw);
+          }}
         />
       </div>
       <div className="flex-grow p-4">
@@ -88,6 +93,7 @@ export const MessageEventView: FC<Props<CurlMessageEvent | WebSocketMessageEvent
           mode={previewMode === PREVIEW_MODE_RAW ? 'text/plain' : 'text/json'}
           defaultValue={previewMode === PREVIEW_MODE_FRIENDLY ? pretty : raw}
           uniquenessKey={event._id}
+          ref={editorRef}
           readOnly
         />
       </div>

--- a/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
@@ -5,11 +5,12 @@ import { Button, Input, SearchField, Tab, TabList, TabPanel, Tabs } from 'react-
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 
 import { useMcpReadyState } from '~/ui/hooks/use-mcp-ready-state';
+import { useRealtimeConnectionNotifications } from '~/ui/hooks/use-realtime-connection-notifications';
 
 import { getSetCookieHeaders } from '../../../common/misc';
+import type { McpEvent } from '../../../main/mcp/types';
 import type { CurlEvent } from '../../../main/network/curl';
 import type { ResponseTimelineEntry } from '../../../main/network/libcurl-promise';
-import type { McpEvent } from '../../../main/network/mcp';
 import type { SocketIOEvent } from '../../../main/network/socket-io';
 import type { WebSocketEvent } from '../../../main/network/websocket';
 import { TRANSPORT_TYPES } from '../../../models/mcp-request';
@@ -129,6 +130,7 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { connect
   }, [response]);
 
   const allEvents = useRealtimeConnectionEvents({ responseId: response._id, protocol }) as EventType[];
+  const allNotifications = useRealtimeConnectionNotifications({ responseId: response._id, protocol });
   const handleSelection = (event: EventType) => {
     setSelectedEvent((selected: EventType | null) => (selected?._id === event._id ? null : event));
   };
@@ -152,11 +154,6 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { connect
 
         // Filter out events that don't match the selected event type
         if (eventType && event.type !== eventType) {
-          return false;
-        }
-
-        // Filter out MCP notification events which will show on another tab
-        if (event.type === 'notification') {
           return false;
         }
 
@@ -195,8 +192,6 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { connect
       setSelectedEvent(events[0]);
     }
   }, [events, autoSelectLatestEvent]);
-
-  const notificationEvents = useMemo(() => allEvents.filter(event => event.type === 'notification'), [allEvents]);
 
   useEffect(() => {
     setSelectedEvent(null);
@@ -272,9 +267,9 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { connect
               id="notifications"
             >
               Notifications
-              {notificationEvents.length > 0 && (
+              {allNotifications.length > 0 && (
                 <span className="shadow-small flex aspect-square items-center justify-between overflow-hidden rounded-lg border border-solid border-[--hl-md] p-2 text-xs">
-                  {notificationEvents.length}
+                  {allNotifications.length}
                 </span>
               )}
             </Tab>
@@ -374,6 +369,8 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { connect
                       onSelect={handleSelection}
                       selectionId={selectedEvent?._id}
                       autoSelectLatestEvent
+                      protocol={protocol}
+                      readyState={connected}
                     />
                   )}
                 </Panel>
@@ -391,7 +388,7 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { connect
         </TabPanel>
         {isMcpResponse(response) && (
           <TabPanel className="flex w-full flex-1 flex-col overflow-hidden" id="notifications">
-            <McpNotificationTab allEvents={notificationEvents} />
+            <McpNotificationTab allEvents={allNotifications} />
           </TabPanel>
         )}
         {!isSocketIOResponse(response) && (

--- a/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
@@ -242,7 +242,7 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
           {isLongRunning ? (
             <div
               data-testid="response-status-tag"
-              className={classnames('px-2 py-1 [&::first-letter]:capitalize', {
+              className={classnames('px-2 py-1 capitalize', {
                 'bg-success': readyState === 'connected',
                 'bg-info': readyState === 'connecting',
                 'bg-danger': readyState === 'disconnected',

--- a/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 
+import classnames from 'classnames';
 import React, { type FC, useEffect, useMemo, useState } from 'react';
 import { Button, Input, SearchField, Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
@@ -65,6 +66,7 @@ export const RealtimeResponsePane: FC<{ requestId?: string }> = () => {
 
 type ResponseType = WebSocketResponse | Response | SocketIOResponse | McpResponse;
 type EventType = CurlEvent | WebSocketEvent | SocketIOEvent | McpEvent;
+type ReadyState = 'disconnected' | 'connecting' | 'connected';
 interface RealtimeActiveResponsePaneProps {
   response: ResponseType;
   responses: ResponseType[];
@@ -94,7 +96,7 @@ const RealTimeActiveResponsePaneForMcp: FC<RealtimeActiveResponsePaneProps> = pr
   const { response } = props;
   const requestId = response.parentId;
   const readyState = useMcpReadyState({ requestId });
-  return <RealtimeActiveResponsePane {...props} connected={readyState === 'connected'} />;
+  return <RealtimeActiveResponsePane {...props} readyState={readyState} />;
 };
 
 const RealTimeActiveResponsePaneForOthers: FC<
@@ -103,21 +105,22 @@ const RealTimeActiveResponsePaneForOthers: FC<
   const { response, protocol } = props;
   const requestId = response.parentId;
   const readyState = useReadyState({ requestId, protocol });
-  return <RealtimeActiveResponsePane {...props} connected={readyState} />;
+  return <RealtimeActiveResponsePane {...props} readyState={readyState ? 'connected' : 'disconnected'} />;
 };
 
-const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { connected: boolean }> = ({
+const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readyState: ReadyState }> = ({
   response,
   responses,
   requestVersions,
   autoSelectLatestEvent,
-  connected,
+  readyState,
 }) => {
   const [selectedEvent, setSelectedEvent] = useState<EventType | null>(null);
   const [timeline, setTimeline] = useState<ResponseTimelineEntry[]>([]);
   const [clearEventsBefore, setClearEventsBefore] = useState<number | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [eventType, setEventType] = useState<CurlEvent['type']>();
+  const isConnected = readyState === 'connected';
 
   const protocol = useMemo(() => {
     if (isSocketIOResponse(response)) {
@@ -237,8 +240,15 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { connect
       <PaneHeader className="row-spaced">
         <div className="no-wrap scrollable scrollable--no-bars pad-left">
           {isLongRunning ? (
-            <div data-testid="response-status-tag" className={`${connected ? 'bg-success' : 'bg-danger'} px-2 py-1`}>
-              {connected ? 'Connected' : 'Disconnected'}
+            <div
+              data-testid="response-status-tag"
+              className={classnames('px-2 py-1 [&::first-letter]:capitalize', {
+                'bg-success': readyState === 'connected',
+                'bg-info': readyState === 'connecting',
+                'bg-danger': readyState === 'disconnected',
+              })}
+            >
+              {readyState}
             </div>
           ) : (
             <>
@@ -370,7 +380,7 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { connect
                       selectionId={selectedEvent?._id}
                       autoSelectLatestEvent
                       protocol={protocol}
-                      readyState={connected}
+                      readyState={isConnected}
                     />
                   )}
                 </Panel>

--- a/packages/insomnia/src/ui/hooks/use-mcp-ready-state.ts
+++ b/packages/insomnia/src/ui/hooks/use-mcp-ready-state.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { REALTIME_EVENTS_CHANNELS } from '~/common/constants';
-import type { McpReadyState } from '~/main/network/mcp';
+import type { McpReadyState } from '~/main/mcp/types';
 
 export function useMcpReadyState({ requestId }: { requestId: string }): McpReadyState {
   const [readyState, setReadyState] = useState<McpReadyState>('disconnected');

--- a/packages/insomnia/src/ui/hooks/use-realtime-connection-events.ts
+++ b/packages/insomnia/src/ui/hooks/use-realtime-connection-events.ts
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { REALTIME_EVENTS_CHANNELS } from '~/common/constants';
 
+import type { McpEvent } from '../../main/mcp/types';
 import type { CurlEvent } from '../../main/network/curl';
-import type { McpEvent } from '../../main/network/mcp';
 import type { SocketIOEvent } from '../../main/network/socket-io';
 import type { WebSocketEvent } from '../../main/network/websocket';
 

--- a/packages/insomnia/src/ui/hooks/use-realtime-connection-notifications.ts
+++ b/packages/insomnia/src/ui/hooks/use-realtime-connection-notifications.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { REALTIME_EVENTS_CHANNELS } from '~/common/constants';
+import type { McpEvent } from '~/main/mcp/types';
+
+type McpNotification = Extract<McpEvent, { type: 'notification' }>;
+export function useRealtimeConnectionNotifications({
+  responseId,
+  protocol,
+}: {
+  responseId: string;
+  protocol: 'curl' | 'webSocket' | 'socketIO' | 'mcp';
+}) {
+  const [notifications, setNotifications] = useState<McpNotification[]>([]);
+  const updateEvents = useCallback(async () => {
+    if (protocol === 'mcp') {
+      // only mcp has notifications for now
+      const notifications = await window.main[protocol].event.findNotifications({ responseId });
+      setNotifications(notifications);
+    }
+  }, [protocol, responseId]);
+
+  useEffect(() => {
+    updateEvents();
+  }, [updateEvents]);
+
+  useEffect(() => {
+    // @ts-expect-error -- we use a dynamic channel here
+    const unsubscribe = window.main.on(`${protocol}.${responseId}.${REALTIME_EVENTS_CHANNELS.MCP_NOTIFICATION}`, () => {
+      updateEvents();
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, [protocol, responseId, updateEvents]);
+
+  return notifications;
+}


### PR DESCRIPTION
**Changes**
- Created a standalone mcp directory to encapsulate all MCP protocol-related components.
   - transport-stdio: handles MCP communication over standard I/O.
   - transport-streamable-http: supports MCP over streamable HTTP transport.
   - oauth-client-provider for integrating MCP OAuth client functionality with the existing Insomnia OAuth implementation.
   - common for shared MCP logic and utility functions
   - client-requests to contain all client-side MCP request handling logic.
- Refine MCP message loading status
   - Each MCP message will have a separate loading status
   - Wrap the origin transport send method to log mcp response when requests failed
- MCP events and notification panel will consume data from different hooks to avoid new coming notifications to affect mcp events panel display
- Add MCP [elicitation](https://modelcontextprotocol.io/specification/draft/client/elicitation) support 

Refer [INS-1436](https://konghq.atlassian.net/browse/INS-1436) [INS-1572](https://konghq.atlassian.net/browse/INS-1572)

[INS-1436]: https://konghq.atlassian.net/browse/INS-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INS-1572]: https://konghq.atlassian.net/browse/INS-1572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ