### PR TITLE
fix: support the encrypt auth flow for mcp auth

### DIFF
--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -64,6 +64,7 @@ import * as models from '~/models';
 import { type McpRequest, TRANSPORT_TYPES, type TransportType } from '~/models/mcp-request';
 import { type McpResponse, prefix as mcpResponsePrefix } from '~/models/mcp-response';
 import type { RequestAuthentication, RequestHeader } from '~/models/request';
+import { encryptOAuthUrl } from '~/network/o-auth-2/utils';
 import { invariant } from '~/utils/invariant';
 
 import { ipcMainHandle, ipcMainOn } from '../ipc/electron';
@@ -645,15 +646,17 @@ class McpOAuthClientProvider implements OAuthClientProvider {
     return this._resourceMetadataUrl;
   }
   async redirectToAuthorization(authorizationUrl: URL) {
+    const { relayUrl, decryptOAuthResult } = encryptOAuthUrl(authorizationUrl.toString());
     BrowserWindow.getAllWindows().forEach(window => {
-      window.webContents.send('show-oauth-authorization-modal', authorizationUrl.toString());
+      window.webContents.send('show-oauth-authorization-modal', relayUrl);
     });
-    const redirectedTo = await authorizeUserInDefaultBrowser({
-      url: authorizationUrl.toString(),
+    const redirectedResult = await authorizeUserInDefaultBrowser({
+      url: relayUrl,
     });
     BrowserWindow.getAllWindows().forEach(window => {
-      window.webContents.send('hide-oauth-authorization-modal', authorizationUrl.toString());
+      window.webContents.send('hide-oauth-authorization-modal');
     });
+    const redirectedTo = decryptOAuthResult(redirectedResult);
     const redirectParams = Object.fromEntries(new URL(redirectedTo).searchParams);
     const authorizationCode = redirectParams.code;
     if (!authorizationCode) {

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -4,9 +4,10 @@ import querystring from 'node:querystring';
 import { v4 as uuidv4 } from 'uuid';
 
 import { isMcpRequestId } from '~/models/mcp-request';
+import { encryptOAuthUrl } from '~/network/o-auth-2/utils';
 
 import { version } from '../../../package.json';
-import { getOauthRedirectUrl, getOauthRelayUrl } from '../../common/constants';
+import { getOauthRedirectUrl } from '../../common/constants';
 import { database as db } from '../../common/database';
 import { escapeRegex } from '../../common/misc';
 import * as models from '../../models';
@@ -154,14 +155,7 @@ export const getOAuth2Token = async (
       let redirectedTo: string | null = null;
       if (authentication.useDefaultBrowser) {
         const authCodeUrlStr = authCodeUrl.toString();
-
-        const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
-          modulusLength: 3072,
-          publicKeyEncoding: { type: 'spki', format: 'pem' },
-          privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
-        });
-
-        const relayUrl = `${getOauthRelayUrl()}?authCodeUrl=${encodeURIComponent(authCodeUrlStr)}&publicKey=${encodeURIComponent(publicKey)}`;
+        const { relayUrl, decryptOAuthResult } = encryptOAuthUrl(authCodeUrlStr);
 
         uiEventBus.emit(OAUTH2_AUTHORIZATION_STATUS_CHANGE, {
           status: 'getting_code',
@@ -173,30 +167,8 @@ export const getOAuth2Token = async (
         const result = await window.main.authorizeUserInDefaultBrowser({
           url: relayUrl,
         });
-        if ('redirectUrl' in result) {
-          redirectedTo = result.redirectUrl;
-        } else {
-          const { encryptedRedirectUrl, encryptedKey, iv } = result;
-          const aesKey = crypto.privateDecrypt(
-            {
-              key: privateKey,
-              padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
-              oaepHash: 'sha256',
-            },
-            Buffer.from(encryptedKey, 'base64'),
-          );
-          const encryptedBuf = Buffer.from(encryptedRedirectUrl, 'base64');
-          const authTag = encryptedBuf.slice(encryptedBuf.length - 16);
-          const ciphertext = encryptedBuf.slice(0, encryptedBuf.length - 16);
-          // nosemgrep: javascript.node-crypto.security.gcm-no-tag-length.gcm-no-tag-length
-          const decipher = crypto.createDecipheriv('aes-256-gcm', aesKey, Buffer.from(iv, 'base64'), {
-            authTagLength: 16,
-          });
-          decipher.setAuthTag(authTag);
 
-          const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf-8');
-          redirectedTo = decrypted;
-        }
+        redirectedTo = decryptOAuthResult(result);
       } else {
         redirectedTo = await window.main.authorizeUserInWindow({
           url: authCodeUrl.toString(),

--- a/packages/insomnia/src/network/o-auth-2/utils.ts
+++ b/packages/insomnia/src/network/o-auth-2/utils.ts
@@ -1,0 +1,46 @@
+import crypto from 'node:crypto';
+
+import { getOauthRelayUrl } from '~/common/constants';
+import type { DefaultBrowserRedirectParam } from '~/common/misc';
+
+export const encryptOAuthUrl = (authCodeUrlStr: string) => {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
+    modulusLength: 3072,
+    publicKeyEncoding: { type: 'spki', format: 'pem' },
+    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+  });
+
+  const relayUrl = `${getOauthRelayUrl()}?authCodeUrl=${encodeURIComponent(authCodeUrlStr)}&publicKey=${encodeURIComponent(publicKey)}`;
+
+  const decryptOAuthResult = (result: DefaultBrowserRedirectParam): string => {
+    if ('redirectUrl' in result) {
+      return result.redirectUrl;
+    }
+
+    const { encryptedRedirectUrl, encryptedKey, iv } = result;
+    const aesKey = crypto.privateDecrypt(
+      {
+        key: privateKey,
+        padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+        oaepHash: 'sha256',
+      },
+      Buffer.from(encryptedKey, 'base64'),
+    );
+    const encryptedBuf = Buffer.from(encryptedRedirectUrl, 'base64');
+    const authTag = encryptedBuf.slice(encryptedBuf.length - 16);
+    const ciphertext = encryptedBuf.slice(0, encryptedBuf.length - 16);
+    // nosemgrep: javascript.node-crypto.security.gcm-no-tag-length.gcm-no-tag-length
+    const decipher = crypto.createDecipheriv('aes-256-gcm', aesKey, Buffer.from(iv, 'base64'), {
+      authTagLength: 16,
+    });
+    decipher.setAuthTag(authTag);
+
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf-8');
+    return decrypted;
+  };
+
+  return {
+    relayUrl,
+    decryptOAuthResult,
+  };
+};


### PR DESCRIPTION
## Background

The mcp auth flow depends on the `authorizeUserInDefaultBrowser` but doesn't fit the new encrypt flow.

## Changes

Extract the encrypt flow and adopt into the mcp