### PR TITLE
fix: Open MCP manage certificates modal instead of settings modal for disable SSL validation

### DIFF
--- a/packages/insomnia/src/ui/components/viewers/response-error-viewer.tsx
+++ b/packages/insomnia/src/ui/components/viewers/response-error-viewer.tsx
@@ -1,24 +1,38 @@
-import React, { type FC, memo } from 'react';
+import React, { type FC, memo, useState } from 'react';
 
 import { useRootLoaderData } from '~/root';
 
 import { docsBase } from '../../../common/documentation';
 import { Link } from '../base/link';
 import { showModal } from '../modals/index';
+import { MCPCertificatesModal } from '../modals/mcp-certificates-modal';
 import { SettingsModal } from '../modals/settings-modal';
+
 interface Props {
   error: string;
   url: string;
   docsLink?: string;
+  isMcpResponse?: boolean;
 }
-export const ResponseErrorViewer: FC<Props> = memo(({ error, docsLink }) => {
+export const ResponseErrorViewer: FC<Props> = memo(({ error, docsLink, isMcpResponse }) => {
+  const [isCertificatesModalOpen, setCertificatesModalOpen] = useState(false);
   let msg: React.ReactNode = null;
   const { settings } = useRootLoaderData()!;
   const { editorFontSize } = settings;
 
   if (error?.toLowerCase().indexOf('certificate') !== -1) {
     msg = (
-      <button className="btn btn--clicky" onClick={() => showModal(SettingsModal)}>
+      <button
+        className="btn btn--clicky"
+        onClick={() => {
+          if (isMcpResponse) {
+            // for mcp request, open manage certificates modal
+            setCertificatesModalOpen(true);
+          } else {
+            showModal(SettingsModal);
+          }
+        }}
+      >
         Disable SSL Validation
       </button>
     );
@@ -55,6 +69,7 @@ export const ResponseErrorViewer: FC<Props> = memo(({ error, docsLink }) => {
           Contact Support
         </Link>
       </div>
+      {isCertificatesModalOpen && <MCPCertificatesModal onClose={() => setCertificatesModalOpen(false)} />}
     </div>
   );
 });

--- a/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
@@ -379,7 +379,12 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
                   )}
                 </Panel>
                 {isMCPAuthError ? (
-                  <ResponseErrorViewer url={response.url} error={response.error} docsLink={docsMcpAuthentication} />
+                  <ResponseErrorViewer
+                    url={response.url}
+                    error={response.error}
+                    docsLink={docsMcpAuthentication}
+                    isMcpResponse
+                  />
                 ) : null}
                 {selectedEvent && (
                   <>


### PR DESCRIPTION
Fix the issue that when MCP request auth fails, the `Disable SSL Validation` should open `Manage Certificates` modal rather than normal `Settings` modal.


[INS-1832](https://konghq.atlassian.net/browse/INS-1832)

[INS-1832]: https://konghq.atlassian.net/browse/INS-1832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ