### PR TITLE
Fix: Using safeParser to parse Insomnia git yaml files

### DIFF
--- a/packages/insomnia/src/common/__tests__/import-v5-parser.test.ts
+++ b/packages/insomnia/src/common/__tests__/import-v5-parser.test.ts
@@ -501,6 +501,10 @@ describe('InsomniaFileSchema (discriminated union)', () => {
     expect(f.type).toBe('mock.insomnia.rest/5.0');
   });
 
+  it('rejects future or unsupported type', () => {
+    expect(() => InsomniaFileSchema.parse({ type: 'futureCollection.insomnia.rest/5.0' })).toThrow();
+  });
+
   it('rejects unknown type', () => {
     expect(() => InsomniaFileSchema.parse({ type: 'nope' })).toThrow();
   });

--- a/packages/insomnia/src/common/__tests__/insomnia-v5.test.ts
+++ b/packages/insomnia/src/common/__tests__/insomnia-v5.test.ts
@@ -98,12 +98,39 @@ invalid: [unclosed array
       expect(result.data).toEqual([]);
       expect(result.error).toBeDefined();
     });
+
+    it('handles unsupported or future schema gracefully', () => {
+      const futureSchemaData = `
+type: futureCollection.insomnia.rest/5.0
+name: Future Schema Collection
+meta:
+  id: wrk_test
+  created: 1234567890
+  modified: 1234567890
+`;
+      const result = tryImportV5Data(futureSchemaData);
+      expect(result.data).toEqual([]);
+      expect(result.error).toBeDefined();
+    });
   });
 
   describe('importInsomniaV5Data', () => {
     it('returns empty array on invalid data', () => {
       const invalidData = 'invalid yaml content';
       const result = importInsomniaV5Data(invalidData);
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array on unsupported or future data', () => {
+      const futureSchemaData = `
+type: futureCollection.insomnia.rest/5.0
+name: Future Schema Collection
+meta:
+  id: wrk_test
+  created: 1234567890
+  modified: 1234567890
+`;
+      const result = importInsomniaV5Data(futureSchemaData);
       expect(result).toEqual([]);
     });
 

--- a/packages/insomnia/src/common/insomnia-v5.ts
+++ b/packages/insomnia/src/common/insomnia-v5.ts
@@ -645,27 +645,36 @@ function getCollection(
 function importData(rawData: string) {
   // Apply schema migration before parsing to handle older schema versions
   const migratedData = migrateToLatestYaml(rawData);
-  const file = InsomniaFileSchema.parse(parse(migratedData));
+  const fileSchemaParser = InsomniaFileSchema.safeParse(parse(migratedData));
 
-  if (file.type === 'collection.insomnia.rest/5.0') {
-    return [getWorkspace(file), ...getEnvironments(file), ...getCookieJar(file), ...getCollection(file)];
-  }
+  if (fileSchemaParser.success) {
+    const file = fileSchemaParser.data;
+    if (file.type === 'collection.insomnia.rest/5.0') {
+      return [getWorkspace(file), ...getEnvironments(file), ...getCookieJar(file), ...getCollection(file)];
+    }
 
-  if (file.type === 'spec.insomnia.rest/5.0') {
-    return [
-      getWorkspace(file),
-      ...getEnvironments(file),
-      ...getCookieJar(file),
-      ...getCollection(file),
-      ...getApiSpec(file),
-      ...getTestSuites(file),
-    ];
-  }
+    if (file.type === 'spec.insomnia.rest/5.0') {
+      return [
+        getWorkspace(file),
+        ...getEnvironments(file),
+        ...getCookieJar(file),
+        ...getCollection(file),
+        ...getApiSpec(file),
+        ...getTestSuites(file),
+      ];
+    }
 
-  if (file.type === 'environment.insomnia.rest/5.0') {
-    return [getWorkspace(file), ...getEnvironments(file)];
+    if (file.type === 'environment.insomnia.rest/5.0') {
+      return [getWorkspace(file), ...getEnvironments(file)];
+    }
+
+    if (file.type === 'mock.insomnia.rest/5.0') {
+      return [getWorkspace(file), getMockServer(file), ...getMockRoutes(file)];
+    }
+    // @ts-expect-error this errors happen when new types are added but not handled here
+    throw new Error(`No import handler found for type ${file.type}`);
   }
-  return [getWorkspace(file), getMockServer(file), ...getMockRoutes(file)];
+  throw new Error(`Failed to parse yaml file to Insomnia schema ${fileSchemaParser.error?.toString()}`);
 }
 
 /**

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -746,21 +746,28 @@ export const initGitRepoCloneAction = async ({
   const insomniaFiles = await recursivelyFindInsomniaFiles(inMemoryFsClient, GIT_CLONE_DIR);
   // Get all files that start with 'insomnia.' recursively in the root directory
 
-  const files = await Promise.all(
-    insomniaFiles.map(async file => {
-      const fileContents = await inMemoryFsClient.promises.readFile(path.join(GIT_CLONE_DIR, file), 'utf8');
+  const files: {
+    scope: WorkspaceScope;
+    name: string;
+    path: string;
+  }[] = [];
 
-      // Apply schema migration before parsing to handle older schema versions
-      const migratedContents = migrateToLatestYaml(fileContents);
-      const insomniaFile = InsomniaFileSchema.parse(YAML.parse(migratedContents));
-
-      return {
+  for (const file of insomniaFiles) {
+    const fileContents = await inMemoryFsClient.promises.readFile(path.join(GIT_CLONE_DIR, file), 'utf8');
+    // Apply schema migration before parsing to handle older schema versions
+    const migratedContents = migrateToLatestYaml(fileContents);
+    const yamlDocument = parse(migratedContents);
+    const fileSchemaParser = InsomniaFileSchema.safeParse(yamlDocument);
+    // Validate that the file conforms to the Insomnia file schema
+    if (fileSchemaParser.success) {
+      const insomniaFile = fileSchemaParser.data;
+      files.push({
         scope: insomniaSchemaTypeToScope(insomniaFile.type),
         name: insomniaFile.name || 'Untitled',
         path: file,
-      };
-    }),
-  );
+      });
+    }
+  }
 
   const legacyInsomniaFile = await containsLegacyInsomniaDir({ fsClient: inMemoryFsClient });
 

--- a/packages/insomnia/src/sync/git/project-ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/project-ne-db-client.ts
@@ -5,7 +5,6 @@ import YAML from 'yaml';
 
 import { database, database as db } from '../../common/database';
 import { extractErrorMessages } from '../../common/import';
-
 import type { InsomniaFile } from '../../common/import-v5-parser';
 import { getInsomniaV5DataExport, tryImportV5Data } from '../../common/insomnia-v5';
 import * as models from '../../models';

--- a/packages/insomnia/src/sync/git/project-ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/project-ne-db-client.ts
@@ -5,12 +5,13 @@ import YAML from 'yaml';
 
 import { database, database as db } from '../../common/database';
 import type { InsomniaFile } from '../../common/import-v5-parser';
-import { getInsomniaV5DataExport, importInsomniaV5Data } from '../../common/insomnia-v5';
+import { getInsomniaV5DataExport, tryImportV5Data } from '../../common/insomnia-v5';
 import * as models from '../../models';
 import { isMcp, isWorkspace, type Workspace } from '../../models/workspace';
 import type { WorkspaceMeta } from '../../models/workspace-meta';
 import Stat from './stat';
 import { SystemError } from './system-error';
+import { extractErrorMessages } from '~/common/import';
 
 /**
  * A fs client to access workspace data stored in NeDB as files.
@@ -82,7 +83,12 @@ export class GitProjectNeDBClient {
     if (dataStr.split('\n').includes('=======')) {
       return;
     }
-    const dataToImport = importInsomniaV5Data(dataStr);
+    const { data: dataToImport, error } = tryImportV5Data(dataStr);
+    if (error) {
+      const errorMsg = extractErrorMessages(error);
+      console.warn(`[git] Skipping import of ${filePath} due to error: ${errorMsg}.  Fallback to default FS.`);
+      throw new Error(`Failed to import data from git file ${filePath}: ${errorMsg}`);
+    }
 
     const bufferId = await db.bufferChanges();
 

--- a/packages/insomnia/src/sync/git/project-ne-db-client.ts
+++ b/packages/insomnia/src/sync/git/project-ne-db-client.ts
@@ -4,6 +4,8 @@ import type { PromiseFsClient } from 'isomorphic-git';
 import YAML from 'yaml';
 
 import { database, database as db } from '../../common/database';
+import { extractErrorMessages } from '../../common/import';
+
 import type { InsomniaFile } from '../../common/import-v5-parser';
 import { getInsomniaV5DataExport, tryImportV5Data } from '../../common/insomnia-v5';
 import * as models from '../../models';
@@ -11,7 +13,6 @@ import { isMcp, isWorkspace, type Workspace } from '../../models/workspace';
 import type { WorkspaceMeta } from '../../models/workspace-meta';
 import Stat from './stat';
 import { SystemError } from './system-error';
-import { extractErrorMessages } from '~/common/import';
 
 /**
  * A fs client to access workspace data stored in NeDB as files.


### PR DESCRIPTION
## Background
Currently we're using `InsomniaFileSchema.parse` to parse git yaml files directly. Whenever it meets malformed yaml files or yaml file that is not supported for current version, it will throw error and the application will crash. 

## Changes
- Using `InsomniaFileSchema.safeParser` to parse yaml files instead. 
- Throw error when `file.type` is not recognized rather than fall back to mock server workspace by default
- Add unit test to cover unsupported yaml file

[INS-1763](https://konghq.atlassian.net/browse/INS-1763)

[INS-1763]: https://konghq.atlassian.net/browse/INS-1763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ