### PR TITLE
[INS-1473] fix credentials not reloading in Git form

### DIFF
--- a/packages/insomnia/src/routes/git-credentials.github.tsx
+++ b/packages/insomnia/src/routes/git-credentials.github.tsx
@@ -8,7 +8,9 @@ import type { Route } from './+types/git-credentials.github';
 export async function clientLoader(_args: Route.ClientActionArgs) {
   const credentials = await gitCredentials.getByProvider('github');
 
-  return credentials;
+  return {
+    credentials,
+  };
 }
 
 export const useGitHubCredentialsFetcher = createFetcherLoadHook(

--- a/packages/insomnia/src/routes/git-credentials.gitlab.tsx
+++ b/packages/insomnia/src/routes/git-credentials.gitlab.tsx
@@ -8,7 +8,7 @@ import type { Route } from './+types/git-credentials.gitlab';
 export async function clientLoader(_args: Route.ClientActionArgs) {
   const credentials = await gitCredentials.getByProvider('gitlab');
 
-  return credentials;
+  return { credentials };
 }
 
 export const useGitLabCredentialsFetcher = createFetcherLoadHook(

--- a/packages/insomnia/src/ui/components/git-credentials/github-repository-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/github-repository-settings-form.tsx
@@ -28,7 +28,7 @@ export const GitHubRepositorySetupFormGroup = (props: Props) => {
     }
   }, [githubTokenLoader]);
 
-  const credentials = githubTokenLoader.data;
+  const credentials = githubTokenLoader.data?.credentials;
 
   if (!credentials?.token) {
     return <GitHubSignInForm />;

--- a/packages/insomnia/src/ui/components/git-credentials/github-repository-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/github-repository-settings-form.tsx
@@ -123,7 +123,8 @@ const GitHubRepositoryForm = ({
         </div>
         <PromptButton
           confirmMessage="Confirm"
-          onClick={() => {
+          onClick={e => {
+            e.preventDefault();
             signOutFetcher.submit();
           }}
         >

--- a/packages/insomnia/src/ui/components/git-credentials/gitlab-repository-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/gitlab-repository-settings-form.tsx
@@ -27,7 +27,7 @@ export const GitLabRepositorySetupFormGroup = (props: Props) => {
     }
   }, [gitlabTokenLoader]);
 
-  const credentials = gitlabTokenLoader.data;
+  const credentials = gitlabTokenLoader.data?.credentials;
 
   if (!credentials?.token) {
     return <GitLabSignInForm />;

--- a/packages/insomnia/src/ui/components/git-credentials/gitlab-repository-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/gitlab-repository-settings-form.tsx
@@ -105,7 +105,8 @@ const GitLabRepositoryForm = ({ uri, credentials, onSubmit }: GitLabRepositoryFo
           </div>
         </div>
         <PromptButton
-          onClick={() => {
+          onClick={e => {
+            e.preventDefault();
             signOutFetcher.submit();
           }}
         >

--- a/packages/insomnia/src/ui/components/project/project-create-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-create-form.tsx
@@ -141,7 +141,7 @@ export const ProjectCreateForm: FC<Props> = ({
                 slot={null}
                 isSelected={projectData.connectRepositoryLater}
                 onChange={isSelected => setProjectData(prev => ({ ...prev, connectRepositoryLater: isSelected }))}
-                className="group mt-4 flex h-full items-center gap-2 p-0 pl-[1px]"
+                className="group mt-4 flex h-full items-center gap-2 p-0 pl-px"
               >
                 <div className="flex h-4 w-4 items-center justify-center rounded-sm ring-1 ring-(--hl-sm) transition-colors group-focus:ring-2 group-data-selected:bg-(--hl-xs)">
                   <Icon


### PR DESCRIPTION
# Overview

- [x] Update the credentials api for both gitlab and github to return an object with the credentials instead of the credentials directly. This ensures the effect that loads the data runs appropriately only when the data are missing.
- [x] Prevent the default of the `Disconnect` prompt button event since it was trying to submit the form and could lead to weird race conditions