### PR TITLE
fix: Insomnia V5.1 parser fails to parse legacy data with incomplete header data

### DIFF
--- a/packages/insomnia/src/common/__tests__/insomnia-v5.test.ts
+++ b/packages/insomnia/src/common/__tests__/insomnia-v5.test.ts
@@ -10,6 +10,7 @@ import YAML from 'yaml';
 
 import { INSOMNIA_SCHEMA_VERSION } from '../../common/insomnia-schema-migrations/schema-version';
 import * as models from '../../models';
+import type { Request } from '../../models/request';
 import { database as db } from '../database';
 import {
   getInsomniaV5DataExport,
@@ -332,7 +333,7 @@ collection: []
     });
   });
 
-  describe('Edge Cases', () => {
+  describe('Legacy Insomnia  Cases', () => {
     it('imports collection without meta', () => {
       const yaml = `
 type: collection.insomnia.rest/5.0
@@ -358,6 +359,40 @@ collection: []
       const result = tryImportV5Data(invalid);
       expect(result.data).toEqual([]);
       expect(result.error).toBeDefined();
+    });
+  });
+
+  describe('Handle legacy Insomnia files', () => {
+    it('imports collection with incomplete header', () => {
+      const yaml = `
+type: collection.insomnia.rest/5.0
+name: Test Collection
+meta:
+  id: wrk_legacy_insomnia_file
+  created: 1234567890
+  modified: 1234567890
+collection:
+  - name: Test Request
+    url: https://api.example.com/test
+    method: GET
+    meta:
+      id: req_test
+      created: 1234567890
+      modified: 1234567890
+    headers:
+      - name: missing_value_header
+      - name: number
+        value: "100"
+      - name: offset
+        value: "0"
+`;
+      const result = tryImportV5Data(yaml);
+      expect(result.error).toBeUndefined();
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0]._id).toBe('wrk_legacy_insomnia_file');
+      expect(result.data[1].type).toBe('Request');
+      const requestData = result.data[1] as Request;
+      expect(requestData.headers).toHaveLength(3);
     });
   });
 });

--- a/packages/insomnia/src/common/__tests__/insomnia-v5.test.ts
+++ b/packages/insomnia/src/common/__tests__/insomnia-v5.test.ts
@@ -333,7 +333,7 @@ collection: []
     });
   });
 
-  describe('Legacy Insomnia  Cases', () => {
+  describe('Edge Cases', () => {
     it('imports collection without meta', () => {
       const yaml = `
 type: collection.insomnia.rest/5.0

--- a/packages/insomnia/src/common/insomnia-schema-migrations/v5.1.ts
+++ b/packages/insomnia/src/common/insomnia-schema-migrations/v5.1.ts
@@ -117,6 +117,13 @@ export function cleanHeadersAndParameters(obj: any): any {
 
             const { id, ...rest } = entry; // remove `id` only here
 
+            if (key === 'headers' && !('name' in rest && 'value' in rest)) {
+              // Ensure headers have name and value fields
+              // Refer INS-1822, legacy app might have headers without name or value and that kind of request will be parsed as GRPC request
+              rest.name = rest.name || '';
+              rest.value = rest.value || '';
+            }
+
             return cleanHeadersAndParameters(rest);
           });
 


### PR DESCRIPTION
Legacy Insomnia will export files with value property missing in header items.
Since the value property of the header item is missing, the latest parser will parse the request as `GRPCRequest` rather than normal `Request`.
Fix to add default value for name or value when it is missing in each header item.

[INS-1822](https://konghq.atlassian.net/browse/INS-1822)

[INS-1822]: https://konghq.atlassian.net/browse/INS-1822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ