### PR TITLE
fix: handle missing active workspace by redirecting to project overview

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.tsx
@@ -1,4 +1,4 @@
-import { href, Outlet, useRouteLoaderData } from 'react-router';
+import { href, Outlet, redirect, useRouteLoaderData } from 'react-router';
 
 import type { SortOrder } from '~/common/constants';
 import { database } from '~/common/database';
@@ -68,6 +68,10 @@ export async function clientLoader({ params, request }: Route.ClientLoaderArgs) 
   const { organizationId, projectId, workspaceId } = params;
 
   const activeWorkspace = await models.workspace.getById(workspaceId);
+
+  if (!activeWorkspace) {
+    throw redirect(href('/organization/:organizationId/project/:projectId', { organizationId, projectId }));
+  }
 
   invariant(activeWorkspace, 'Workspace not found');
 


### PR DESCRIPTION
# Overview

When a workspace is deleted by switching a branch and it is the active empty view an error is thrown in the UI

# Solution

This PR adds a redirect to the project in case the workspace is not found to make sure we don't have any errors like this again.