### PR TITLE
use ecmascript 11

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.test-suite.$testSuiteId.tsx
@@ -71,8 +71,8 @@ const UnitTestItemView = ({ unitTest }: { unitTest: UnitTest; testsRunning: bool
     undef: true,
     // Prevent undefined usages
     node: true,
-    // Enable NodeJS globals
-    esversion: 8, // ES8 syntax (async/await, etc)
+    // https://jshint.com/docs/options/#esversion
+    esversion: 11,
   };
 
   const [isOpen, setIsOpen] = useState(false);

--- a/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
+++ b/packages/insomnia/src/ui/components/editors/request-script-editor.tsx
@@ -142,7 +142,8 @@ const lintOptions = {
   undef: true,
   // Prevent undefined usages
   node: true,
-  esversion: 8, // ES8 syntax (async/await, etc)
+  // https://jshint.com/docs/options/#esversion
+  esversion: 11,
 };
 
 // TODO: We probably don't want to expose every property like .toObject() so we need a way to filter those out


### PR DESCRIPTION
Customer requested the linter support ECMAScript features past version 8. This upgrades to 11.

related
https://github.com/jshint/jshint/issues/3645


issue:
<img width="628" height="172" alt="image" src="https://github.com/user-attachments/assets/a311492e-c380-4205-b23e-a7dfab71bd3d" />

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
