### PR TITLE
[INS-1598] - fix "see all features" link visibility in onboarding

### DIFF
--- a/packages/insomnia/src/routes/onboarding.$.tsx
+++ b/packages/insomnia/src/routes/onboarding.$.tsx
@@ -146,7 +146,7 @@ const Component = () => {
                 <FeatureWizardView />
               </div>
               <div className="flex shrink-0 items-center justify-between">
-                {location.pathname !== '/onboarding' ? (
+                {location.pathname !== '/onboarding' && location.pathname !== '/onboarding/' ? (
                   <Link className="flex items-center gap-2 px-4 text-sm hover:no-underline" to="/onboarding">
                     <i className="fa fa-border-all" />
                     See all features


### PR DESCRIPTION
# Overview

The "See all features" link is displayed on the initial page because of the trailing slash that is included when using the `href(<route>)` function.