### PR TITLE
fix(inso): include transient variables during interpolation

### DIFF
--- a/packages/insomnia-inso/src/cli.test.ts
+++ b/packages/insomnia-inso/src/cli.test.ts
@@ -47,6 +47,8 @@ const shouldReturnSuccessCode = [
   '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-smoke-test/fixtures/simple.yaml -e production --requestNamePattern "example http" wrk_dc393c',
   // after-response script and test
   '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/after-response.yml wrk_616795 --verbose',
+  // transient variables
+  '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/transient-variables.yml wrk_3d6697b --verbose',
   // select request by id
   '$PWD/packages/insomnia-inso/bin/inso run collection -w packages/insomnia-inso/src/examples/three-requests.yml -i req_3fd28aabbb18447abab1f45e6ee4bdc1 -i req_6063adcdab5b409e9b4f00f47322df4a wrk_c992d40',
   // setNextRequest runs the next request then ends

--- a/packages/insomnia-inso/src/examples/transient-variables.yml
+++ b/packages/insomnia-inso/src/examples/transient-variables.yml
@@ -1,0 +1,95 @@
+type: collection.insomnia.rest/5.0
+schema_version: "5.1"
+name: Simple Crud
+meta:
+  id: wrk_3d6697ba0f6a43cdb9e7378d54d1a1cb
+  created: 1763445405875
+  modified: 1763445405875
+  description: ""
+collection:
+  - url: http://localhost:4010/simple-crud
+    name: Create Thing
+    meta:
+      id: req_a93f56d7079740ce89d9365a58d2d202
+      created: 1763445410113
+      modified: 1763445948725
+      isPrivate: false
+      description: ""
+      sortKey: -1763445410113
+    method: POST
+    body:
+      mimeType: application/json
+      text: |-
+        {
+        	"some": "thing"
+        }
+    headers:
+      - name: Content-Type
+        value: application/json
+      - name: User-Agent
+        value: insomnia/12.1.0-beta.0
+        description: ""
+        disabled: false
+    scripts:
+      afterResponse: |-
+        const jsonBody = insomnia.response.json();
+        insomnia.variables.set('thingId', jsonBody.id);
+
+        insomnia.test('got a 201', () => {
+          insomnia.expect(insomnia.response.code).to.eql(201);
+        });
+
+        insomnia.test('variable set', () => {
+        	insomnia.expect(insomnia.variables.get('thingId')).to.eql(jsonBody.id);
+        });
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+  - url: http://localhost:4010/simple-crud/{{thingId}}
+    name: Retrieve Thing
+    meta:
+      id: req_8aa3c21007f746e7b400d2e17a0a1aba
+      created: 1763445773731
+      modified: 1763445889533
+      isPrivate: false
+      description: ""
+      sortKey: -1763445410013
+    method: GET
+    headers:
+      - name: User-Agent
+        value: insomnia/12.1.0-beta.0
+        description: ""
+        disabled: false
+    scripts:
+      afterResponse: |-
+        const jsonBody = insomnia.response.json();
+        insomnia.test('got the thing', () => {
+        	insomnia.expect(jsonBody.id).to.eql(insomnia.variables.get('thingId'))
+        	insomnia.expect(jsonBody.some).to.eql("thing");
+        });
+    settings:
+      renderRequestBody: true
+      encodeUrl: true
+      followRedirects: global
+      cookies:
+        send: true
+        store: true
+      rebuildPath: true
+cookieJar:
+  name: Default Jar
+  meta:
+    id: jar_217626d704282108ee9f812e810d658e53370cb1
+    created: 1763445405878
+    modified: 1763445982968
+environments:
+  name: Base Environment
+  meta:
+    id: env_217626d704282108ee9f812e810d658e53370cb1
+    created: 1763445405877
+    modified: 1763445982970
+    isPrivate: false

--- a/packages/insomnia-smoke-test/server/index.ts
+++ b/packages/insomnia-smoke-test/server/index.ts
@@ -16,6 +16,7 @@ import { startGRPCServer } from './grpc';
 import insomniaApi from './insomnia-api';
 import { mtlsRouter } from './mtls';
 import { oauthRoutes } from './oauth';
+import simpleCrud from './simple-crud';
 import { startSocketIOServer } from './socket-io';
 import { startWebSocketServer } from './websocket';
 
@@ -71,6 +72,7 @@ app.use('/protected', mtlsRouter);
 githubApi(app);
 gitlabApi(app);
 insomniaApi(app);
+simpleCrud(app);
 
 app.get('/delay/seconds/:duration', (req, res) => {
   const delaySec = Number.parseInt(req.params.duration || '2');

--- a/packages/insomnia-smoke-test/server/simple-crud.ts
+++ b/packages/insomnia-smoke-test/server/simple-crud.ts
@@ -1,0 +1,21 @@
+import express from 'express';
+
+const db = new Map<string, any>();
+
+export default (app: express.Application) => {
+  app.get('/simple-crud/:id', (req, res) => {
+    const { id } = req.params;
+    const item = db.get(id);
+    if (!item) {
+      res.status(404).send();
+      return;
+    }
+    res.status(200).send({ id, ...item });
+  });
+
+  app.post('/simple-crud', express.json(), (req, res) => {
+    const id = crypto.randomUUID();
+    db.set(id, req.body);
+    res.status(201).send({ id, ...req.body });
+  });
+};

--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -89,6 +89,7 @@ export async function getSendRequestCallbackMemDb(
       environment: mutatedContext.environment,
       purpose: 'send',
       extraInfo: undefined,
+      transientVariables: mutatedContext.transientVariables || transientVariables,
       baseEnvironment: mutatedContext.baseEnvironment,
       userUploadEnvironment: mutatedContext.userUploadEnvironment,
       ignoreUndefinedEnvVariable,


### PR DESCRIPTION
one line fix to include the `transientVariables` during a collection run

added mini crud routes to the smoke test server to confirm the fix