### PR TITLE
fix: improve layout of NoProjectView component

### DIFF
--- a/packages/insomnia/src/ui/components/panes/no-project-view.tsx
+++ b/packages/insomnia/src/ui/components/panes/no-project-view.tsx
@@ -11,11 +11,11 @@ interface Props {
 
 export const NoProjectView: FC<Props> = ({ storageRules, isGitSyncEnabled }) => {
   return (
-    <div className="h-full overflow-y-auto pt-16">
+    <div className="h-full overflow-y-auto px-8 pt-16">
       <div className="max-h-full text-center">
         <p className="mb-3 text-xl font-semibold">Welcome to your organization!</p>
         <p className="mb-3">Create a new project to get started</p>
-        <div className="flex justify-center">
+        <div className="mx-auto flex max-w-2xl justify-center pb-16">
           <ProjectCreateForm
             storageRules={storageRules}
             isGitSyncEnabled={isGitSyncEnabled}


### PR DESCRIPTION
# Overview

- [x] Adds scroll overflow and padding to the new project form when there are no projects under an organization