### PR TITLE
[INS-1797] fix importing wsdl files with references

### DIFF
--- a/packages/insomnia/esbuild.entrypoints.ts
+++ b/packages/insomnia/esbuild.entrypoints.ts
@@ -106,6 +106,7 @@ export default async function build(options: Options) {
       '@reflink/reflink-linux-x64-musl',
       '@reflink/reflink-win32-arm64-msvc',
       '@reflink/reflink-win32-x64-msvc',
+      'apiconnect-wsdl',
       ...Object.keys(builtinModules),
     ],
   };


### PR DESCRIPTION
# Overview

Currently importing WSDL files with references fails due to the way we bundle the wsdl parsing package.

# Solution

- [x] Move apiconnect-wsdl to external dependencies so that it works as previously