### PR TITLE
feat: add model config to segment even for mock creation

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
@@ -291,6 +291,8 @@ async function createMockServer(
       workspaceId: workspace._id,
     })}/mock-server`;
 
+    const modelConfig = await window.main.llm.getCurrentConfig();
+
     const generationStartTime = Date.now();
 
     if (workspaceData.mockServerCreationType === 'ai') {
@@ -308,7 +310,6 @@ async function createMockServer(
         specText = workspaceData.mockServerSpecText!;
       }
 
-      const modelConfig = await window.main.llm.getCurrentConfig();
       const result = await window.main.generateMockRouteDataFromSpec(
         openapiSpec,
         specUrl,
@@ -347,6 +348,8 @@ async function createMockServer(
     window.main.trackSegmentEvent({
       event: SegmentEvent.mockCreate,
       properties: {
+        provider: modelConfig && modelConfig.backend || '',
+        model: modelConfig && modelConfig.model || '',
         hosting: workspaceData.mockServerType || '',
         generation: workspaceData.mockServerCreationType || '',
         generation_from: workspaceData.apiSpecContents ? 'design_doc' : workspaceData.mockServerSpecSource || '',


### PR DESCRIPTION
Adds the AI provider and model used to create a Mock Server to the segment event for Mock Server Creation.