### PR TITLE
Fix: revert structuredClone method used for clone in context menu

### DIFF
--- a/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/code-editor.tsx
@@ -744,7 +744,8 @@ export const CodeEditor = memo(
             event.preventDefault();
             const pluginTemplateTags = (await getTemplateTags()).map(tag => ({
               // Skip unsupported objects like functions in template tag to send in IPC
-              templateTag: structuredClone(tag.templateTag),
+              // eslint-disable-next-line unicorn/prefer-structured-clone
+              templateTag: JSON.parse(JSON.stringify(tag.templateTag)),
             }));
             const target = event.target as HTMLElement;
             // right click on nunjucks tag

--- a/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
+++ b/packages/insomnia/src/ui/components/.client/codemirror/one-line-editor.tsx
@@ -381,7 +381,8 @@ export const OneLineEditor = forwardRef<OneLineEditorHandle, OneLineEditorProps>
           event.preventDefault();
           const pluginTemplateTags = (await getTemplateTags()).map(tag => ({
             // Skip unsupported objects like functions in template tag to send in IPC
-            templateTag: structuredClone(tag.templateTag),
+            // eslint-disable-next-line unicorn/prefer-structured-clone
+            templateTag: JSON.parse(JSON.stringify(tag.templateTag)),
           }));
           const target = event.target as HTMLElement;
           // right click on nunjucks tag


### PR DESCRIPTION
The `tag.templateTag` methods contains function which can't be serialized.
Using `structuredClone` will use throw error so all context menu for editor will not work.

Revert to use the origin way of `JSON.parse(JSON.stringify(tag.templateTag))` to fix the issue
