### PR TITLE
chore: enable react-hooks/purity rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -97,7 +97,6 @@ export default defineConfig([
       'react-hooks/immutability': 'off', //TODO: delete me
       'react-hooks/preserve-manual-memoization': 'off', //TODO: delete me
       'react-hooks/incompatible-library': 'off', //TODO(use react-aria virtualizer): delete me
-      'react-hooks/purity': 'off', //TODO(bingbing): delete me
     },
   },
   {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -1288,6 +1288,8 @@ const ScratchPadTutorialPanel = () => {
     dismissedAt: number;
   }>('scratchpad-sign-up-tip-dismissed', { dismissed: false, dismissedAt: 0 });
 
+  const [currentTime] = useState(() => Date.now());
+
   const handleDismiss = () => {
     setSignUpTipDismissedState({ dismissed: true, dismissedAt: Date.now() });
   };
@@ -1315,10 +1317,9 @@ const ScratchPadTutorialPanel = () => {
     }
 
     const twoWeeksInMs = 14 * 24 * 60 * 60 * 1000;
-    const now = Date.now();
 
-    return now - signUpTipDismissedState.dismissedAt >= twoWeeksInMs;
-  }, [signUpTipDismissedState]);
+    return currentTime - signUpTipDismissedState.dismissedAt >= twoWeeksInMs;
+  }, [signUpTipDismissedState, currentTime]);
 
   return (
     <>


### PR DESCRIPTION
## Background
[INS-1769](https://konghq.atlassian.net/browse/INS-1769)
Enable the eslint rule `react-hooks/purity`

## Changes

- Enable the rule and fix
- Most of the changes are introduced by tailwind classname prettier plugin

[INS-1769]: https://konghq.atlassian.net/browse/INS-1769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ