### PR TITLE
feat: clear all credentials upon logout [INS-1630]

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test:smoke:build": "npm run test:build -w insomnia-smoke-test -- --project=Smoke",
     "test:smoke:package": "npm run test:package -w insomnia-smoke-test -- --project=Smoke",
     "test:crit:package": "npm run test:package -w insomnia-smoke-test -- --project=Critical",
+    "test:crit:dev": "npm run test:dev -w insomnia-smoke-test -- --project=Critical",
     "postinstall": "patch-package && npm run verify-bundle-plugins -w insomnia"
   },
   "devDependencies": {

--- a/packages/insomnia-smoke-test/tests/critical/scratchpad.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/scratchpad.test.ts
@@ -3,6 +3,7 @@ import { test } from '../../playwright/test';
 test('can open scratchpad', async ({ page }) => {
   await page.getByTestId('user-dropdown').click();
   await page.getByText('Log Out').click();
+  await page.getByRole('button', { name: 'Log Out' }).click();
   await page.getByLabel('Use local Scratch Pad').click();
   await page.getByText('Unlock full features').click();
 });

--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -111,7 +111,7 @@ export async function isLoggedIn() {
 }
 
 /** Log out and delete session data */
-export async function logout() {
+export async function logout(clearCredentials = false) {
   const sessionId = await getCurrentSessionId();
   if (sessionId) {
     try {
@@ -128,7 +128,9 @@ export async function logout() {
   }
 
   await _unsetSessionData();
-  await _removeAllCredentials();
+  if (clearCredentials) {
+    await _removeAllCredentials();
+  }
   window.main.loginStateChange();
 }
 
@@ -294,8 +296,8 @@ async function _removeAllCredentials() {
 /*
  * Removes a git repository from the database and unlinks it from a workspace.
  *
- * Clearing only the credentials from the git repo would leave the associated project in a broken
- * state where the user would need to manually reset the git project settings, and that is not
+ * Clearing only the credentials from the git repo would leave the associated workspace in a broken
+ * state where the user would need to manually reset the git repo settings, and that is not
  * immediately apparent in the UI.
  *
  * This way, the user can simply re-connect with their settings.

--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -1,11 +1,13 @@
 import { AI_PLUGIN_NAME, LLM_BACKENDS } from '~/common/constants';
 import { type GitRepository, isGitCredentialsOAuth } from '~/models/git-repository';
+import { EMPTY_GIT_PROJECT_ID } from '~/models/project';
 
 import {
   cloudCredential,
   gitCredentials,
   gitRepository,
   pluginData,
+  project,
   settings,
   userSession,
   workspaceMeta,
@@ -294,18 +296,30 @@ async function _removeAllCredentials() {
 }
 
 /*
- * Removes a git repository from the database and unlinks it from a workspace.
+ * Removes a git repo from the database and unlinks it from associated projects and workspaces.
  *
  * Clearing only the credentials from the git repo would leave the associated workspace in a broken
  * state where the user would need to manually reset the git repo settings, and that is not
  * immediately apparent in the UI.
  *
  * This way, the user can simply re-connect with their settings.
+ *
+ * Almost identical to resetGitRepoAction in main/git-service.ts, but walks through
+ * each model instance individually to clear them all out.
+ *
  */
 async function _removeGitRepository(repo: GitRepository) {
-  const wsMeta = await workspaceMeta.getByGitRepositoryId(repo._id);
-  if (wsMeta) {
-    await workspaceMeta.update(wsMeta, { gitRepositoryId: null });
+  const projects = await project.all();
+  for (const p of projects) {
+    if (project.isGitProject(p) && p.gitRepositoryId === repo._id) {
+      await project.update(p, { gitRepositoryId: EMPTY_GIT_PROJECT_ID });
+    }
+  }
+  const workspaceMetas = await workspaceMeta.all();
+  for (const wsMeta of workspaceMetas) {
+    if (wsMeta.gitRepositoryId === repo._id) {
+      await workspaceMeta.update(wsMeta, { gitRepositoryId: null });
+    }
   }
   await gitRepository.remove(repo);
 }

--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -230,12 +230,13 @@ async function _removeAllCredentials() {
       if ('secretAccessKey' in cred.credentials) {
         removals.push(
           cloudCredential.update(cred, {
-            // is an AWS temporary credential
+            // AWS
             credentials: { ...cred.credentials, secretAccessKey: '', sessionToken: '' },
           }),
         );
         continue;
       }
+      // hashicorp
       if ('access_token' in cred.credentials) {
         removals.push(cloudCredential.update(cred, { credentials: { ...cred.credentials, access_token: '' } }));
         continue;
@@ -244,6 +245,13 @@ async function _removeAllCredentials() {
         removals.push(cloudCredential.update(cred, { credentials: { ...cred.credentials, client_secret: '' } }));
         continue;
       }
+      if ('secret_id' in cred.credentials) {
+        removals.push(
+          cloudCredential.update(cred, { credentials: { ...cred.credentials, secret_id: '', role_id: '' } }),
+        );
+        continue;
+      }
+      // azure
       if ('accessToken' in cred.credentials) {
         removals.push(cloudCredential.update(cred, { credentials: { ...cred.credentials, accessToken: '' } }));
       }
@@ -283,11 +291,19 @@ async function _removeAllCredentials() {
   await Promise.all(removals);
 }
 
+/*
+ * Removes a git repository from the database and unlinks it from a workspace.
+ *
+ * Clearing only the credentials from the git repo would leave the associated project in a broken
+ * state where the user would need to manually reset the git project settings, and that is not
+ * immediately apparent in the UI.
+ *
+ * This way, the user can simply re-connect with their settings.
+ */
 async function _removeGitRepository(repo: GitRepository) {
-  let wsMeta = await workspaceMeta.getByGitRepositoryId(repo._id);
-  while (wsMeta) {
+  const wsMeta = await workspaceMeta.getByGitRepositoryId(repo._id);
+  if (wsMeta) {
     await workspaceMeta.update(wsMeta, { gitRepositoryId: null });
-    wsMeta = await workspaceMeta.getByGitRepositoryId(repo._id);
   }
   await gitRepository.remove(repo);
 }

--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -1,4 +1,15 @@
-import { userSession } from '../models';
+import { AI_PLUGIN_NAME, LLM_BACKENDS } from '~/common/constants';
+import { type GitRepository, isGitCredentialsOAuth } from '~/models/git-repository';
+
+import {
+  cloudCredential,
+  gitCredentials,
+  gitRepository,
+  pluginData,
+  settings,
+  userSession,
+  workspaceMeta,
+} from '../models';
 import { insomniaFetch } from '../ui/insomniaFetch';
 import * as crypt from './crypt';
 
@@ -117,6 +128,7 @@ export async function logout() {
   }
 
   await _unsetSessionData();
+  await _removeAllCredentials();
   window.main.loginStateChange();
 }
 
@@ -193,6 +205,91 @@ async function _unsetSessionData() {
     vaultSalt: '',
     vaultKey: '',
   });
+}
+
+/**
+ * Removes all sensitive data (credentials, keys, tokens, etc.) from disk.
+ *
+ * If any cloud credential is authenticated (key/token provided), it is cleared.
+ *
+ * All Git provider (GitHub, GitLab) credentials are deleted.
+ *
+ * If any custom git repositories are authenticated, the workspace is disconnected and the git
+ * repository is deleted from the database (but it does not remove a checkout from the filesystem).
+ *
+ * If any proxy is authenticated, it is cleared.
+ *
+ * If any LLM provider is authenticated, the API key is removed, and deactivated if active.
+ */
+async function _removeAllCredentials() {
+  const removals: Promise<unknown>[] = [gitCredentials.removeAll()];
+
+  const cloudCredentials = await cloudCredential.all();
+  for (const cred of cloudCredentials) {
+    if ('credentials' in cred) {
+      if ('secretAccessKey' in cred.credentials) {
+        removals.push(
+          cloudCredential.update(cred, {
+            // is an AWS temporary credential
+            credentials: { ...cred.credentials, secretAccessKey: '', sessionToken: '' },
+          }),
+        );
+        continue;
+      }
+      if ('access_token' in cred.credentials) {
+        removals.push(cloudCredential.update(cred, { credentials: { ...cred.credentials, access_token: '' } }));
+        continue;
+      }
+      if ('client_secret' in cred.credentials) {
+        removals.push(cloudCredential.update(cred, { credentials: { ...cred.credentials, client_secret: '' } }));
+        continue;
+      }
+      if ('accessToken' in cred.credentials) {
+        removals.push(cloudCredential.update(cred, { credentials: { ...cred.credentials, accessToken: '' } }));
+      }
+    }
+  }
+
+  for (const backend of LLM_BACKENDS) {
+    const apiKey = await pluginData.getByKey(AI_PLUGIN_NAME, `${backend}.apiKey`);
+    if (apiKey) {
+      removals.push(pluginData.removeByKey(AI_PLUGIN_NAME, `${backend}.apiKey`));
+      if (backend === (await window.main.llm.getActiveBackend())) {
+        removals.push(window.main.llm.clearActiveBackend());
+      }
+    }
+  }
+
+  const customGitRepos = await gitRepository.all();
+  for (const repo of customGitRepos) {
+    if (!repo.credentials) continue; // unauthenticated git repositories need not be removed
+    if (isGitCredentialsOAuth(repo.credentials)) {
+      if (repo.credentials.token) {
+        removals.push(_removeGitRepository(repo));
+      }
+    } else if (repo.credentials.password) {
+      removals.push(_removeGitRepository(repo));
+    }
+  }
+
+  const proxySettings = await settings.get();
+  if (proxySettings.httpProxy?.includes('@')) {
+    removals.push(settings.update(proxySettings, { httpProxy: '' }));
+  }
+  if (proxySettings.httpsProxy?.includes('@')) {
+    removals.push(settings.update(proxySettings, { httpsProxy: '' }));
+  }
+
+  await Promise.all(removals);
+}
+
+async function _removeGitRepository(repo: GitRepository) {
+  let wsMeta = await workspaceMeta.getByGitRepositoryId(repo._id);
+  while (wsMeta) {
+    await workspaceMeta.update(wsMeta, { gitRepositoryId: null });
+    wsMeta = await workspaceMeta.getByGitRepositoryId(repo._id);
+  }
+  await gitRepository.remove(repo);
 }
 
 // TODO: v12 remove this function and getLocalStorageDataFromFileOrigin from main

--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -1,7 +1,5 @@
-import { AI_PLUGIN_NAME, LLM_BACKENDS } from '~/common/constants';
-import { type GitRepository, isGitCredentialsOAuth } from '~/models/git-repository';
-import { EMPTY_GIT_PROJECT_ID } from '~/models/project';
-
+import { AI_PLUGIN_NAME, LLM_BACKENDS } from '../common/constants';
+import { database } from '../common/database';
 import {
   cloudCredential,
   gitCredentials,
@@ -12,6 +10,9 @@ import {
   userSession,
   workspaceMeta,
 } from '../models';
+import { type GitRepository, isGitCredentialsOAuth } from '../models/git-repository';
+import { EMPTY_GIT_PROJECT_ID, type Project } from '../models/project';
+import type { WorkspaceMeta } from '../models/workspace-meta';
 import { insomniaFetch } from '../ui/insomniaFetch';
 import * as crypt from './crypt';
 
@@ -309,17 +310,14 @@ async function _removeAllCredentials() {
  *
  */
 async function _removeGitRepository(repo: GitRepository) {
-  const projects = await project.all();
+  const projects = await database.find<Project>(project.type, { gitRepositoryId: repo._id });
   for (const p of projects) {
-    if (project.isGitProject(p) && p.gitRepositoryId === repo._id) {
-      await project.update(p, { gitRepositoryId: EMPTY_GIT_PROJECT_ID });
-    }
+    await project.update(p, { gitRepositoryId: EMPTY_GIT_PROJECT_ID });
   }
-  const workspaceMetas = await workspaceMeta.all();
+
+  const workspaceMetas = await database.find<WorkspaceMeta>(workspaceMeta.type, { gitRepositoryId: repo._id });
   for (const wsMeta of workspaceMetas) {
-    if (wsMeta.gitRepositoryId === repo._id) {
-      await workspaceMeta.update(wsMeta, { gitRepositoryId: null });
-    }
+    await workspaceMeta.update(wsMeta, { gitRepositoryId: null });
   }
   await gitRepository.remove(repo);
 }

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -77,6 +77,8 @@ export const CHECK_FOR_UPDATES_INTERVAL = 1000 * 60 * 60 * 24;
 
 export const ACCEPTED_NODE_CA_FILE_EXTS = ['.pem', '.crt', '.cer', '.p12'];
 
+export const LLM_BACKENDS = ['gguf', 'claude', 'openai', 'gemini'] as const;
+
 // Available editor key map
 export enum EditorKeyMap {
   default = 'default',

--- a/packages/insomnia/src/main/llm-config-service.ts
+++ b/packages/insomnia/src/main/llm-config-service.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import { app } from 'electron';
 
+import type { LLM_BACKENDS } from '~/common/constants';
 import { SegmentEvent, trackSegmentEvent } from '~/main/analytics';
 import { ipcMainHandle } from '~/main/ipc/electron';
 
@@ -9,7 +10,7 @@ import * as models from '../models';
 
 const LLM_PLUGIN_NAME = 'insomnia-llm';
 
-export type LLMBackend = 'gguf' | 'claude' | 'openai' | 'gemini';
+export type LLMBackend = (typeof LLM_BACKENDS)[number];
 
 export interface LLMConfig {
   backend: LLMBackend;
@@ -116,16 +117,16 @@ export const getAIFeatureEnabled = async (feature: 'aiMockServers' | 'aiCommitMe
   return data?.value === 'true';
 };
 
-export const setAIFeatureEnabled = async (feature: 'aiMockServers' | 'aiCommitMessages', enabled: boolean): Promise<void> => {
+export const setAIFeatureEnabled = async (
+  feature: 'aiMockServers' | 'aiCommitMessages',
+  enabled: boolean,
+): Promise<void> => {
   await models.pluginData.upsertByKey(LLM_PLUGIN_NAME, `feature.${feature}`, String(enabled));
 
-  trackSegmentEvent(
-    enabled ? SegmentEvent.aiFeatureEnabled : SegmentEvent.aiFeatureDisabled,
-    {
-      feature: feature,
-      set_for: "user",
-    }
-  );
+  trackSegmentEvent(enabled ? SegmentEvent.aiFeatureEnabled : SegmentEvent.aiFeatureDisabled, {
+    feature: feature,
+    set_for: 'user',
+  });
 };
 
 export interface LLMConfigServiceAPI {
@@ -150,6 +151,10 @@ export const registerLLMConfigServiceAPI = () => {
   );
   ipcMainHandle('llm.getAllConfigurations', async () => getAllConfigurations());
   ipcMainHandle('llm.getCurrentConfig', async () => getCurrentConfig());
-  ipcMainHandle('llm.getAIFeatureEnabled', async (_, feature: 'aiMockServers' | 'aiCommitMessages') => getAIFeatureEnabled(feature));
-  ipcMainHandle('llm.setAIFeatureEnabled', async (_, feature: 'aiMockServers' | 'aiCommitMessages', enabled: boolean) => setAIFeatureEnabled(feature, enabled));
+  ipcMainHandle('llm.getAIFeatureEnabled', async (_, feature: 'aiMockServers' | 'aiCommitMessages') =>
+    getAIFeatureEnabled(feature),
+  );
+  ipcMainHandle('llm.setAIFeatureEnabled', async (_, feature: 'aiMockServers' | 'aiCommitMessages', enabled: boolean) =>
+    setAIFeatureEnabled(feature, enabled),
+  );
 };

--- a/packages/insomnia/src/models/cloud-credential.ts
+++ b/packages/insomnia/src/models/cloud-credential.ts
@@ -170,3 +170,7 @@ export function getByName(name: string, provider: CloudProviderName) {
 export function all() {
   return db.find<CloudProviderCredential>(type);
 }
+
+export function removeAll() {
+  return db.removeWhere<CloudProviderCredential>(type, {});
+}

--- a/packages/insomnia/src/models/cloud-credential.ts
+++ b/packages/insomnia/src/models/cloud-credential.ts
@@ -170,7 +170,3 @@ export function getByName(name: string, provider: CloudProviderName) {
 export function all() {
   return db.find<CloudProviderCredential>(type);
 }
-
-export function removeAll() {
-  return db.removeWhere<CloudProviderCredential>(type, {});
-}

--- a/packages/insomnia/src/models/git-credentials.ts
+++ b/packages/insomnia/src/models/git-credentials.ts
@@ -66,3 +66,7 @@ export function remove(credentials: GitCredentials) {
 export function all() {
   return db.find<GitCredentials>(type);
 }
+
+export function removeAll() {
+  return db.removeWhere<GitCredentials>(type, {});
+}

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { Button } from 'react-aria-components';
 import {
   href,
+  isRouteErrorResponse,
   Links,
   matchPath,
   Meta,
@@ -12,10 +13,10 @@ import {
   Scripts,
   ScrollRestoration,
   useNavigate,
+  useNavigation,
   useParams,
   useRouteLoaderData,
 } from 'react-router';
-import { isRouteErrorResponse, useNavigation } from 'react-router';
 
 import { EXTERNAL_VAULT_PLUGIN_NAME, isDevelopment } from '~/common/constants';
 import * as models from '~/models';
@@ -115,9 +116,11 @@ export const ErrorBoundary: FC<Route.ErrorBoundaryProps> = ({ error }) => {
           our Github Issues
         </a>
       </p>
-      <div className="p-6 text-[--color-font]">
-        <code className="break-words p-2">{errorMessage}</code>
-      </div>
+      {errorMessage && (
+        <div className="p-6 text-[--color-font]">
+          <code className="break-words p-2">{errorMessage}</code>
+        </div>
+      )}
       <div className="flex items-center gap-2">
         <Button
           className="flex items-center justify-center gap-2 rounded-sm border border-solid border-[--hl-md] px-4 py-1 text-base font-semibold text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"

--- a/packages/insomnia/src/routes/auth.logout.tsx
+++ b/packages/insomnia/src/routes/auth.logout.tsx
@@ -5,14 +5,24 @@ import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/auth.logout';
 
-export async function clientAction(_args: Route.ClientActionArgs) {
-  await logout();
+interface LogoutData {
+  clearCredentials?: boolean;
+}
+
+export async function clientAction({ request }: Route.ClientActionArgs) {
+  const data = (await request.json()) as LogoutData;
+  await logout(data.clearCredentials ?? false);
   return redirect(href('/auth/login'));
 }
 
 export const useLogoutFetcher = createFetcherSubmitHook(
-  submit => () => {
-    return submit({}, { action: href('/auth/logout'), method: 'POST' });
-  },
+  submit =>
+    (data: LogoutData = {}) => {
+      return submit(JSON.stringify(data), {
+        action: href('/auth/logout'),
+        method: 'POST',
+        encType: 'application/json',
+      });
+    },
   clientAction,
 );

--- a/packages/insomnia/src/ui/components/header-user-button.tsx
+++ b/packages/insomnia/src/ui/components/header-user-button.tsx
@@ -5,6 +5,8 @@ import type { CurrentPlan, UserProfileResponse } from '~/models/organization';
 import { useLogoutFetcher } from '~/routes/auth.logout';
 import { Avatar } from '~/ui/components/avatar';
 import { Icon } from '~/ui/components/icon';
+import { showModal } from '~/ui/components/modals';
+import { LogoutModal } from '~/ui/components/modals/logout-modal';
 import { showSettingsModal } from '~/ui/components/modals/settings-modal';
 
 interface UserButtonProps {
@@ -29,7 +31,11 @@ export const HeaderUserButton = ({ user, isMinimal = false }: UserButtonProps) =
           className="focus:outline-none"
           onAction={action => {
             if (action === 'logout') {
-              logoutFetcher.submit();
+              showModal(LogoutModal, {
+                onConfirm: async (clearCredentials: boolean) => {
+                  await logoutFetcher.submit({ clearCredentials });
+                },
+              });
             }
 
             if (action === 'my-profile') {

--- a/packages/insomnia/src/ui/components/modals/logout-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/logout-modal.tsx
@@ -1,0 +1,85 @@
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+
+import type { ModalHandle, ModalProps } from '../base/modal';
+import { Modal } from '../base/modal';
+import { ModalBody } from '../base/modal-body';
+import { ModalFooter } from '../base/modal-footer';
+import { ModalHeader } from '../base/modal-header';
+
+interface State {
+  onConfirm: (clearCredentials: boolean) => Promise<void>;
+  loading?: boolean;
+}
+
+export interface LogoutModalHandle {
+  show: (options: State) => void;
+  hide: () => void;
+}
+
+export const LogoutModal = forwardRef<LogoutModalHandle, ModalProps>((_, ref) => {
+  const modalRef = useRef<ModalHandle>(null);
+  const [state, setState] = useState<State>({
+    onConfirm: async () => {},
+    loading: false,
+  });
+  const [clearCredentials, setClearCredentials] = useState(true);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      hide: () => {
+        modalRef.current?.hide();
+      },
+      show: ({ onConfirm }) => {
+        setState({ onConfirm, loading: false });
+        setClearCredentials(true);
+        modalRef.current?.show();
+      },
+    }),
+    [],
+  );
+
+  const handleConfirm = async () => {
+    await state.onConfirm(clearCredentials);
+    modalRef.current?.hide();
+  };
+
+  const handleCancel = () => {
+    modalRef.current?.hide();
+  };
+
+  return (
+    <Modal ref={modalRef}>
+      <ModalHeader>Log Out</ModalHeader>
+      <ModalBody className="wide pad">
+        <label className="flex items-center gap-2">
+          <input type="checkbox" checked={clearCredentials} onChange={e => setClearCredentials(e.target.checked)} />
+          Delete stored credentials
+        </label>
+        <p className="mt-2 text-sm text-gray-400">
+          This will remove all sensitive data, including <b>cloud provider credentials (AWS, GCP, Azure, HashiCorp)</b>,{' '}
+          <b>GitHub and GitLab provider tokens</b>, <b>authenticated proxies</b>, and <b>AI Provider API keys</b> from
+          your local storage. This will also disconnect authenticated Git repositories from your workspaces.
+        </p>
+      </ModalBody>
+      <ModalFooter>
+        <div className="flex items-center gap-4">
+          <button type="button" className="btn" onClick={handleCancel}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn"
+            disabled={state.loading}
+            style={{ color: 'var(--color-font-danger)', backgroundColor: 'var(--color-danger)' }}
+            onClick={handleConfirm}
+          >
+            Log Out
+          </button>
+        </div>
+      </ModalFooter>
+    </Modal>
+  );
+});
+
+LogoutModal.displayName = 'LogoutModal';

--- a/packages/insomnia/src/ui/modals.tsx
+++ b/packages/insomnia/src/ui/modals.tsx
@@ -10,6 +10,7 @@ import { AskModal } from './components/modals/ask-modal';
 import { CodePromptModal } from './components/modals/code-prompt-modal';
 import { ErrorModal } from './components/modals/error-modal';
 import { GenerateCodeModal } from './components/modals/generate-code-modal';
+import { LogoutModal } from './components/modals/logout-modal';
 import { NunjucksModal } from './components/modals/nunjucks-modal';
 import { PromptModal } from './components/modals/prompt-modal';
 import { RequestRenderErrorModal } from './components/modals/request-render-error-modal';
@@ -58,6 +59,8 @@ const Modals = () => {
         <SyncMergeModal ref={instance => registerModal(instance, 'SyncMergeModal')} />
 
         <UpgradeModal ref={instance => registerModal(instance, 'UpgradeModal')} />
+
+        <LogoutModal ref={instance => registerModal(instance, 'LogoutModal')} />
 
         <OAuthAuthorizationStatusModal />
       </ErrorBoundary>


### PR DESCRIPTION
On logout, prompts the user to confirm these actions:

- Clears any secret values from their respective models (`pluginData`, `cloudCredential`).
- Clears authenticated proxies.
- Removes all Git provider credentials.
- Disconnects custom authenticated git repo configs to spare the user from having to manually reset them.
  - Other repos (GitHub, GitLab) can reconnect via the OAuth flows.