### PR TITLE
feat: add mcp error details to the events and the UI

### DIFF
--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -164,6 +164,7 @@ const _handleTransportError = (message: JSONRPCRequest, requestId: string, error
     error: {
       requestId: message.id,
       message: error.message || 'Transport Error',
+      ...(error.cause ? { cause: (error.cause as Error).message || String(error.cause) } : {}),
     },
   };
   writeEventLogAndNotify(requestId, messageEvent);
@@ -373,7 +374,10 @@ const openMcpClientConnection = async (options: OpenMcpClientConnectionOptions) 
       responseId,
       environmentId: responseEnvironmentId,
       timelinePath,
-      message: error.message || 'Something went wrong',
+      message:
+        error instanceof Error
+          ? error.message + (error.cause ? `\ncause: ${(error.cause as Error).message || String(error.cause)}` : '')
+          : 'Something went wrong',
       errorType: isMCPAuthError(error) ? 'auth' : '',
       transportType: options.transportType,
     });


### PR DESCRIPTION
## Background
When fetch throws an error, most of the details are in the cause, but currently, we only show the error.message. This makes it hard to find the root cause of an error.

## Changes

- Show cause in the transport events
- Show cause in the error message