### PR TITLE
fix: redundant update toast

### DIFF
--- a/packages/insomnia/src/main/updates.ts
+++ b/packages/insomnia/src/main/updates.ts
@@ -168,7 +168,6 @@ const _checkForUpdates = (updateUrl: string) => {
     console.log(`[updater] Checking for updates url=${updateUrl}`);
     autoUpdater.setFeedURL({ url: updateUrl });
     autoUpdater.checkForUpdates();
-    showUpdateStatusToast('Up to Date');
   } catch (err) {
     console.warn('[updater] Failed to check for updates:', err.message);
     showUpdateStatusToast('Update Error');


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
<img width="2064" height="1074" alt="image" src="https://github.com/user-attachments/assets/f036abf4-c748-4ff2-b004-451717e1fdbd" />
This `up to date` toast always displays, even if there is a new version.