### PR TITLE
fix: tailwind v4 border issue

### DIFF
--- a/packages/insomnia/src/ui/components/mcp/event-view.tsx
+++ b/packages/insomnia/src/ui/components/mcp/event-view.tsx
@@ -172,7 +172,7 @@ export const MessageEventView = ({ event }: Props) => {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="box-border flex h-8 flex-row border-b border-gray-300">
+      <div className="box-border flex h-8 flex-row items-center border-b border-(--hl-md)">
         <Dropdown
           aria-label="Websocket Preview Mode Dropdown"
           className="p-2"

--- a/packages/insomnia/src/ui/components/mcp/mcp-notification-tab.tsx
+++ b/packages/insomnia/src/ui/components/mcp/mcp-notification-tab.tsx
@@ -73,7 +73,7 @@ export const McpNotificationTab = ({ allEvents }: McpNotificationTabProps) => {
         <>
           <PanelResizeHandle className={'h-px w-full bg-(--hl-md)'} />
           <Panel minSize={10} defaultSize={50}>
-            <div className="h-full flex-1 border-t border-(--hl-md)">
+            <div className="h-full flex-1">
               <McpEventView event={selectedEvent} key={selectedEvent._id} />
             </div>
           </Panel>

--- a/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/runner-test-result-pane.tsx
@@ -58,7 +58,6 @@ export const RunnerTestResultPane: FC<Props> = ({ result }) => {
       return (
         <div key={key} data-testid={key} className="border-b border-dashed border-b-(--hl-md) pt-6 pb-6">
           <div className="mb-3 pl-3 leading-10 font-bold uppercase"> Iteration {i + 1} </div>
-          <div className="border border-solid border-gray-600" />
           {resultByRequest}
         </div>
       );

--- a/packages/insomnia/src/ui/components/websockets/event-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-view.tsx
@@ -75,7 +75,7 @@ export const MessageEventView: FC<Props<CurlMessageEvent | WebSocketMessageEvent
   const previewMode = ('previewMode' in activeRequestMeta && activeRequestMeta.previewMode) || PREVIEW_MODE_SOURCE;
   return (
     <div className="flex h-full flex-col">
-      <div className="box-border flex h-8 flex-row border-b border-gray-300 p-2">
+      <div className="box-border flex h-8 items-center border-b border-(--hl-sm) p-2">
         <WebSocketPreviewModeDropdown
           download={handleDownloadResponseBody}
           copyToClipboard={handleCopyResponseToClipboard}

--- a/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
@@ -395,7 +395,7 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
                   <>
                     <PanelResizeHandle className={'h-px w-full bg-(--hl-md)'} />
                     <Panel minSize={10} defaultSize={isMcpResponse(response) ? 85 : 60}>
-                      <div className="h-full flex-1 border-t border-(--hl-md)">{getEventView(selectedEvent)}</div>
+                      <div className="h-full flex-1">{getEventView(selectedEvent)}</div>
                     </Panel>
                   </>
                 )}


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

In Tailwind v3, we need to set border style explicitly, otherwise the border style will be none.(Tailwind has a default solid style, but we reset the border style to none)

In Tailwind v4, the Tailwind default border style has a higher specificity than the reset CSS in our repo.
