### PR TITLE
fix(ui): persist active request pane tab state

### DIFF
--- a/packages/insomnia/src/ui/components/markdown-preview.tsx
+++ b/packages/insomnia/src/ui/components/markdown-preview.tsx
@@ -20,7 +20,7 @@ export const MarkdownPreview: FC<Props> = ({ markdown, heading }) => {
     let shouldUpdate = true;
     const fn = async () => {
       try {
-        const compiled = markdownToHTML(markdown);
+        const compiled = markdownToHTML(String(markdown || '')); 
         shouldUpdate && setCompiled(compiled);
         shouldUpdate && setError('');
       } catch (err) {

--- a/packages/insomnia/src/ui/components/markdown-preview.tsx
+++ b/packages/insomnia/src/ui/components/markdown-preview.tsx
@@ -20,7 +20,7 @@ export const MarkdownPreview: FC<Props> = ({ markdown, heading }) => {
     let shouldUpdate = true;
     const fn = async () => {
       try {
-        const compiled = markdownToHTML(String(markdown || '')); 
+        const compiled = markdownToHTML(markdown);
         shouldUpdate && setCompiled(compiled);
         shouldUpdate && setError('');
       } catch (err) {

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -96,8 +96,8 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
   const isBodyEmpty = Boolean(typeof activeRequest.body.mimeType !== 'string' && !activeRequest.body.text);
   const requestAuth = getAuthObjectOrNull(activeRequest.authentication);
   const isNoneOrInherited = requestAuth?.type === 'none' || requestAuth === null;
-  const storageKey = `request-tab-selection:${requestId}`;
-  const [activeTab, setActiveTab] = reactUse.useLocalStorage(storageKey, 'params');
+  const activeRequestTabKey = `request-tab-selection:${requestId}`;
+  const [activeRequestTab, setActiveRequestTab] = reactUse.useLocalStorage(activeRequestTabKey, 'params');
 
   return (
     <Pane type="request">
@@ -116,8 +116,8 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
       <Tabs 
           aria-label="Request pane tabs" 
           className="flex h-full w-full flex-1 flex-col" 
-          selectedKey={activeTab || 'params'}
-          onSelectionChange={(key) => setActiveTab(key as string)}>
+          selectedKey={activeRequestTab || 'params'}
+          onSelectionChange={(key) => setActiveRequestTab(key as string)}>
         <TabList
           className="scrollbar-thin flex h-(--line-height-sm) w-full shrink-0 items-center overflow-x-auto border-b border-solid border-b-(--hl-md) bg-(--color-bg)"
           aria-label="Request pane tabs"

--- a/packages/insomnia/src/ui/components/panes/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/panes/request-pane.tsx
@@ -96,6 +96,8 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
   const isBodyEmpty = Boolean(typeof activeRequest.body.mimeType !== 'string' && !activeRequest.body.text);
   const requestAuth = getAuthObjectOrNull(activeRequest.authentication);
   const isNoneOrInherited = requestAuth?.type === 'none' || requestAuth === null;
+  const storageKey = `request-tab-selection:${requestId}`;
+  const [activeTab, setActiveTab] = reactUse.useLocalStorage(storageKey, 'params');
 
   return (
     <Pane type="request">
@@ -111,7 +113,11 @@ export const RequestPane: FC<Props> = ({ environmentId, settings, onPaste }) => 
           />
         </ErrorBoundary>
       </PaneHeader>
-      <Tabs aria-label="Request pane tabs" className="flex h-full w-full flex-1 flex-col">
+      <Tabs 
+          aria-label="Request pane tabs" 
+          className="flex h-full w-full flex-1 flex-col" 
+          selectedKey={activeTab || 'params'}
+          onSelectionChange={(key) => setActiveTab(key as string)}>
         <TabList
           className="scrollbar-thin flex h-(--line-height-sm) w-full shrink-0 items-center overflow-x-auto border-b border-solid border-b-(--hl-md) bg-(--color-bg)"
           aria-label="Request pane tabs"


### PR DESCRIPTION
### Description
Closes #8774

This PR addresses a UX friction point where switching between requests causes the Request Pane to "forget" the user's active tab and setting it to the last one used by another request.

**Changes:**
- Implemented `useLocalStorage` in `RequestPane.tsx` to persist the `activeTab` state.
- State is keyed by `requestId` (e.g., `request-tab-selection:req_123`), ensuring every request maintains its own independent context.
- The state persists across app restarts, improving workflow continuity for users working with complex request setups.

### Testing Instructions
1. Open **Request A** and select the **"Body"** tab.
2. Switch to **Request B** and select the **"Headers"** tab.
3. Switch back to **Request A**.
   - **Expected:** The view immediately restores the **"Body"** tab.
4. Switch back to **Request B**.
   - **Expected:** The view immediately restores the **"Headers"** tab.
5. Close and reopen Insomnia.
   - **Expected:** The tab selections for both requests remain persisted.

https://github.com/user-attachments/assets/49f7f3b8-972d-483f-bd57-df38526a4741

