### PR TITLE
[INS-1598] fix: remove unnecessary padding from feature list in onboarding view

### DIFF
--- a/packages/insomnia/src/routes/onboarding.$.tsx
+++ b/packages/insomnia/src/routes/onboarding.$.tsx
@@ -56,11 +56,11 @@ const FeatureWizardView = () => {
       <Route
         path="/"
         element={
-          <ul className="grid grid-cols-2 justify-center gap-2">
+          <ul className="grid h-full flex-1 grid-cols-2 content-stretch justify-center gap-2">
             {features.map(feature => (
               <li key={feature.id}>
                 <Link
-                  className="flex h-32 w-full select-none flex-col items-center justify-center gap-2 rounded-sm border border-solid border-[--hl-md] bg-[--hl-xs] p-4 transition-colors hover:bg-[--hl-sm] hover:no-underline"
+                  className="flex h-full w-full select-none flex-col items-center justify-center gap-2 rounded-sm border border-solid border-[--hl-md] bg-[--hl-xs] p-4 transition-colors hover:bg-[--hl-sm] hover:no-underline"
                   to={`/onboarding/${feature.id}`}
                 >
                   <FontAwesomeIcon icon={feature.icon} className="text-xl" />
@@ -81,7 +81,7 @@ const FeatureWizardView = () => {
               key={feature.id}
               path={feature.id}
               element={
-                <div className="relative flex h-96 flex-col gap-4 bg-[--color-bg] p-4 text-left">
+                <div className="relative flex h-full flex-col gap-4 bg-[--color-bg] p-4 text-left">
                   <h1 className="flex justify-between text-lg">
                     <span>{feature.title}</span>
                     <span>

--- a/packages/insomnia/src/routes/onboarding.$.tsx
+++ b/packages/insomnia/src/routes/onboarding.$.tsx
@@ -56,7 +56,7 @@ const FeatureWizardView = () => {
       <Route
         path="/"
         element={
-          <ul className="grid grid-cols-2 justify-center gap-2 p-4">
+          <ul className="grid grid-cols-2 justify-center gap-2">
             {features.map(feature => (
               <li key={feature.id}>
                 <Link


### PR DESCRIPTION
# Overview:

- [x] Removes extra padding from onboarding feature list
- [x] The height of the feature list is the same as the height of the feature preview

| Before | After |
|--------|-------|
| <img width="760" height="650" alt="image" src="https://github.com/user-attachments/assets/da53a6d3-f926-44ed-870b-aaea19e0796c" /> | <img width="757" height="646" alt="image" src="https://github.com/user-attachments/assets/a9a6dced-e022-4436-b99c-4ebffc7364c9" /> |