### PR TITLE
feat: add a error type for mcp response and optimize the ui when encounter an mcp auth error

### DIFF
--- a/packages/insomnia/src/common/documentation.ts
+++ b/packages/insomnia/src/common/documentation.ts
@@ -15,6 +15,7 @@ export const docsIntroductionToInsoCLI = insomniaDocs('/inso-cli/introduction');
 export const docsPreRequestScript = insomniaDocs('/insomnia/pre-request-script');
 export const docsAfterResponseScript = insomniaDocs('/insomnia/after-response-script');
 export const docsMcpClient = newInsomniaDocs('/mcp-clients-in-insomnia');
+export const docsMcpAuthentication = newInsomniaDocs('/mcp-clients-in-insomnia/#mcp-authentication');
 export const docsPricingLearnMoreLink = newInsomniaDocs(
   '/storage/#what-are-the-user-and-git-sync-limits-for-the-essentials-plan',
 );

--- a/packages/insomnia/src/main/mcp/oauth-client-provider.ts
+++ b/packages/insomnia/src/main/mcp/oauth-client-provider.ts
@@ -15,6 +15,17 @@ import type { RequestAuthentication } from '~/models/request';
 import { encryptOAuthUrl } from '~/network/o-auth-2/utils';
 import { invariant } from '~/utils/invariant';
 
+export class MCPAuthError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'MCPAuthError';
+  }
+}
+
+export const isMCPAuthError = (error: unknown): error is MCPAuthError => {
+  return error instanceof Error && error.name === 'MCPAuthError';
+};
+
 export class McpOAuthClientProvider implements OAuthClientProvider {
   private _codeVerifier?: string;
   private _resourceMetadataUrl?: URL;

--- a/packages/insomnia/src/main/mcp/transport-streamable-http.ts
+++ b/packages/insomnia/src/main/mcp/transport-streamable-http.ts
@@ -9,7 +9,7 @@ import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { BrowserWindow } from 'electron';
 
 import { timelineFileStreams, writeEventLogAndNotify } from '~/main/mcp/common';
-import type { McpOAuthClientProvider } from '~/main/mcp/oauth-client-provider';
+import { MCPAuthError, type McpOAuthClientProvider } from '~/main/mcp/oauth-client-provider';
 import type { McpAuthEventWithoutBase, OpenMcpHTTPClientConnectionOptions } from '~/main/mcp/types';
 import * as models from '~/models';
 import { TRANSPORT_TYPES } from '~/models/mcp-request';
@@ -244,10 +244,14 @@ const wrappedFetch = async (
       if (authResult !== 'AUTHORIZED') {
         throw new UnauthorizedError();
       }
-      return await wrappedFetch(url, init, options, calledByAuth);
+    } catch (e) {
+      console.error('Authentication failed', e);
+      // Wrap and throw MCPAuthError for better identification, some of the errors thrown by sdk are generic Error which is hard to identify
+      throw new MCPAuthError(e.message || 'Authentication failed', { cause: e });
     } finally {
       unsubscribe();
     }
+    return await wrappedFetch(url, init, options, calledByAuth);
   }
   return response;
 };

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -51,7 +51,7 @@ import {
   updateMcpConnectionState,
   writeEventLogAndNotify,
 } from '~/main/mcp/common';
-import { McpOAuthClientProvider } from '~/main/mcp/oauth-client-provider';
+import { isMCPAuthError, McpOAuthClientProvider } from '~/main/mcp/oauth-client-provider';
 import { createStdioTransport } from '~/main/mcp/transport-stdio';
 import { createStreamableHTTPTransport } from '~/main/mcp/transport-streamable-http';
 import type {
@@ -152,7 +152,7 @@ const _handleMcpMessage = (message: JSONRPCMessage, requestId: string) => {
 const _handleTransportError = (message: JSONRPCRequest, requestId: string, error: Error) => {
   const messageEvent: McpErrorEventWithoutBase = {
     type: 'error',
-    message: error.message || 'Transport Error',
+    message: error.name || 'Transport Error',
     error: {
       requestId: message.id,
       message: error.message || 'Transport Error',
@@ -180,6 +180,7 @@ const createErrorResponse = async ({
   timelinePath,
   message,
   transportType,
+  errorType,
 }: {
   responseId: string;
   requestId: string;
@@ -187,6 +188,7 @@ const createErrorResponse = async ({
   timelinePath: string;
   message: string;
   transportType: TransportType;
+  errorType?: string;
 }) => {
   const settings = await models.settings.get();
   const responsePatch = {
@@ -197,6 +199,7 @@ const createErrorResponse = async ({
     status: 'danger',
     statusMessage: 'Error',
     error: message,
+    errorType,
     transportType,
   };
 
@@ -362,6 +365,7 @@ const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) 
       environmentId: responseEnvironmentId,
       timelinePath,
       message: error.message || 'Something went wrong',
+      errorType: isMCPAuthError(error) ? 'auth' : '',
       transportType: options.transportType,
     });
     console.error(`Failed to create ${options.transportType} transport: ${error}`);

--- a/packages/insomnia/src/models/mcp-response.ts
+++ b/packages/insomnia/src/models/mcp-response.ts
@@ -28,6 +28,7 @@ export interface BaseMcpResponse {
   // Actual timelines are stored on the filesystem
   timelinePath: string;
   error: string;
+  errorType?: string;
   requestVersionId: string | null;
   transportType: TransportType;
 }
@@ -44,6 +45,7 @@ export function init(): BaseMcpResponse {
     timelinePath: '',
     eventLogPath: '',
     error: '',
+    errorType: '',
     status: '',
     statusCode: 0,
     statusMessage: '',

--- a/packages/insomnia/src/ui/components/viewers/response-error-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-error-viewer.tsx
@@ -9,8 +9,9 @@ import { SettingsModal } from '../modals/settings-modal';
 interface Props {
   error: string;
   url: string;
+  docsLink?: string;
 }
-export const ResponseErrorViewer: FC<Props> = memo(({ error }) => {
+export const ResponseErrorViewer: FC<Props> = memo(({ error, docsLink }) => {
   let msg: React.ReactNode = null;
   const { settings } = useRootLoaderData()!;
   const { editorFontSize } = settings;
@@ -29,7 +30,7 @@ export const ResponseErrorViewer: FC<Props> = memo(({ error }) => {
     );
   } else {
     msg = (
-      <Link button className="btn btn--clicky" href={docsBase}>
+      <Link button className="btn btn--clicky" href={docsLink || docsBase}>
         Documentation
       </Link>
     );

--- a/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
@@ -5,6 +5,7 @@ import React, { type FC, useEffect, useMemo, useState } from 'react';
 import { Button, Input, SearchField, Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 
+import { docsMcpAuthentication } from '~/common/documentation';
 import { useMcpReadyState } from '~/ui/hooks/use-mcp-ready-state';
 import { useRealtimeConnectionNotifications } from '~/ui/hooks/use-realtime-connection-notifications';
 
@@ -235,6 +236,9 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
 
   const cookieHeaders = hideCookies ? [] : getSetCookieHeaders(response.headers);
 
+  // When it is an MCP auth error, show the docs link about MCP authentication and keep the events view to be visible for better context.
+  const isMCPAuthError = isMcpResponse(response) && response.error && response.errorType === 'auth';
+
   return (
     <Pane type="response">
       <PaneHeader className="row-spaced">
@@ -319,7 +323,7 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
         </TabList>
         <TabPanel className="flex w-full flex-1 flex-col overflow-hidden" id="events">
           <PanelGroup direction="vertical" className="grid h-full w-full grid-rows-[repeat(auto-fit,minmax(0,1fr))]">
-            {response.error ? (
+            {response.error && !isMCPAuthError ? (
               <ResponseErrorViewer url={response.url} error={response.error} />
             ) : (
               <>
@@ -384,6 +388,9 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
                     />
                   )}
                 </Panel>
+                {isMCPAuthError ? (
+                  <ResponseErrorViewer url={response.url} error={response.error} docsLink={docsMcpAuthentication} />
+                ) : null}
                 {selectedEvent && (
                   <>
                     <PanelResizeHandle className={'h-[1px] w-full bg-[--hl-md]'} />


### PR DESCRIPTION
## Background
[INS-1662](https://konghq.atlassian.net/browse/INS-1662)
We may encounter different auth errors based on the mcp auth server implementation.

## Changes
- Add a response error type
- Show more details by display the events when the error is an auth error

[INS-1662]: https://konghq.atlassian.net/browse/INS-1662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ