### PR TITLE
removed tab override in codemirror extension

### DIFF
--- a/packages/insomnia/src/ui/components/.client/codemirror/extensions/autocomplete.ts
+++ b/packages/insomnia/src/ui/components/.client/codemirror/extensions/autocomplete.ts
@@ -104,13 +104,6 @@ CodeMirror.defineOption(
         container: hintsContainer,
         closeCharacters: COMPLETION_CLOSE_KEYS,
         completeSingle: false,
-        extraKeys: {
-          Tab: (_cm, widget) => {
-            // Override default behavior and don't select hint on Tab
-            widget.close();
-            return CodeMirror.Pass;
-          },
-        },
         // Good for debugging
         // closeOnUnfocus: false,
       });


### PR DESCRIPTION
Closes-#7713

**Background**

Looks like the default code mirror behavior was overridden in the original PR when autocomplete was implemented, to not allow `tab` key  to autocomplete

https://github.com/Kong/insomnia/pull/112


**Changes**

Removing the override so it reverts to default code mirror behavior allowing `tab` to autocomplete suggestions

Tested in local, can upload videos if needed.