### PR TITLE
bump: @kong/insomnia-plugin-external-vault

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4084,9 +4084,9 @@
       ]
     },
     "node_modules/@kong/insomnia-plugin-external-vault": {
-      "version": "0.1.1-dev.0.20250902151320",
-      "resolved": "https://npm.pkg.github.com/download/@kong/insomnia-plugin-external-vault/0.1.1-dev.0.20250902151320/b124623c7d0e3de9d3b5f66250bcae056f95361f",
-      "integrity": "sha512-jtRSIHTToXSFWyQIrCrO6fYn7klm/N+tIRbBQr432U8uoeY8vI40w9j5omzLPZ6tqi+HBj1NUJTr2/ELbmQp/A==",
+      "version": "0.1.3",
+      "resolved": "https://npm.pkg.github.com/download/@kong/insomnia-plugin-external-vault/0.1.3/2daee6c43270d411accae9330aedff9c8ff8e327",
+      "integrity": "sha512-3//xSvw0Fg8vP7lHXCKa4wGYr2m6yDEGWls4YGNzSl/pIi9BOyoTnoNzkpOiWFUTNX1yCOQJUPPRFjE6ZbkEUA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -30290,7 +30290,6 @@
         "@getinsomnia/srp-js": "1.0.0-alpha.1",
         "@grpc/grpc-js": "^1.13.3",
         "@grpc/proto-loader": "^0.7.13",
-        "@kong/insomnia-plugin-ai": "^1.0.5",
         "@react-router/fs-routes": "^7.9.4",
         "@react-router/node": "^7.9.4",
         "@react-router/serve": "^7.9.4",
@@ -30439,7 +30438,7 @@
       },
       "optionalDependencies": {
         "@kong/insomnia-plugin-ai": "^1.0.5",
-        "@kong/insomnia-plugin-external-vault": "0.1.1-dev.0.20250902151320"
+        "@kong/insomnia-plugin-external-vault": "0.1.3"
       }
     },
     "packages/insomnia-inso": {
@@ -30470,7 +30469,7 @@
         "shellwords": "^1.0.1"
       },
       "optionalDependencies": {
-        "@kong/insomnia-plugin-external-vault": "0.1.1-dev.0.20250902151320"
+        "@kong/insomnia-plugin-external-vault": "0.1.3"
       }
     },
     "packages/insomnia-inso/node_modules/consola": {

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -65,6 +65,6 @@
     "yaml": "^2.7.1"
   },
   "optionalDependencies": {
-    "@kong/insomnia-plugin-external-vault": "0.1.1-dev.0.20250902151320"
+    "@kong/insomnia-plugin-external-vault": "0.1.3"
   }
 }

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -199,7 +199,7 @@
   },
   "optionalDependencies": {
     "@kong/insomnia-plugin-ai": "^1.0.5",
-    "@kong/insomnia-plugin-external-vault": "0.1.1-dev.0.20250902151320"
+    "@kong/insomnia-plugin-external-vault": "0.1.3"
   },
   "dev": {
     "dev-server-port": 3334


### PR DESCRIPTION

Update `@kong/insomnia-plugin-external-vault` to version `0.1.3`.