### PR TITLE
fix: inso test result category always be unknown

### DIFF
--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
+import type { RequestTestResult } from '../../../insomnia-scripting-environment/src/objects';
 import type { BaseModel } from '../models';
 import * as models from '../models';
 import type { Environment, UserUploadEnvironment } from '../models/environment';
@@ -138,10 +139,16 @@ export async function getSendRequestCallbackMemDb(
     const bodyBuffer = (await getBodyBuffer(res)) as Buffer;
     const data = bodyBuffer ? bodyBuffer.toString('utf8') : undefined;
 
-    const testResults = [
-      ...(mutatedContext.requestTestResults || []),
-      ...(postMutatedContext.requestTestResults || []),
-    ];
+    const preTestResults: RequestTestResult[] = (mutatedContext.requestTestResults || []).map(result => ({
+      ...result,
+      category: 'pre-request',
+    }));
+    const postTestResults: RequestTestResult[] = (postMutatedContext?.requestTestResults || []).map(result => ({
+      ...result,
+      category: 'after-response',
+    }));
+
+    const testResults = [...preTestResults, ...postTestResults];
     return {
       status,
       statusMessage,

--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -139,16 +139,10 @@ export async function getSendRequestCallbackMemDb(
     const bodyBuffer = (await getBodyBuffer(res)) as Buffer;
     const data = bodyBuffer ? bodyBuffer.toString('utf8') : undefined;
 
-    const preTestResults: RequestTestResult[] = (mutatedContext.requestTestResults || []).map(result => ({
-      ...result,
-      category: 'pre-request',
-    }));
-    const postTestResults: RequestTestResult[] = (postMutatedContext?.requestTestResults || []).map(result => ({
-      ...result,
-      category: 'after-response',
-    }));
-
-    const testResults = [...preTestResults, ...postTestResults];
+    const testResults = [
+      ...(mutatedContext.requestTestResults || []),
+      ...(postMutatedContext.requestTestResults || []),
+    ];
     return {
       status,
       statusMessage,

--- a/packages/insomnia/src/common/send-request.ts
+++ b/packages/insomnia/src/common/send-request.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import type { RequestTestResult } from '../../../insomnia-scripting-environment/src/objects';
 import type { BaseModel } from '../models';
 import * as models from '../models';
 import type { Environment, UserUploadEnvironment } from '../models/environment';

--- a/packages/insomnia/src/network/network.ts
+++ b/packages/insomnia/src/network/network.ts
@@ -384,6 +384,10 @@ export const tryToExecutePreRequestScript = async (
     originalRequestGroups,
   });
 
+  const preTestResults: RequestTestResult[] = (mutatedContext.requestTestResults || []).map(result => ({
+    ...result,
+    category: 'pre-request',
+  }));
   return {
     request: mutatedContext.request,
     environment: mutatedContext.environment,
@@ -393,7 +397,7 @@ export const tryToExecutePreRequestScript = async (
     globals: mutatedContext.globals,
     baseGlobals: mutatedContext.baseGlobals,
     cookieJar: mutatedContext.cookieJar,
-    requestTestResults: mutatedContext.requestTestResults,
+    requestTestResults: preTestResults,
     userUploadEnvironment: mutatedContext.userUploadEnvironment,
     execution: mutatedContext.execution,
     transientVariables: mutatedContext.transientVariables,
@@ -483,7 +487,7 @@ export async function savePatchesMadeByScript(patches: {
   });
 }
 
-export const tryToExecuteScript = async (context: RequestAndContextAndOptionalResponse) => {
+const tryToExecuteScript = async (context: RequestAndContextAndOptionalResponse) => {
   const {
     script,
     request,
@@ -757,7 +761,12 @@ export async function tryToExecuteAfterResponseScript(context: RequestAndContext
     });
   }
 
-  return postMutatedContext;
+  const postTestResults: RequestTestResult[] = (postMutatedContext?.requestTestResults || []).map(result => ({
+    ...result,
+    category: 'after-response',
+  }));
+
+  return { ...postMutatedContext, requestTestResults: postTestResults };
 }
 
 export const tryToInterpolateRequest = async ({

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
@@ -281,13 +281,8 @@ export const sendActionImplementation = async (options: {
 
   window.main.completeExecutionStep({ requestId });
 
-  const preTestResults = (mutatedContext.requestTestResults || []).map(
-    (result: RequestTestResult): RequestTestResult => ({ ...result, category: 'pre-request' }),
-  );
-  const postTestResults =
-    (postMutatedContext?.requestTestResults || []).map(
-      (result: RequestTestResult): RequestTestResult => ({ ...result, category: 'after-response' }),
-    ) || [];
+  const preTestResults = mutatedContext.requestTestResults || [];
+  const postTestResults = postMutatedContext?.requestTestResults || [];
   if (testResultCollector) {
     testResultCollector.results = [...testResultCollector.results, ...preTestResults, ...postTestResults];
     const timingSteps = await window.main.getExecution({ requestId });


### PR DESCRIPTION
## Background
[INS-1702](https://konghq.atlassian.net/browse/INS-1702)
The test results' category is always unknown

## Changes
Update the category based on the context

[INS-1702]: https://konghq.atlassian.net/browse/INS-1702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ