### PR TITLE
fix: record failed mcp auth fetch events

### DIFF
--- a/packages/insomnia/src/main/mcp/transport-streamable-http.ts
+++ b/packages/insomnia/src/main/mcp/transport-streamable-http.ts
@@ -241,8 +241,8 @@ const wrappedFetch = async (
           data: {
             statusCode: null,
             statusMessage: 'Fetch failed',
-            message: error.message,
-            ...(error.cause ? { cause: error.cause instanceof Error ? error.cause.message : String(error.cause) } : {}),
+            message: error?.message || String(error),
+            ...(error.cause ? { cause: error.cause.message || String(error.cause) } : {}),
           },
         };
         writeEventLogAndNotify(requestId, authErrorEvent);

--- a/packages/insomnia/src/main/mcp/transport-streamable-http.ts
+++ b/packages/insomnia/src/main/mcp/transport-streamable-http.ts
@@ -217,21 +217,35 @@ const wrappedFetch = async (
         },
       };
       writeEventLogAndNotify(requestId, authRequestEvent);
-      const response = await fetch(url, init);
+      try {
+        const response = await fetch(url, init);
 
-      const authResponseEvent: McpAuthEventWithoutBase = {
-        type: 'message',
-        method: 'MCP Auth',
-        direction: 'INCOMING',
-        data: {
-          statusCode: response.status,
-          statusMessage: response.statusText,
-          body: await response.clone().text(),
-        },
-      };
-      writeEventLogAndNotify(requestId, authResponseEvent);
+        const authResponseEvent: McpAuthEventWithoutBase = {
+          type: 'message',
+          method: 'MCP Auth',
+          direction: 'INCOMING',
+          data: {
+            statusCode: response.status,
+            statusMessage: response.statusText,
+            body: await response.clone().text(),
+          },
+        };
+        writeEventLogAndNotify(requestId, authResponseEvent);
 
-      return response;
+        return response;
+      } catch (error) {
+        const authErrorEvent: McpAuthEventWithoutBase = {
+          type: 'message',
+          method: 'MCP Auth',
+          direction: 'INCOMING',
+          data: {
+            message: error.message,
+            ...(error.cause ? { cause: error.cause instanceof Error ? error.cause.message : String(error.cause) } : {}),
+          },
+        };
+        writeEventLogAndNotify(requestId, authErrorEvent);
+        throw error;
+      }
     };
 
     try {

--- a/packages/insomnia/src/main/mcp/transport-streamable-http.ts
+++ b/packages/insomnia/src/main/mcp/transport-streamable-http.ts
@@ -239,6 +239,8 @@ const wrappedFetch = async (
           method: 'MCP Auth',
           direction: 'INCOMING',
           data: {
+            statusCode: null,
+            statusMessage: 'Fetch failed',
             message: error.message,
             ...(error.cause ? { cause: error.cause instanceof Error ? error.cause.message : String(error.cause) } : {}),
           },


### PR DESCRIPTION
## Background
[INS-1649](https://konghq.atlassian.net/browse/INS-1649)

While fetch fails because of a network issue or SSL cert, it throws an error instead of returning the response.

## Changes

- Catch the fetch error and log the events
- Catch the cause for better debugging



[INS-1649]: https://konghq.atlassian.net/browse/INS-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ