### PR TITLE
feat: Allow empty credential configs to work with cloud providers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,8 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
           cache-dependency-path: package-lock.json
-          registry-url: "https://npm.pkg.github.com"
-          scope: "@kong"
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@kong'
 
       - name: Install packages
         run: npm ci
@@ -52,6 +52,8 @@ jobs:
 
       - name: Check Circular References
         uses: actions/github-script@v7
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: github.event_name == 'pull_request' && always()
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4066,9 +4066,9 @@
       ]
     },
     "node_modules/@kong/insomnia-plugin-external-vault": {
-      "version": "0.1.3",
-      "resolved": "https://npm.pkg.github.com/download/@kong/insomnia-plugin-external-vault/0.1.3/2daee6c43270d411accae9330aedff9c8ff8e327",
-      "integrity": "sha512-3//xSvw0Fg8vP7lHXCKa4wGYr2m6yDEGWls4YGNzSl/pIi9BOyoTnoNzkpOiWFUTNX1yCOQJUPPRFjE6ZbkEUA==",
+      "version": "0.1.4-dev.20251224090833",
+      "resolved": "https://npm.pkg.github.com/download/@kong/insomnia-plugin-external-vault/0.1.4-dev.20251224090833/d383d375e52d52688a87f837394e106db37771ec",
+      "integrity": "sha512-VpUgWXWw7lzQHxXLqa4RyAhaCcl1oSc9AEQFjRFY6sd+sz4ioJ4bUILOzVzDfHUyBCpvOK6iiyYUjdmKcUUaQQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -31072,7 +31072,7 @@
       },
       "optionalDependencies": {
         "@kong/insomnia-plugin-ai": "^1.0.7",
-        "@kong/insomnia-plugin-external-vault": "0.1.3"
+        "@kong/insomnia-plugin-external-vault": "0.1.4-dev.20251224090833"
       }
     },
     "packages/insomnia-api": {
@@ -31107,7 +31107,7 @@
         "shellwords": "^1.0.1"
       },
       "optionalDependencies": {
-        "@kong/insomnia-plugin-external-vault": "0.1.3"
+        "@kong/insomnia-plugin-external-vault": "0.1.4-dev.20251224090833"
       }
     },
     "packages/insomnia-inso/node_modules/consola": {

--- a/packages/insomnia-inso/package.json
+++ b/packages/insomnia-inso/package.json
@@ -66,6 +66,6 @@
     "yaml": "^2.7.1"
   },
   "optionalDependencies": {
-    "@kong/insomnia-plugin-external-vault": "0.1.3"
+    "@kong/insomnia-plugin-external-vault": "0.1.4-dev.20251224090833"
   }
 }

--- a/packages/insomnia/package.json
+++ b/packages/insomnia/package.json
@@ -202,7 +202,7 @@
   },
   "optionalDependencies": {
     "@kong/insomnia-plugin-ai": "^1.0.7",
-    "@kong/insomnia-plugin-external-vault": "0.1.3"
+    "@kong/insomnia-plugin-external-vault": "0.1.4-dev.20251224090833"
   },
   "dev": {
     "dev-server-port": 3334

--- a/packages/insomnia/src/account/session.ts
+++ b/packages/insomnia/src/account/session.ts
@@ -193,34 +193,7 @@ async function _removeAllCredentials() {
   const cloudCredentials = await cloudCredential.all();
   for (const cred of cloudCredentials) {
     if ('credentials' in cred) {
-      if ('secretAccessKey' in cred.credentials) {
-        removals.push(
-          cloudCredential.update(cred, {
-            // AWS
-            credentials: { ...cred.credentials, secretAccessKey: '', sessionToken: '' },
-          }),
-        );
-        continue;
-      }
-      // hashicorp
-      if ('access_token' in cred.credentials) {
-        removals.push(cloudCredential.update(cred, { credentials: { ...cred.credentials, access_token: '' } }));
-        continue;
-      }
-      if ('client_secret' in cred.credentials) {
-        removals.push(cloudCredential.update(cred, { credentials: { ...cred.credentials, client_secret: '' } }));
-        continue;
-      }
-      if ('secret_id' in cred.credentials) {
-        removals.push(
-          cloudCredential.update(cred, { credentials: { ...cred.credentials, secret_id: '', role_id: '' } }),
-        );
-        continue;
-      }
-      // azure
-      if ('accessToken' in cred.credentials) {
-        removals.push(cloudCredential.update(cred, { credentials: { ...cred.credentials, accessToken: '' } }));
-      }
+      removals.push(cloudCredential.update(cred, { credentials: undefined }));
     }
   }
 

--- a/packages/insomnia/src/models/cloud-credential.ts
+++ b/packages/insomnia/src/models/cloud-credential.ts
@@ -97,16 +97,16 @@ export interface AzureOAuthCredential {
 type BaseCloudCredential =
   | {
       provider: 'aws';
-      credentials: AWSTemporaryCredential | AWSFileCredential | AWSSSOCredential;
+      credentials?: AWSTemporaryCredential | AWSFileCredential | AWSSSOCredential;
     }
   | {
       provider: 'gcp';
-      credentials: GCPCredential;
+      credentials?: GCPCredential;
     }
-  | { provider: 'azure'; credentials: AzureOAuthCredential }
+  | { provider: 'azure'; credentials?: AzureOAuthCredential }
   | {
       provider: 'hashicorp';
-      credentials:
+      credentials?:
         | HCPCredential
         | VaultAppRoleCredential
         | VaultTokenCredential

--- a/packages/insomnia/src/routes/cloud-credentials.$cloudCredentialId.update.ts
+++ b/packages/insomnia/src/routes/cloud-credentials.$cloudCredentialId.update.ts
@@ -34,8 +34,10 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
     if (provider === 'hashicorp') {
       // update access token and expires_at
       const { access_token, expires_at } = result as { access_token: string; expires_at: number };
-      patch.credentials['access_token'] = access_token;
-      patch.credentials['expires_at'] = expires_at;
+      if (patch.credentials) {
+        patch.credentials['access_token'] = access_token;
+        patch.credentials['expires_at'] = expires_at;
+      }
     }
     await models.cloudCredential.update(originCredential, patch);
     return result as { access_token: string; expires_at: number };

--- a/packages/insomnia/src/ui/components/modals/cloud-credential-modal/aws-credential-form.tsx
+++ b/packages/insomnia/src/ui/components/modals/cloud-credential-modal/aws-credential-form.tsx
@@ -19,7 +19,7 @@ export interface AWSCredentialFormProps {
   isLoading: boolean;
   errorMessage?: string;
 }
-const initialFormValue: { name: string; credentials: AWSCloudCredential['credentials'] } = {
+const initialFormValue: { name: string; credentials: Required<AWSCloudCredential>['credentials'] } = {
   name: '',
   credentials: {
     type: AWSCredentialType.temp,
@@ -34,7 +34,7 @@ export const providerType: CloudProviderName = 'aws';
 export const AWSCredentialForm = (props: AWSCredentialFormProps) => {
   const { data, onSubmit, isLoading, errorMessage } = props;
   const isEdit = !!data;
-  const { name, credentials } = (data || initialFormValue) as {
+  const { name, credentials = initialFormValue.credentials } = (data || initialFormValue) as {
     name: string;
     credentials: AWSCloudCredential['credentials'];
   };

--- a/packages/insomnia/src/ui/components/modals/cloud-credential-modal/hashicorp-credential-form.tsx
+++ b/packages/insomnia/src/ui/components/modals/cloud-credential-modal/hashicorp-credential-form.tsx
@@ -37,9 +37,9 @@ export const providerType: CloudProviderName = 'hashicorp';
 export const HashiCorpCredentialForm = (props: HashiCorpCredentialFormProps) => {
   const { data, onSubmit, isLoading, errorMessage } = props;
   const isEdit = !!data;
-  const { name, credentials } = data || initialFormValue;
+  const { name, credentials = initialFormValue.credentials } = data || initialFormValue;
   const [isValidUrl, setIsValidUrl] = useState(true);
-  const { type } = credentials as HashiCorpCredential['credentials'];
+  const { type } = credentials as Required<HashiCorpCredential>['credentials'];
   const [credentialType, setCredentialType] = useState<HashiCorpCredentialType>(type);
   const [credentialAuthMethod, setAuthMethod] = useState<HashiCorpVaultAuthMethod>(
     (credentials as VaultTokenCredential | VaultAppRoleCredential).authMethod,

--- a/packages/insomnia/src/ui/components/settings/cloud-service-credentials.tsx
+++ b/packages/insomnia/src/ui/components/settings/cloud-service-credentials.tsx
@@ -180,7 +180,7 @@ export const CloudServiceCredentialList = () => {
               const { _id, name, provider, credentials } = cloudCred;
               let isAzureTokenExpired = !credentials;
               if (credentials && provider === 'azure') {
-                const tokenExpiresOn = 'expiresOn' in credentials ? credentials.expiresOn : undefined;
+                const tokenExpiresOn = 'expiresOn' in credentials ? credentials.expiresOn : null;
                 if (tokenExpiresOn && new Date() >= new Date(tokenExpiresOn)) {
                   isAzureTokenExpired = true;
                 }

--- a/packages/insomnia/src/ui/components/settings/cloud-service-credentials.tsx
+++ b/packages/insomnia/src/ui/components/settings/cloud-service-credentials.tsx
@@ -6,7 +6,6 @@ import { useDeleteCloudCredentialActionFetcher } from '~/routes/cloud-credential
 
 import { EXTERNAL_VAULT_PLUGIN_NAME } from '../../../common/constants';
 import {
-  type AzureOAuthCredential,
   type CloudProviderCredential,
   type CloudProviderName,
   getProviderDisplayName,
@@ -179,9 +178,9 @@ export const CloudServiceCredentialList = () => {
           <tbody>
             {cloudCredentials.map(cloudCred => {
               const { _id, name, provider, credentials } = cloudCred;
-              let isAzureTokenExpired = false;
-              if (provider === 'azure') {
-                const tokenExpiresOn = (credentials as AzureOAuthCredential).expiresOn;
+              let isAzureTokenExpired = !credentials;
+              if (credentials && provider === 'azure') {
+                const tokenExpiresOn = 'expiresOn' in credentials ? credentials.expiresOn : undefined;
                 if (tokenExpiresOn && new Date() >= new Date(tokenExpiresOn)) {
                   isAzureTokenExpired = true;
                 }


### PR DESCRIPTION
### Background
When user logs out from Insomnia, there's an option allowing user to clear all sensitive data. 
This includes all cloud credential data configured for external vault. 
Currently, we only wipe out certain properties which is error-prone.

### Changes
- Modify the logic to support empty credential config.
- Wipe out entire `credentials` content when log out with `Delete stored credentials` options enabled.

[INS-1646](https://konghq.atlassian.net/browse/INS-1646)


[INS-1646]: https://konghq.atlassian.net/browse/INS-1646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ