### PR TITLE
feat: Support to cancel separate MCP message

### DIFF
--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -77,6 +77,7 @@ const mcp: McpBridgeAPI = {
   client: {
     responseElicitationRequest: options => ipcRenderer.send('mcp.client.responseElicitationRequest', options),
     hasRequestResponded: options => ipcRenderer.invoke('mcp.client.hasRequestResponded', options),
+    cancelRequest: options => ipcRenderer.invoke('mcp.client.cancelRequest', options),
   },
   event: {
     findMany: options => ipcRenderer.invoke('mcp.event.findMany', options),

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -82,6 +82,7 @@ const mcp: McpBridgeAPI = {
   event: {
     findMany: options => ipcRenderer.invoke('mcp.event.findMany', options),
     findNotifications: options => ipcRenderer.invoke('mcp.event.findNotifications', options),
+    findPendingEvents: options => ipcRenderer.invoke('mcp.event.findPendingEvents', options),
   },
 };
 

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -126,6 +126,7 @@ export type HandleChannels =
   | 'mcp.readyState'
   | 'mcp.event.findMany'
   | 'mcp.event.findNotifications'
+  | 'mcp.event.findPendingEvents'
   | 'mcp.notification.rootListChange'
   | 'mcp.client.hasRequestResponded'
   | 'mcp.client.cancelRequest'

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -128,6 +128,7 @@ export type HandleChannels =
   | 'mcp.event.findNotifications'
   | 'mcp.notification.rootListChange'
   | 'mcp.client.hasRequestResponded'
+  | 'mcp.client.cancelRequest'
   | 'mcp.close';
 
 export const ipcMainHandle = (

--- a/packages/insomnia/src/main/mcp/common.ts
+++ b/packages/insomnia/src/main/mcp/common.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 
 import {
+  type CancelledNotification,
   type ElicitResult,
   ElicitResultSchema,
   JSONRPCErrorSchema,
@@ -10,11 +11,19 @@ import { BrowserWindow } from 'electron';
 import { v4 as uuidV4 } from 'uuid';
 
 import { REALTIME_EVENTS_CHANNELS } from '~/common/constants';
-import { METHOD_ELICITATION_CREATE_MESSAGE, METHOD_LIST_ROOTS, METHOD_UNKNOWN } from '~/common/mcp-utils';
+import {
+  METHOD_ELICITATION_CREATE_MESSAGE,
+  METHOD_LIST_ROOTS,
+  METHOD_NOTIFICATION_CANCELLED,
+  METHOD_SAMPLING_CREATE_MESSAGE,
+  METHOD_UNKNOWN,
+  unsupportedMethodPrefix,
+} from '~/common/mcp-utils';
 import type {
   CommonMcpOptions,
   McpClient,
   McpEvent,
+  McpEventDirection,
   McpEventWithoutBase,
   McpNotificationEvent,
   McpReadyState,
@@ -40,6 +49,10 @@ export const mcpConnections = new Map<string, ConnectingState | ConnectedState>(
 export const eventLogFileStreams = new Map<string, fs.WriteStream>();
 export const timelineFileStreams = new Map<string, fs.WriteStream>();
 export const requestIdToResponseIdMap = new Map<string, string>();
+export const pendingMcpRequestEventIds = new Map<
+  string,
+  { jsonRPCId: string; eventId: string; direction: McpEventDirection }[]
+>();
 // map to save server elicitation requests
 export const mcpServerElicitationRequests = new Map<
   string,
@@ -106,6 +119,52 @@ export const writeEventLogAndNotify = (
       }
     }
   });
+  const responseId = requestIdToResponseIdMap.get(requestId) || '';
+  const pendingEventIds = pendingMcpRequestEventIds.get(responseId);
+  if (pendingEventIds) {
+    const removePendingEvent = (condition: (value: { jsonRPCId: string; direction: McpEventDirection }) => unknown) => {
+      if (pendingEventIds.length > 0) {
+        const index = pendingEventIds.findIndex(condition);
+        if (index !== -1) {
+          pendingEventIds.splice(index, 1);
+        }
+      }
+    };
+
+    if (eventData.type === 'message') {
+      const { direction, data } = eventData;
+      const jsonRPCId = 'id' in data && data.id;
+      const eventMethod = eventData.method;
+      const isUnsupportedMethod = eventMethod.startsWith(unsupportedMethodPrefix);
+      const isErrorRequest = 'error' in data && data.error;
+      const isServerRequest =
+        eventMethod === METHOD_ELICITATION_CREATE_MESSAGE || eventMethod === METHOD_SAMPLING_CREATE_MESSAGE;
+      if (eventMethod === METHOD_NOTIFICATION_CANCELLED) {
+        // find the cancelled notification message indicates cancellation of the request
+        removePendingEvent(e => e.jsonRPCId === (data as CancelledNotification).params.requestId);
+      } else if (jsonRPCId && !isUnsupportedMethod && !isErrorRequest) {
+        if (direction === 'OUTGOING') {
+          if (isServerRequest) {
+            removePendingEvent(e => e.jsonRPCId === jsonRPCId && e.direction === 'INCOMING');
+          } else {
+            // Track mcp client outgoing requests
+            pendingEventIds.push({ jsonRPCId, eventId: eventData._id, direction });
+          }
+        } else if (direction === 'INCOMING') {
+          if (isServerRequest) {
+            // Track mcp server incoming requests
+            pendingEventIds.push({ jsonRPCId, eventId: eventData._id, direction });
+          } else {
+            removePendingEvent(e => e.jsonRPCId === jsonRPCId && e.direction === 'OUTGOING');
+          }
+        }
+      }
+    } else if (eventData.type === 'error' && eventData.error?.requestId) {
+      const errorRequestId = eventData.error.requestId;
+      // Remove pending event from map on error response from server
+      removePendingEvent(e => e.jsonRPCId === errorRequestId);
+    }
+  }
 };
 
 export const notifyMcpClientStateChange = (channel: string, value?: McpReadyState) => {
@@ -152,6 +211,7 @@ export const clearMcpMaps = (requestId: string, timelineMessage: string, event?:
     ?.write(JSON.stringify({ value: timelineMessage, name: 'Text', timestamp: Date.now() }) + '\n');
   timelineFileStreams.get(requestId)?.end();
   timelineFileStreams.delete(requestId);
+  pendingMcpRequestEventIds.delete(requestId);
   mcpServerElicitationRequests.delete(requestId);
 };
 
@@ -179,6 +239,14 @@ export const findMany = async (options: { responseId: string }): Promise<McpEven
 
 export const findNotifications = async (options: { responseId: string }): Promise<McpNotificationEvent[]> => {
   return (await getAllEvents(options)).filter(e => e.type === 'notification') as McpNotificationEvent[];
+};
+
+export const findPendingEvents = async (options: { responseId: string }): Promise<string[]> => {
+  const pendingEventIds = pendingMcpRequestEventIds.get(options.responseId);
+  if (pendingEventIds) {
+    return pendingEventIds.map(e => e.eventId);
+  }
+  return [];
 };
 
 export const getMcpReadyState = async (options: CommonMcpOptions) => {

--- a/packages/insomnia/src/main/mcp/common.ts
+++ b/packages/insomnia/src/main/mcp/common.ts
@@ -45,6 +45,8 @@ export const mcpServerElicitationRequests = new Map<
   string,
   Map<string | number, { resolve: (value: ElicitResult) => void; reject: (reason?: any) => void }>
 >();
+// map to save abort controllers for each MCP request
+export const mcpRequestAbortControllers = new Map<string, Map<string, AbortController>>();
 
 const mcpEventIdGenerator = () => `mcp-${uuidV4()}`;
 export const getMcpStateChannel = (requestId: string) =>
@@ -198,4 +200,35 @@ export const hasRequestResponded = async ({
     return !pendingServerRequestResolvers.has(serverRequestId);
   }
   return hasResponded;
+};
+
+export const setAbortControllerForMcpRequest = (options: { messageId: string } & CommonMcpOptions) => {
+  const { requestId, messageId } = options;
+  const abortControllersForRequest = mcpRequestAbortControllers.get(requestId) || new Map();
+  if (!mcpRequestAbortControllers.has(requestId)) {
+    mcpRequestAbortControllers.set(requestId, abortControllersForRequest);
+  }
+  const abortController = new AbortController();
+  abortControllersForRequest.set(messageId, abortController);
+  return abortController;
+};
+
+export const clearAbortControllerForMcpRequest = (options: { messageId: string } & CommonMcpOptions) => {
+  const { requestId, messageId } = options;
+  const abortControllersForRequest = mcpRequestAbortControllers.get(requestId);
+  if (abortControllersForRequest) {
+    abortControllersForRequest.delete(messageId);
+  }
+};
+
+export const cancelRequest = async (options: { messageId: string } & CommonMcpOptions) => {
+  const { requestId, messageId } = options;
+  const abortControllersForRequest = mcpRequestAbortControllers.get(requestId);
+  if (abortControllersForRequest) {
+    const abortController = abortControllersForRequest.get(messageId);
+    if (abortController) {
+      abortController.abort();
+      abortControllersForRequest.delete(messageId);
+    }
+  }
 };

--- a/packages/insomnia/src/main/mcp/common.ts
+++ b/packages/insomnia/src/main/mcp/common.ts
@@ -119,8 +119,7 @@ export const writeEventLogAndNotify = (
       }
     }
   });
-  const responseId = requestIdToResponseIdMap.get(requestId) || '';
-  const pendingEventIds = pendingMcpRequestEventIds.get(responseId);
+  const pendingEventIds = pendingMcpRequestEventIds.get(requestId);
   if (pendingEventIds) {
     const removePendingEvent = (condition: (value: { jsonRPCId: string; direction: McpEventDirection }) => unknown) => {
       if (pendingEventIds.length > 0) {
@@ -133,7 +132,7 @@ export const writeEventLogAndNotify = (
 
     if (eventData.type === 'message') {
       const { direction, data } = eventData;
-      const jsonRPCId = 'id' in data && data.id;
+      const jsonRPCId = 'id' in data ? data.id : null;
       const eventMethod = eventData.method;
       const isUnsupportedMethod = eventMethod.startsWith(unsupportedMethodPrefix);
       const isErrorRequest = 'error' in data && data.error;
@@ -142,7 +141,7 @@ export const writeEventLogAndNotify = (
       if (eventMethod === METHOD_NOTIFICATION_CANCELLED) {
         // find the cancelled notification message indicates cancellation of the request
         removePendingEvent(e => e.jsonRPCId === (data as CancelledNotification).params.requestId);
-      } else if (jsonRPCId && !isUnsupportedMethod && !isErrorRequest) {
+      } else if (jsonRPCId !== null && !isUnsupportedMethod && !isErrorRequest) {
         if (direction === 'OUTGOING') {
           if (isServerRequest) {
             removePendingEvent(e => e.jsonRPCId === jsonRPCId && e.direction === 'INCOMING');
@@ -212,6 +211,7 @@ export const clearMcpMaps = (requestId: string, timelineMessage: string, event?:
   timelineFileStreams.get(requestId)?.end();
   timelineFileStreams.delete(requestId);
   pendingMcpRequestEventIds.delete(requestId);
+  mcpRequestAbortControllers.delete(requestId);
   mcpServerElicitationRequests.delete(requestId);
 };
 
@@ -241,8 +241,8 @@ export const findNotifications = async (options: { responseId: string }): Promis
   return (await getAllEvents(options)).filter(e => e.type === 'notification') as McpNotificationEvent[];
 };
 
-export const findPendingEvents = async (options: { responseId: string }): Promise<string[]> => {
-  const pendingEventIds = pendingMcpRequestEventIds.get(options.responseId);
+export const findPendingEvents = async (options: CommonMcpOptions): Promise<string[]> => {
+  const pendingEventIds = pendingMcpRequestEventIds.get(options.requestId);
   if (pendingEventIds) {
     return pendingEventIds.map(e => e.eventId);
   }

--- a/packages/insomnia/src/main/mcp/types.ts
+++ b/packages/insomnia/src/main/mcp/types.ts
@@ -91,3 +91,4 @@ export interface OpenMcpHTTPClientConnectionOptions extends CommonMcpOptions {
 export type OpenMcpClientConnectionOptions = OpenMcpHTTPClientConnectionOptions | OpenMcpStdioClientConnectionOptions;
 
 export type McpReadyState = 'disconnected' | 'connecting' | 'connected';
+export type McpEventDirection = 'INCOMING' | 'OUTGOING';

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -318,7 +318,7 @@ const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) 
   const timelinePath = path.join(responsesDir, responseId + '.timeline');
   timelineFileStreams.set(requestId, fs.createWriteStream(timelinePath));
   requestIdToResponseIdMap.set(options.requestId, responseId);
-  pendingMcpRequestEventIds.set(responseId, []);
+  pendingMcpRequestEventIds.set(requestId, []);
 
   const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(workspaceId);
   // fallback to base environment

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import type { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import type { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { RequestOptions } from '@modelcontextprotocol/sdk/shared/protocol.js';
 import {
   CancelledNotificationSchema,
   ElicitRequestSchema,
@@ -13,10 +14,12 @@ import {
   type JSONRPCRequest,
   type JSONRPCResponse,
   ListRootsRequestSchema,
+  type Request,
   ServerNotificationSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import electron from 'electron';
 import { v4 as uuidV4 } from 'uuid';
+import type { ZodType } from 'zod';
 
 import { getAppVersion, getProductName, REALTIME_EVENTS_CHANNELS } from '~/common/constants';
 import { getMcpMethodFromMessage, METHOD_NOTIFICATION_CANCELLED } from '~/common/mcp-utils';
@@ -36,6 +39,8 @@ import {
   unsubscribeResource,
 } from '~/main/mcp/client-requests';
 import {
+  cancelRequest,
+  clearAbortControllerForMcpRequest,
   clearMcpMaps,
   eventLogFileStreams,
   findMany,
@@ -47,11 +52,12 @@ import {
   mcpServerElicitationRequests,
   parseAndLogMcpRequest,
   requestIdToResponseIdMap,
+  setAbortControllerForMcpRequest,
   timelineFileStreams,
   updateMcpConnectionState,
   writeEventLogAndNotify,
 } from '~/main/mcp/common';
-import { McpOAuthClientProvider } from '~/main/mcp/oauth-client-provider';
+import { McpOAuthClientProvider } from '~/main/mcp/oauth';
 import { createStdioTransport } from '~/main/mcp/transport-stdio';
 import { createStreamableHTTPTransport } from '~/main/mcp/transport-streamable-http';
 import type {
@@ -396,6 +402,21 @@ const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) 
       pendingServerRequestResolvers.delete(serverRequestId);
     }
   });
+  const originClientRequest = mcpClient.request.bind(mcpClient);
+  mcpClient.request = <T extends ZodType<object>>(request: Request, resultSchema: T, options?: RequestOptions) => {
+    // @ts-expect-error - need to access private property _requestMessageId to get message id
+    const messageId = mcpClient._requestMessageId.toString();
+    // add abort controller for each MCP client request
+    const abortController = setAbortControllerForMcpRequest({ requestId, messageId: messageId });
+    const optionsWithSignal = {
+      ...options,
+      signal: abortController.signal,
+    };
+    return originClientRequest(request, resultSchema, optionsWithSignal).finally(() => {
+      // clear abort controller after request is completed
+      clearAbortControllerForMcpRequest({ requestId, messageId: messageId });
+    });
+  };
 
   const serverCapabilities = mcpClient.getServerCapabilities();
   const primitivePromises: Promise<any>[] = [];
@@ -466,6 +487,7 @@ export interface McpBridgeAPI {
   client: {
     responseElicitationRequest: typeof responseElicitationRequest;
     hasRequestResponded: typeof hasRequestResponded;
+    cancelRequest: typeof cancelRequest;
   };
   readyState: {
     getCurrent: typeof getMcpReadyState;
@@ -517,6 +539,9 @@ export const registerMcpHandlers = () => {
   );
   ipcMainHandle('mcp.client.hasRequestResponded', (_, options: Parameters<typeof hasRequestResponded>[0]) =>
     hasRequestResponded(options),
+  );
+  ipcMainHandle('mcp.client.cancelRequest', (_, options: Parameters<typeof cancelRequest>[0]) =>
+    cancelRequest(options),
   );
 };
 

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -38,6 +38,7 @@ import {
   subscribeResource,
   unsubscribeResource,
 } from '~/main/mcp/client-requests';
+import { findPendingEvents } from '~/main/mcp/common';
 import {
   cancelRequest,
   clearAbortControllerForMcpRequest,
@@ -51,13 +52,14 @@ import {
   mcpConnections,
   mcpServerElicitationRequests,
   parseAndLogMcpRequest,
+  pendingMcpRequestEventIds,
   requestIdToResponseIdMap,
   setAbortControllerForMcpRequest,
   timelineFileStreams,
   updateMcpConnectionState,
   writeEventLogAndNotify,
 } from '~/main/mcp/common';
-import { McpOAuthClientProvider } from '~/main/mcp/oauth';
+import { McpOAuthClientProvider } from '~/main/mcp/oauth-client-provider';
 import { createStdioTransport } from '~/main/mcp/transport-stdio';
 import { createStreamableHTTPTransport } from '~/main/mcp/transport-streamable-http';
 import type {
@@ -316,6 +318,7 @@ const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) 
   const timelinePath = path.join(responsesDir, responseId + '.timeline');
   timelineFileStreams.set(requestId, fs.createWriteStream(timelinePath));
   requestIdToResponseIdMap.set(options.requestId, responseId);
+  pendingMcpRequestEventIds.set(responseId, []);
 
   const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(workspaceId);
   // fallback to base environment
@@ -498,6 +501,7 @@ export interface McpBridgeAPI {
   event: {
     findMany: typeof findMany;
     findNotifications: typeof findNotifications;
+    findPendingEvents: typeof findPendingEvents;
   };
 }
 
@@ -530,6 +534,9 @@ export const registerMcpHandlers = () => {
   ipcMainHandle('mcp.event.findMany', (_, options: Parameters<typeof findMany>[0]) => findMany(options));
   ipcMainHandle('mcp.event.findNotifications', (_, options: Parameters<typeof findNotifications>[0]) =>
     findNotifications(options),
+  );
+  ipcMainHandle('mcp.event.findPendingEvents', (_, options: Parameters<typeof findPendingEvents>[0]) =>
+    findPendingEvents(options),
   );
   ipcMainHandle('mcp.notification.rootListChange', (_, options: Parameters<typeof sendRootListChangeNotification>[0]) =>
     sendRootListChangeNotification(options),

--- a/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
@@ -1,19 +1,13 @@
-import type { CancelledNotification } from '@modelcontextprotocol/sdk/types.js';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { format } from 'date-fns';
-import React, { type FC, useEffect, useRef } from 'react';
+import React, { type FC, useEffect, useRef, useState } from 'react';
 import { Button, Cell, Column, Row, Table, TableBody, TableHeader } from 'react-aria-components';
 
 import { HelpTooltip } from '~/ui/components/help-tooltip';
 import { Icon } from '~/ui/components/icon';
 
-import {
-  METHOD_NOTIFICATION_CANCELLED,
-  METHOD_UNKNOWN,
-  NOTIFICATIONS_LIST_CHANGED,
-  unsupportedMethodPrefix,
-} from '../../../common/mcp-utils';
-import type { McpEvent, McpMessageEvent } from '../../../main/mcp/types';
+import { METHOD_UNKNOWN, NOTIFICATIONS_LIST_CHANGED, unsupportedMethodPrefix } from '../../../common/mcp-utils';
+import type { McpEvent } from '../../../main/mcp/types';
 import type { CurlEvent } from '../../../main/network/curl';
 import type { SocketIOEvent } from '../../../main/network/socket-io';
 import type { WebSocketEvent } from '../../../main/network/websocket';
@@ -31,6 +25,7 @@ interface Props {
   onSelect: (event: EventTypes) => void;
   autoSelectLatestEvent?: boolean;
   readyState?: boolean;
+  responseId?: string;
   protocol?: 'curl' | 'webSocket' | 'socketIO' | 'mcp';
 }
 
@@ -145,7 +140,10 @@ const getMessage = (event: EventTypes, isLoading: boolean): string | JSX.Element
       return 'Disconnected';
     }
     case 'error': {
-      return event.message;
+      const maxMcpErrorLength = 20;
+      return isMcpEvent(event) && event.message.length >= maxMcpErrorLength
+        ? `${event.message.slice(0, maxMcpErrorLength)}...`
+        : event.message;
     }
     case 'addEvent': {
       return `Listening to event: ${event.eventName}`;
@@ -169,8 +167,10 @@ export const EventLogView: FC<Props> = ({
   autoSelectLatestEvent = false,
   protocol,
   readyState,
+  responseId,
 }) => {
   const parentRef = useRef<HTMLTableSectionElement>(null);
+  const [pendingEvents, setPendingEvents] = useState<string[]>([]);
 
   const virtualizer = useVirtualizer({
     getScrollElement: () => parentRef.current,
@@ -179,12 +179,22 @@ export const EventLogView: FC<Props> = ({
     overscan: 30,
     getItemKey: index => events[index]._id,
   });
-  const isMcpEvents = protocol === 'mcp';
 
   useEffect(() => {
     // re-measure the virtualizer when EventLogView mounted, especially when switched in a tab
     virtualizer.measure();
   }, [virtualizer]);
+
+  useEffect(() => {
+    const updatePendingEvents = async (resId: string) => {
+      const pendingEvents = await window.main.mcp.event.findPendingEvents({ responseId: resId });
+      setPendingEvents(pendingEvents);
+    };
+    // For mcp protocol, fetch pending event ids from main process to show loading state
+    if (protocol === 'mcp' && responseId && events.length > 0) {
+      updatePendingEvents(responseId);
+    }
+  }, [events.length, protocol, responseId]);
 
   return (
     <>
@@ -221,49 +231,21 @@ export const EventLogView: FC<Props> = ({
             items={virtualizer.getVirtualItems()}
           >
             {item => {
-              let isLoading = false;
               const event = events[item.index];
+              const isLoading = event.type === 'message' && readyState && pendingEvents.includes(event._id);
               const isSelectedRow = event._id === selectionId;
               // add focus style when autoSelectLatestEvent is true for the first row
               const rowExtraClasses =
                 isSelectedRow && autoSelectLatestEvent
                   ? 'bg-[--hl-sm] outline-none'
                   : 'focus-within:bg-[--hl-sm] focus:outline-none';
-              if (isMcpEvents && event.type === 'message' && readyState) {
-                // Adding loading indicator if the message has not been responded by the server from json-rpc id
-                const { direction, data } = event;
-                const jsonRPCId = 'id' in data && data.id;
-                const method = (event as McpMessageEvent).method;
-                const isUnsupportedMethod = method.startsWith(unsupportedMethodPrefix);
-                const isErrorRequest = event.data.error;
-                if (jsonRPCId && !isUnsupportedMethod && !isErrorRequest) {
-                  isLoading = !events.find(e => {
-                    if (e.type === 'message') {
-                      const eventMethod = (e as McpMessageEvent).method;
-                      if (eventMethod === METHOD_NOTIFICATION_CANCELLED) {
-                        const eventData = e.data as CancelledNotification;
-                        // find the cancelled notification message indicates cancellation of the request
-                        return e.direction === direction && eventData.params.requestId === jsonRPCId;
-                      }
-                      // find the response message from server with the same json-rpc id but different direction
-                      return (
-                        eventMethod === method && e.direction !== direction && 'id' in e.data && e.data.id === jsonRPCId
-                      );
-                    } else if (e.type === 'error' && e.error && direction === 'OUTGOING') {
-                      // find the error message with the same json-rpc id for all outgoing requests
-                      return e.error?.requestId === jsonRPCId;
-                    }
-                    return false;
-                  });
-                }
-              }
               return (
                 <Row className={`group transition-colors ${rowExtraClasses}`}>
                   <Cell className="whitespace-nowrap border-b border-solid border-[--hl-sm] p-2 text-sm font-medium focus:outline-none group-last-of-type:border-none">
                     <SvgIcon icon={getIcon(event)} />
                   </Cell>
                   <Cell className="whitespace-nowrap border-b border-solid border-[--hl-sm] text-sm font-medium focus:outline-none group-last-of-type:border-none">
-                    {getMessage(event, isLoading)}
+                    {getMessage(event, !!isLoading)}
                   </Cell>
                   <Cell className="whitespace-nowrap border-b border-solid border-[--hl-sm] text-sm font-medium focus:outline-none group-last-of-type:border-none">
                     <Timestamp time={event.timestamp} />

--- a/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
@@ -227,7 +227,7 @@ export const EventLogView: FC<Props> = ({
           >
             {item => {
               const event = events[item.index];
-              const isLoading = event.type === 'message' && readyState && pendingEvents.includes(event._id);
+              const isLoading = event.type === 'message' && !!readyState && pendingEvents.includes(event._id);
               const isSelectedRow = event._id === selectionId;
               // add focus style when autoSelectLatestEvent is true for the first row
               const rowExtraClasses =
@@ -240,7 +240,7 @@ export const EventLogView: FC<Props> = ({
                     <SvgIcon icon={getIcon(event)} />
                   </Cell>
                   <Cell className="whitespace-nowrap border-b border-solid border-[--hl-sm] text-sm font-medium focus:outline-none group-last-of-type:border-none">
-                    {getMessage(event, !!isLoading)}
+                    {getMessage(event, isLoading)}
                   </Cell>
                   <Cell className="whitespace-nowrap border-b border-solid border-[--hl-sm] text-sm font-medium focus:outline-none group-last-of-type:border-none">
                     <Timestamp time={event.timestamp} />

--- a/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
@@ -2,7 +2,7 @@ import type { CancelledNotification } from '@modelcontextprotocol/sdk/types.js';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { format } from 'date-fns';
 import React, { type FC, useEffect, useRef } from 'react';
-import { Cell, Column, Row, Table, TableBody, TableHeader } from 'react-aria-components';
+import { Button, Cell, Column, Row, Table, TableBody, TableHeader } from 'react-aria-components';
 
 import { HelpTooltip } from '~/ui/components/help-tooltip';
 import { Icon } from '~/ui/components/icon';
@@ -95,10 +95,24 @@ const getMessage = (event: EventTypes, isLoading: boolean): string | JSX.Element
         const eventMethod = event.method || METHOD_UNKNOWN;
         const isUnsupportedMethod = eventMethod.startsWith(unsupportedMethodPrefix);
         return (
-          <div className="flex items-center">
-            {isLoading && <Icon className="mr-2 animate-spin" icon="spinner" />}
+          <div className="flex items-center gap-3">
             {isUnsupportedMethod && <span className="bg-warning mr-2 rounded-sm px-2 py-1">Unsupported</span>}
             <span className="flex-shrink">{eventMethod.replace(`${unsupportedMethodPrefix}`, '')}</span>
+            {isLoading && <Icon className="animate-spin" icon="spinner" />}
+            {isLoading && event.direction === 'OUTGOING' && event.data?.id && (
+              <Button
+                aria-label="Create in collection"
+                className="flex aspect-square h-full items-center justify-center rounded-sm text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
+                onPress={() => {
+                  window.main.mcp.client.cancelRequest({
+                    requestId: event.requestId,
+                    messageId: event.data.id.toString(),
+                  });
+                }}
+              >
+                <SvgIcon icon="prohibited" />
+              </Button>
+            )}
           </div>
         );
       }

--- a/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
@@ -140,10 +140,7 @@ const getMessage = (event: EventTypes, isLoading: boolean): string | JSX.Element
       return 'Disconnected';
     }
     case 'error': {
-      const maxMcpErrorLength = 20;
-      return isMcpEvent(event) && event.message.length > maxMcpErrorLength
-        ? `${event.message.slice(0, maxMcpErrorLength)}...`
-        : event.message;
+      return event.message;
     }
     case 'addEvent': {
       return `Listening to event: ${event.eventName}`;
@@ -198,7 +195,7 @@ export const EventLogView: FC<Props> = ({
 
   return (
     <>
-      <div className="max-h-96 w-full flex-1 select-none overflow-hidden overflow-y-auto border border-solid border-[--hl-sm]">
+      <div className="max-h-96 w-full flex-1 select-none overflow-hidden overflow-x-auto overflow-y-auto border border-solid border-[--hl-sm]">
         <Table
           selectionMode="single"
           selectedKeys={selectionId ? [selectionId] : []}

--- a/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
@@ -96,7 +96,7 @@ const getMessage = (event: EventTypes, isLoading: boolean): string | JSX.Element
             {isLoading && <Icon className="animate-spin" icon="spinner" />}
             {isLoading && event.direction === 'OUTGOING' && event.data?.id && (
               <Button
-                aria-label="Create in collection"
+                aria-label="Cancel Request"
                 className="flex aspect-square h-full items-center justify-center rounded-sm text-sm text-[--color-font] ring-1 ring-transparent transition-all hover:bg-[--hl-xs] focus:ring-inset focus:ring-[--hl-md] aria-pressed:bg-[--hl-sm]"
                 onPress={() => {
                   window.main.mcp.client.cancelRequest({
@@ -141,7 +141,7 @@ const getMessage = (event: EventTypes, isLoading: boolean): string | JSX.Element
     }
     case 'error': {
       const maxMcpErrorLength = 20;
-      return isMcpEvent(event) && event.message.length >= maxMcpErrorLength
+      return isMcpEvent(event) && event.message.length > maxMcpErrorLength
         ? `${event.message.slice(0, maxMcpErrorLength)}...`
         : event.message;
     }
@@ -187,14 +187,14 @@ export const EventLogView: FC<Props> = ({
 
   useEffect(() => {
     const updatePendingEvents = async (resId: string) => {
-      const pendingEvents = await window.main.mcp.event.findPendingEvents({ responseId: resId });
+      const pendingEvents = await window.main.mcp.event.findPendingEvents({ requestId: resId });
       setPendingEvents(pendingEvents);
     };
     // For mcp protocol, fetch pending event ids from main process to show loading state
     if (protocol === 'mcp' && responseId && events.length > 0) {
-      updatePendingEvents(responseId);
+      updatePendingEvents(events[0].requestId);
     }
-  }, [events.length, protocol, responseId]);
+  }, [events, protocol, responseId]);
 
   return (
     <>

--- a/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
@@ -25,7 +25,6 @@ interface Props {
   onSelect: (event: EventTypes) => void;
   autoSelectLatestEvent?: boolean;
   readyState?: boolean;
-  responseId?: string;
   protocol?: 'curl' | 'webSocket' | 'socketIO' | 'mcp';
 }
 
@@ -164,7 +163,6 @@ export const EventLogView: FC<Props> = ({
   autoSelectLatestEvent = false,
   protocol,
   readyState,
-  responseId,
 }) => {
   const parentRef = useRef<HTMLTableSectionElement>(null);
   const [pendingEvents, setPendingEvents] = useState<string[]>([]);
@@ -188,10 +186,10 @@ export const EventLogView: FC<Props> = ({
       setPendingEvents(pendingEvents);
     };
     // For mcp protocol, fetch pending event ids from main process to show loading state
-    if (protocol === 'mcp' && responseId && events.length > 0) {
+    if (protocol === 'mcp' && events.length > 0) {
       updatePendingEvents(events[0].requestId);
     }
-  }, [events, protocol, responseId]);
+  }, [events, protocol]);
 
   return (
     <>

--- a/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
@@ -381,7 +381,6 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
                       autoSelectLatestEvent
                       protocol={protocol}
                       readyState={isConnected}
-                      responseId={response._id}
                     />
                   )}
                 </Panel>

--- a/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
@@ -381,6 +381,7 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
                       autoSelectLatestEvent
                       protocol={protocol}
                       readyState={isConnected}
+                      responseId={response._id}
                     />
                   )}
                 </Panel>


### PR DESCRIPTION
**Changes:**
- Add a new map to save abortController instance for each mcp message
- Wrap the client implementation to add abortController to each mcp message automatically
- Refine to save loading mcp message status in main process for performance consideration
- Add a cancel button for each loading MCP messages

Refer [INS-1652](https://konghq.atlassian.net/browse/INS-1652)

[INS-1652]: https://konghq.atlassian.net/browse/INS-1652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ