### PR TITLE
Remove unnecessary parameter in OAuth flow [INS-1859]

### DIFF
--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -195,7 +195,6 @@ export const getOAuth2Token = async (
         { name: 'grant_type', value: GRANT_TYPE_AUTHORIZATION_CODE },
         { name: 'code', value: redirectParams.code },
         ...insertAuthKeyIf('redirect_uri', redirectUrl),
-        ...insertAuthKeyIf('state', authentication.state),
         ...insertAuthKeyIf('audience', authentication.audience),
         ...insertAuthKeyIf('resource', authentication.resource),
         ...insertAuthKeyIf('code_verifier', codeVerifier),


### PR DESCRIPTION
We didn’t implement the OAuth2 flow strictly according to the spec.
According to the specification, the state parameter should only be sent to the Auth Provider during the authorization request. It does not need to be included when exchanging the authorization code for a token. However, we are currently also sending state in the code-to-token exchange. The user’s Auth server performs strict validation, detects the extra, unnecessary parameter, and therefore returns a 400 error.