### PR TITLE
[INS-1736] fix(schema): allow nullable authentication and path parameters in collection schema

### DIFF
--- a/packages/insomnia/src/common/import-v5-parser.ts
+++ b/packages/insomnia/src/common/import-v5-parser.ts
@@ -370,7 +370,7 @@ export const RequestGroupSchema = z.object({
   meta: MetaGroupSchema.optional(),
   children: z.array(z.any()).optional(),
   scripts: ScriptsSchema.optional(),
-  authentication: AuthenticationSchema.optional(),
+  authentication: AuthenticationSchema.optional().nullable(),
   environment: JsonSchema.optional(),
   environmentPropertyOrder: JsonSchema.optional(),
   headers: HeadersSchema.optional(),
@@ -415,7 +415,7 @@ export const RequestSchema = z.object({
       store: true,
     },
   }),
-  pathParameters: RequestPathParametersSchema.optional(),
+  pathParameters: RequestPathParametersSchema.optional().nullable(),
 });
 
 export const WebsocketRequestSchema = z.object({
@@ -435,7 +435,7 @@ export const WebsocketRequestSchema = z.object({
   authentication: AuthenticationSchema.optional(),
   headers: HeadersSchema.optional(),
   parameters: RequestParametersSchema.optional(),
-  pathParameters: RequestPathParametersSchema.optional(),
+  pathParameters: RequestPathParametersSchema.optional().nullable(),
 });
 
 export const SocketIOEventListenerSchema = z.object({

--- a/packages/insomnia/src/common/insomnia-schema-migrations/index.ts
+++ b/packages/insomnia/src/common/insomnia-schema-migrations/index.ts
@@ -57,7 +57,11 @@ const migrations: Migration<any>[] = [
  * @param referenceContent - Optional reference content to normalize property order against
  * @returns Migrated and normalized YAML content
  */
-export function migrateToLatestYaml(yamlContent: string, referenceContent?: string): string {
+export function migrateToLatestYaml(yamlContent?: string, referenceContent?: string): string {
+  if (!yamlContent) {
+    return '';
+  }
+
   try {
     const parsed = parse(yamlContent);
     const version = getVersionFromParsed(parsed);

--- a/packages/insomnia/src/common/significant-diff-detection.ts
+++ b/packages/insomnia/src/common/significant-diff-detection.ts
@@ -116,12 +116,22 @@ function sortObject<T>(obj: T): T {
   return obj;
 }
 
+// Treat undefined, null, and missing key as equivalent
+function emptyKeyReplacer(_key: string, value: any) {
+  if (value === null || value === '') {
+    return undefined;
+  }
+  return value;
+}
+
 /**
  * Performs original deep equality check by comparing canonical (sorted) JSON strings.
  * Works best for JSON-compatible data (objects, arrays, primitives).
  */
 function deepEqual<T>(original: T, modified: T): boolean {
-  return JSON.stringify(sortObject(original)) === JSON.stringify(sortObject(modified));
+  return (
+    JSON.stringify(sortObject(original), emptyKeyReplacer) === JSON.stringify(sortObject(modified), emptyKeyReplacer)
+  );
 }
 
 /**


### PR DESCRIPTION
# Overview

In the legacy git collections requests and folders could have some nullable fields.
This creates an issue where the parser cannot properly parse the contents and returns an empty value.

## Resolution

- [x] Make these fields nullable so the parser accepts those values