### PR TITLE
feat(Project Modal): Sticky action toolbar on the bottom of the modal

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.update.tsx
@@ -9,6 +9,7 @@ import { EMPTY_GIT_PROJECT_ID } from '~/models/project';
 import type { WorkspaceMeta } from '~/models/workspace-meta';
 import { reportGitProjectCount } from '~/routes/organization.$organizationId.project.new';
 import { SegmentEvent } from '~/ui/analytics';
+import { showToast } from '~/ui/components/toast-notification';
 import { insomniaFetch } from '~/ui/insomnia-fetch';
 import { invariant } from '~/utils/invariant';
 import { createFetcherSubmitHook } from '~/utils/router';
@@ -73,12 +74,25 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
           error = 'The owner of the organization allows only Local Vault project creation, please try again.';
         }
 
+        showToast({
+          title: 'Error updating project',
+          description: error,
+          icon: 'warning',
+          status: 'error',
+        });
+
         return {
           error,
         };
       }
 
       await models.project.update(project, { name });
+
+      showToast({
+        title: 'Project updated',
+        status: 'success',
+      });
+
       return {
         success: true,
       };
@@ -115,12 +129,25 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
           error = 'The owner of the organization allows only Cloud Sync project creation, please try again.';
         }
 
+        showToast({
+          title: 'Error updating project',
+          description: error,
+          icon: 'warning',
+          status: 'error',
+        });
+
         return {
           error,
         };
       }
 
       await models.project.update(project, { name, remoteId: null });
+
+      showToast({
+        title: 'Project updated',
+        status: 'success',
+      });
+
       return {
         success: true,
       };
@@ -168,6 +195,13 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
           error = 'The owner of the organization allows only Local Vault project creation, please try again.';
         }
 
+        showToast({
+          title: 'Error updating project',
+          description: error,
+          icon: 'warning',
+          status: 'error',
+        });
+
         return {
           error,
         };
@@ -182,6 +216,12 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
       await models.project.update(project, { name, remoteId: newCloudProject.id, gitRepositoryId: null });
 
       project.gitRepositoryId && reportGitProjectCount(organizationId, sessionId);
+
+      showToast({
+        title: 'Project updated',
+        status: 'success',
+      });
+
       return {
         success: true,
       };
@@ -218,6 +258,13 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
           if (response.error === 'PROJECT_STORAGE_RESTRICTION') {
             error = 'The owner of the organization allows only Cloud Sync project creation, please try again.';
           }
+
+          showToast({
+            title: 'Error updating project',
+            description: error,
+            icon: 'warning',
+            status: 'error',
+          });
 
           return {
             error,
@@ -275,6 +322,13 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
         await database.flushChanges(bufferId);
 
         if (errors) {
+          showToast({
+            title: 'Error updating project',
+            description: errors.join(', '),
+            icon: 'warning',
+            status: 'error',
+          });
+
           return {
             error: errors.join(', '),
           };
@@ -282,6 +336,11 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
       }
 
       reportGitProjectCount(organizationId, sessionId);
+
+      showToast({
+        title: 'Project updated',
+        status: 'success',
+      });
 
       return {
         success: true,
@@ -321,6 +380,12 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
         },
         ref: projectData.ref,
       });
+
+      showToast({
+        title: 'Project updated',
+        status: 'success',
+      });
+
       return {
         success: true,
       };
@@ -335,6 +400,11 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
 
       reportGitProjectCount(organizationId, sessionId);
 
+      showToast({
+        title: 'Project updated',
+        status: 'success',
+      });
+
       return {
         success: true,
       };
@@ -348,6 +418,11 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
       properties: {
         storage: 'local',
       },
+    });
+
+    showToast({
+      title: 'Project updated',
+      status: 'success',
     });
 
     return {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.new.tsx
@@ -7,6 +7,7 @@ import * as models from '~/models';
 import type { GitCredentials, OauthProviderName } from '~/models/git-repository';
 import { EMPTY_GIT_PROJECT_ID, type Project } from '~/models/project';
 import { SegmentEvent } from '~/ui/analytics';
+import { showToast } from '~/ui/components/toast-notification';
 import { insomniaFetch } from '~/ui/insomnia-fetch';
 import { invariant } from '~/utils/invariant';
 import { createFetcherSubmitHook } from '~/utils/router';
@@ -183,6 +184,10 @@ export const createProject = async (organizationId: string, newProjectData: Crea
     },
   });
 
+  showToast({
+    title: 'Project created',
+    status: 'success',
+  });
   return newProjectId;
 };
 

--- a/packages/insomnia/src/ui/components/git/connection-info.tsx
+++ b/packages/insomnia/src/ui/components/git/connection-info.tsx
@@ -13,14 +13,18 @@ export const GitConnectionInfo = ({ gitRepository }: { gitRepository?: GitReposi
     <div className="text-[12px]">
       <div className="mb-6 font-semibold text-(--hl)">Connection Info</div>
       <div className="flex flex-col gap-4">
-        <div className="flex">
-          <div className="w-[110px] font-semibold">Provider</div>
-          <GitProviderTag provider={provider} />
-        </div>
-        <div className="flex">
-          <div className="w-[110px] font-semibold">Repo URL</div>
-          <div>{repoUrl}</div>
-        </div>
+        <dl className="flex">
+          <dt className="w-[110px] font-semibold">Provider</dt>
+          <dd>
+            <GitProviderTag provider={provider} />
+          </dd>
+        </dl>
+        <dl className="flex">
+          <dt className="w-[110px] font-semibold">Repo URL</dt>
+          <dd>
+            <a href={repoUrl}>{repoUrl}</a>
+          </dd>
+        </dl>
         {/* TODO: get repo branch */}
         {/* <div className="flex">
           <div className="w-[110px] font-semibold">Base Branch</div>

--- a/packages/insomnia/src/ui/components/modals/project-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/project-modal.tsx
@@ -54,7 +54,7 @@ export const ProjectModal = ({
       <Modal className="flex max-h-[calc(var(--visual-viewport-height)-140px)] w-full max-w-3xl flex-col overflow-hidden rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) text-(--color-font)">
         <Dialog
           aria-label="Create or update dialog"
-          className="grid flex-1 grid-rows-[min-content_1fr] gap-4 overflow-hidden p-10 outline-hidden"
+          className="grid flex-1 grid-rows-[min-content_1fr_min-content] gap-4 overflow-hidden p-10 outline-hidden"
         >
           {({ close }) => (
             <>

--- a/packages/insomnia/src/ui/components/panes/no-project-view.tsx
+++ b/packages/insomnia/src/ui/components/panes/no-project-view.tsx
@@ -1,4 +1,5 @@
 import React, { type FC } from 'react';
+import { Heading } from 'react-aria-components';
 
 import type { StorageRules } from '~/models/organization';
 
@@ -11,18 +12,16 @@ interface Props {
 
 export const NoProjectView: FC<Props> = ({ storageRules, isGitSyncEnabled }) => {
   return (
-    <div className="h-full overflow-y-auto px-8 pt-16">
-      <div className="max-h-full text-center">
-        <p className="mb-3 text-xl font-semibold">Welcome to your organization!</p>
-        <p className="mb-3">Create a new project to get started</p>
-        <div className="mx-auto flex max-w-2xl justify-center pb-16">
-          <ProjectCreateForm
-            storageRules={storageRules}
-            isGitSyncEnabled={isGitSyncEnabled}
-            defaultProjectName="My first project"
-          />
-        </div>
+    <div className="grid w-[min(var(--container-xl),100%)] grid-rows-[min-content_1fr_min-content] place-items-stretch items-stretch gap-4 self-center overflow-hidden p-16">
+      <div>
+        <p className="mb-3 text-3xl font-semibold">Welcome to your organization!</p>
+        <Heading className="mb-3">Create a new project to get started</Heading>
       </div>
+      <ProjectCreateForm
+        storageRules={storageRules}
+        isGitSyncEnabled={isGitSyncEnabled}
+        defaultProjectName="My first project"
+      />
     </div>
   );
 };

--- a/packages/insomnia/src/ui/components/project/git-repo-scan-result.tsx
+++ b/packages/insomnia/src/ui/components/project/git-repo-scan-result.tsx
@@ -21,12 +21,14 @@ interface Props {
 
 export const GitRepoScanResult: FC<Props> = ({ initCloneGitRepositoryFetcher, insomniaFiles, repoURI }) => {
   const fileTypeCountMap: Partial<Record<ProjectScopeKeys, number>> = {};
+
   insomniaFiles?.forEach(({ scope }) => {
     if (!fileTypeCountMap[scope]) {
       fileTypeCountMap[scope] = 0;
     }
     fileTypeCountMap[scope]++;
   });
+
   return (
     <>
       <div className="rounded border border-solid border-(--hl-sm) px-4 pt-4 text-left">

--- a/packages/insomnia/src/ui/components/project/project-create-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-create-form.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import type { FC } from 'react';
 import React, { useEffect, useState } from 'react';
 import { Button, Input, Label, TextField } from 'react-aria-components';
@@ -102,16 +101,20 @@ export const ProjectCreateForm: FC<Props> = ({
   };
 
   return (
-    <div className="flex w-full flex-col gap-4 overflow-y-auto">
-      {error && (
-        <div className="flex items-center gap-2 rounded-xs bg-[rgba(var(--color-danger-rgb),0.5)] px-2 py-1 text-sm text-(--color-font-danger)">
-          <Icon icon="triangle-exclamation" />
-          <span>{error}</span>
-        </div>
-      )}
+    <>
+      {/* Content */}
+      <div className="flex flex-col gap-2 overflow-y-auto">
+        {error && (
+          <div className="flex items-center gap-2 rounded-xs bg-[rgba(var(--color-danger-rgb),0.5)] px-2 py-1 text-sm text-(--color-font-danger)">
+            <Icon icon="triangle-exclamation" />
+            <span>{error}</span>
+          </div>
+        )}
 
-      <div className={classNames({ hidden: activeView !== 'project' })}>
-        <div className="mt-4 flex w-full flex-col justify-start gap-4 pb-2 text-left">
+        {/* Important Note: We want to keep the state of the components so we only hide the contents */}
+        <div
+          className={`flex w-full flex-col justify-start gap-4 pb-2 text-left ${activeView === 'project' ? '' : 'hidden'}`}
+        >
           <TextField
             autoFocus
             name="name"
@@ -147,7 +150,20 @@ export const ProjectCreateForm: FC<Props> = ({
             />
           )}
         </div>
-        <div className="mt-4 flex w-full items-center justify-end gap-2 px-0.5">
+
+        <div className={activeView === 'git-results' ? '' : 'hidden'}>
+          <GitRepoScanResult
+            initCloneGitRepositoryFetcher={initCloneGitRepositoryFetcher}
+            insomniaFiles={insomniaFiles}
+            repoURI={projectData.uri}
+          />
+        </div>
+      </div>
+
+      {/* Actions */}
+
+      {activeView === 'project' && (
+        <div className="flex w-full items-center justify-end gap-2 px-0.5">
           <div className="flex items-center gap-2">
             {onCancel && (
               <Button
@@ -177,15 +193,10 @@ export const ProjectCreateForm: FC<Props> = ({
             )}
           </div>
         </div>
-      </div>
+      )}
 
-      <div className={classNames({ hidden: activeView !== 'git-results' })}>
-        <GitRepoScanResult
-          initCloneGitRepositoryFetcher={initCloneGitRepositoryFetcher}
-          insomniaFiles={insomniaFiles}
-          repoURI={projectData.uri}
-        />
-        <div className="mt-8 flex items-center justify-end gap-2">
+      {activeView === 'git-results' && (
+        <div className="flex items-center justify-end gap-2">
           <Button
             isDisabled={newProjectFetcher.state !== 'idle' || initCloneGitRepositoryFetcher.state !== 'idle'}
             onPress={() => {
@@ -229,7 +240,7 @@ export const ProjectCreateForm: FC<Props> = ({
             </Button>
           )}
         </div>
-      </div>
-    </div>
+      )}
+    </>
   );
 };

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -207,7 +207,13 @@ export const ProjectSettingsForm: FC<Props> = ({
                   : 'Anything added in the project will be securely synced to the Insomnia cloud and enables you to collaborate on projects with others. '
               }
               footer={
-                <LearnMoreLink href={'https://developer.konghq.com/insomnia/storage/'}>
+                <LearnMoreLink
+                  href={`https://developer.konghq.com/insomnia/storage/${
+                    isGitProject(project!)
+                      ? '#what-happens-if-i-change-a-git-sync-project-into-a-cloud-sync-project'
+                      : '#can-i-change-a-local-vault-project-into-a-cloud-sync-project'
+                  }`}
+                >
                   Learn more about changing project types
                 </LearnMoreLink>
               }
@@ -224,7 +230,13 @@ export const ProjectSettingsForm: FC<Props> = ({
                   : 'Your files will now be stored on your local machine. You will no longer be able to collaborate with others on this project.'
               }
               footer={
-                <LearnMoreLink href={'https://developer.konghq.com/insomnia/storage/'}>
+                <LearnMoreLink
+                  href={`https://developer.konghq.com/insomnia/storage/${
+                    isGitProject(project!)
+                      ? '#can-i-change-a-git-sync-project-into-a-local-vault-project'
+                      : '#can-i-change-a-cloud-sync-project-into-a-local-vault-project'
+                  }`}
+                >
                   Learn more about changing project types
                 </LearnMoreLink>
               }

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -121,7 +121,7 @@ export const ProjectSettingsForm: FC<Props> = ({
       gitRepository?.credentials && 'oauth2format' in gitRepository.credentials
         ? (gitRepository?.credentials?.oauth2format ?? 'github')
         : undefined,
-    connectRepositoryLater: Boolean(!gitRepository?._id),
+    connectRepositoryLater: false,
   });
 
   const initCloneGitRepositoryFetcher = useGitProjectInitCloneActionFetcher();

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import type { FC } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { Button, Input, Label, TextField } from 'react-aria-components';
@@ -159,16 +158,20 @@ export const ProjectSettingsForm: FC<Props> = ({
   };
 
   return (
-    <div className="flex w-full flex-col gap-4 overflow-y-auto">
-      {error && (
-        <div className="flex items-center gap-2 rounded-xs bg-[rgba(var(--color-danger-rgb),0.5)] px-2 py-1 text-sm text-(--color-font-danger)">
-          <Icon icon="triangle-exclamation" />
-          <span>{error}</span>
-        </div>
-      )}
+    <>
+      {/* Content */}
+      <div className="flex flex-col gap-2 overflow-y-auto">
+        {error && (
+          <div className="flex items-center gap-2 rounded-xs bg-[rgba(var(--color-danger-rgb),0.5)] px-2 py-1 text-sm text-(--color-font-danger)">
+            <Icon icon="triangle-exclamation" />
+            <span>{error}</span>
+          </div>
+        )}
 
-      <div className={classNames({ hidden: activeView !== 'project' })}>
-        <div className="mt-4 flex w-full flex-col justify-start gap-4 pb-2 text-left">
+        {/* Important Note: We want to keep the state of the components so we only hide the contents */}
+        <div
+          className={`flex w-full flex-col justify-start gap-4 pb-2 text-left ${activeView === 'project' ? '' : 'hidden'}`}
+        >
           <TextField
             autoFocus
             name="name"
@@ -246,7 +249,19 @@ export const ProjectSettingsForm: FC<Props> = ({
             ))}
         </div>
 
-        <div className="mt-4 flex w-full items-center justify-end gap-2 px-0.5">
+        <div className={activeView === 'git-results' ? '' : 'hidden'}>
+          <GitRepoScanResult
+            initCloneGitRepositoryFetcher={initCloneGitRepositoryFetcher}
+            insomniaFiles={insomniaFiles}
+            repoURI={projectData.uri}
+          />
+        </div>
+      </div>
+
+      {/* Actions */}
+
+      {activeView === 'project' && (
+        <div className="flex w-full items-center justify-end gap-2 px-0.5">
           <div className="flex items-center gap-2">
             {onCancel && (
               <Button
@@ -281,15 +296,10 @@ export const ProjectSettingsForm: FC<Props> = ({
             )}
           </div>
         </div>
-      </div>
+      )}
 
-      <div className={classNames({ hidden: activeView !== 'git-results' })}>
-        <GitRepoScanResult
-          initCloneGitRepositoryFetcher={initCloneGitRepositoryFetcher}
-          insomniaFiles={insomniaFiles}
-          repoURI={projectData.uri}
-        />
-        <div className="mt-8 flex items-center justify-end gap-2">
+      {activeView === 'git-results' && (
+        <div className="flex items-center justify-end gap-2">
           <Button
             isDisabled={updateProjectFetcher.state !== 'idle' || initCloneGitRepositoryFetcher.state !== 'idle'}
             onPress={() => {
@@ -333,7 +343,7 @@ export const ProjectSettingsForm: FC<Props> = ({
             </Button>
           )}
         </div>
-      </div>
-    </div>
+      )}
+    </>
   );
 };


### PR DESCRIPTION
# Overview

- [x] Use the grid layout on the modal and make sure the actions toolbar on the bottom is always displayed
- [x] Add toast notifications for creating/updating a project. Closes INS-1849
- [x] Fix empty organization view overflow
- [x] The url in the **Connection Info** view is now clickable

| View | Screenshot |
|--------|-------|
| Create project | <img width="668" height="448" alt="image" src="https://github.com/user-attachments/assets/df2b0fe3-dd4b-435d-8de9-d27f0caadde0" /> |
| Create project notification | <img width="191" height="64" alt="image" src="https://github.com/user-attachments/assets/643c29b0-5aab-477c-a081-2be970346b9d" /> |
| Update project | <img width="658" height="446" alt="image" src="https://github.com/user-attachments/assets/0378e55b-7aca-4bc6-8392-e97aeef17afd" /> |
| Update project notification | <img width="214" height="92" alt="image" src="https://github.com/user-attachments/assets/8f9330c8-5351-49d7-b70a-4894f217c585" /> |
| Empty organization view | <img width="525" height="387" alt="image" src="https://github.com/user-attachments/assets/dae4df49-7af0-477d-9883-b8f185e5d99f" /> |