### PR TITLE
feat: add squirrel windows sign check - [INS-1338]

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -163,7 +163,7 @@ jobs:
           CREDENTIAL_ID: ${{secrets.ES_CREDENTIAL_ID}}
           TOTP_SECRET: ${{secrets.ES_TOTP_SECRET}}
 
-      - name: Check exe signature (Windows only)
+      - name: Check squirrel exe signature (Windows only)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -163,6 +163,44 @@ jobs:
           CREDENTIAL_ID: ${{secrets.ES_CREDENTIAL_ID}}
           TOTP_SECRET: ${{secrets.ES_TOTP_SECRET}}
 
+      - name: Check exe signature (Windows only)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $version = $env:INSO_VERSION
+          $nupkg = "Insomnia.Core-${version}-full.nupkg"
+          7z x "packages/insomnia/dist/squirrel-windows/${nupkg}" -o"${version}-extract"
+
+          $exeFiles = Get-ChildItem -Path "$extractDir" -Filter *.exe -Recurse
+
+          if ($exeFiles.Count -eq 0) {
+            Write-Warning "No .exe files found in the package"
+            exit 1
+          }
+
+          Write-Host "Found $($exeFiles.Count) .exe file(s):"
+          Write-Host ""
+
+          foreach ($exe in $exeFiles) {
+            Write-Host "Checking: $($exe.Name)"
+            Write-Host "  Path: $($exe.FullName)"
+            
+            $signature = Get-AuthenticodeSignature -FilePath $exe.FullName
+            
+            Write-Host "  Status: $($signature.Status)"
+            Write-Host "  Signer: $($signature.SignerCertificate.Subject)"
+            Write-Host "  Timestamp: $($signature.TimeStamperCertificate.NotAfter)"
+            
+            if ($signature.Status -ne 'Valid') {
+              Write-Error "  ❌ Invalid signature for $($exe.Name)"
+              exit 1
+            } else {
+              Write-Host "  ✓ Valid signature" -ForegroundColor Green
+            }
+            Write-Host ""
+          }
+          Write-Host "✓ All executables are properly signed" -ForegroundColor Green
+
       - name: Package inso
         run: |
           echo "Replacing electron binary with node binary"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -172,7 +172,7 @@ jobs:
           Write-Host "scan insomnia-${version}-full.nupkg"
           7z x "packages/insomnia/dist/squirrel-windows/${nupkg}" -o"${version}-extract"
 
-          $exeFiles = Get-ChildItem -Path "${version}-extract/lib/net45" -Depth 0 -Filter *.exe
+          $exeFiles = Get-ChildItem -Path "${version}-extract/lib/net45" -Filter *.exe
 
           if ($exeFiles.Count -eq 0) {
             Write-Warning "No .exe files found in the package"
@@ -185,20 +185,15 @@ jobs:
           foreach ($exe in $exeFiles) {
             Write-Host "Checking: $($exe.Name)"
             Write-Host "  Path: $($exe.FullName)"
-            
             $signature = Get-AuthenticodeSignature -FilePath $exe.FullName
-            
             Write-Host "  Status: $($signature.Status)"
             Write-Host "  Signer: $($signature.SignerCertificate.Subject)"
             Write-Host "  Timestamp: $($signature.TimeStamperCertificate.NotAfter)"
-            
             if ($signature.Status -ne 'Valid') {
               Write-Error "  ❌ Invalid signature for $($exe.Name)"
               exit 1
-            } else {
-              Write-Host "  ✓ Valid signature" -ForegroundColor Green
             }
-            Write-Host ""
+            Write-Host "  ✓ Valid signature" -ForegroundColor Green
           }
           Write-Host "✓ All executables are properly signed" -ForegroundColor Green
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -168,10 +168,11 @@ jobs:
         shell: pwsh
         run: |
           $version = $env:INSO_VERSION
-          $nupkg = "Insomnia.Core-${version}-full.nupkg"
+          $nupkg = "insomnia-${version}-full.nupkg"
+          Write-Host "scan insomnia-${version}-full.nupkg"
           7z x "packages/insomnia/dist/squirrel-windows/${nupkg}" -o"${version}-extract"
 
-          $exeFiles = Get-ChildItem -Path "${version}-extract" -Filter *.exe -Recurse
+          $exeFiles = Get-ChildItem -Path "${version}-extract/lib/net45" -Depth 0 -Filter *.exe
 
           if ($exeFiles.Count -eq 0) {
             Write-Warning "No .exe files found in the package"

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -171,7 +171,7 @@ jobs:
           $nupkg = "Insomnia.Core-${version}-full.nupkg"
           7z x "packages/insomnia/dist/squirrel-windows/${nupkg}" -o"${version}-extract"
 
-          $exeFiles = Get-ChildItem -Path "$extractDir" -Filter *.exe -Recurse
+          $exeFiles = Get-ChildItem -Path "${version}-extract" -Filter *.exe -Recurse
 
           if ($exeFiles.Count -eq 0) {
             Write-Warning "No .exe files found in the package"


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
## Background
We rely on electron-builder to sign unpacked electron contents. We had an issue that the insomnia execution_stb.exe is not signed after build process and blocked some of the users(https://github.com/Kong/insomnia/issues/8951 ).
So we want to add a check in CI to avoid similar issues caused by electron-builder update.


Test in release-build: https://github.com/Kong/insomnia/actions/runs/19261707105/job/55067799140
<img width="1538" height="442" alt="image" src="https://github.com/user-attachments/assets/168eefa0-e1c8-4708-80a4-9a7ba9b44ae2" />

