### PR TITLE
fix(ui): sanitize search fields to prevent crash on non-string values

### DIFF
--- a/packages/insomnia/src/ui/hooks/use-filtered-requests.ts
+++ b/packages/insomnia/src/ui/hooks/use-filtered-requests.ts
@@ -14,15 +14,13 @@ interface SearchableFields {
 }
 
 function isMatched(filter: string, doc: SearchableFields): boolean {
-  // FIX for Issue #9392: Defensive coding to prevent .trim() crashes.
-  // We ensure all fields are converted to Strings and nulls/undefined are removed.
   const searchTargets = [
     doc.name,
     doc.description,
     ...(isRequestGroup(doc) ? [] : [doc.url]),
   ]
-    .filter(field => field !== null && field !== undefined) // Remove empty slots
-    .map(field => String(field)); // Force convert numbers/objects to string
+    .filter(field => field !== null && field !== undefined)
+    .map(field => String(field));
 
   return Boolean(
     fuzzyMatchAll(filter, searchTargets, {

--- a/packages/insomnia/src/ui/hooks/use-filtered-requests.ts
+++ b/packages/insomnia/src/ui/hooks/use-filtered-requests.ts
@@ -14,8 +14,18 @@ interface SearchableFields {
 }
 
 function isMatched(filter: string, doc: SearchableFields): boolean {
+  // FIX for Issue #9392: Defensive coding to prevent .trim() crashes.
+  // We ensure all fields are converted to Strings and nulls/undefined are removed.
+  const searchTargets = [
+    doc.name,
+    doc.description,
+    ...(isRequestGroup(doc) ? [] : [doc.url]),
+  ]
+    .filter(field => field !== null && field !== undefined) // Remove empty slots
+    .map(field => String(field)); // Force convert numbers/objects to string
+
   return Boolean(
-    fuzzyMatchAll(filter, [doc.name, doc.description, ...(isRequestGroup(doc) ? [] : [doc.url!])], {
+    fuzzyMatchAll(filter, searchTargets, {
       splitSpace: false,
       loose: true,
     })?.indexes,


### PR DESCRIPTION
### Description
This PR fixes a crash in the application search bar (Issue #9392) where `TypeError: I.trim is not a function` would occur if a searchable field (like `description`) contained a non-string value (e.g., a number or object) from a malformed import or database state.

### The Fix
I updated the `isMatched` function in `use-filtered-requests.ts` to implement a sanitization pipeline:
1. **Filter:** Explicitly removes `null` or `undefined` values.
2. **Coercion:** Maps all remaining fields to `String()` before passing them to the fuzzy matcher.

This ensures that `trim()` is never called on a non-string type, preventing the runtime crash.

### Verification
**Reproduction:**
I reproduced the crash locally by importing a workspace with a numeric `description` field (`12345` instead of `"12345"`). The app previously crashed upon typing in the search bar.

**Validation:**
With this fix applied, searching against the same malformed data works correctly. The numeric values are coerced to strings and matched without error.

Closes #9392