### PR TITLE
Support editing custom git credentials in the preference modal

### DIFF
--- a/packages/insomnia/src/models/git-credentials.ts
+++ b/packages/insomnia/src/models/git-credentials.ts
@@ -8,8 +8,24 @@ export type GitRemoteProviderType = 'github' | 'gitlab' | 'custom';
 
 export type GitCredentials = BaseModel & BaseGitCredentials;
 
+// for those keys do not need to add in model init method
+export const optionalKeys = [
+  'baseURI',
+  'renewalAttempts',
+  'lastRenewalAttempt',
+  'token',
+  'refreshToken',
+  'expiresAt',
+  'scopes',
+  'emails',
+  'selectedEmail',
+  'username',
+  'password',
+];
+
 export type GitCredentialsV1 = BaseModel & BaseGitCredentialsV1;
 export type GitCredentialsV2 = BaseModel & BaseGitCredentialsV2;
+export type CustomGitCredentialV2 = BaseModel & CustomCredential;
 
 export const name = 'Git Credentials';
 

--- a/packages/insomnia/src/models/git-credentials.ts
+++ b/packages/insomnia/src/models/git-credentials.ts
@@ -10,11 +10,7 @@ export type GitCredentials = BaseModel & BaseGitCredentials;
 
 // for those keys do not need to add in model init method
 export const optionalKeys = [
-  'baseURI',
-  'renewalAttempts',
   'lastRenewalAttempt',
-  'token',
-  'refreshToken',
   'expiresAt',
   'scopes',
   'emails',

--- a/packages/insomnia/src/routes/git-credentials.$id.update.tsx
+++ b/packages/insomnia/src/routes/git-credentials.$id.update.tsx
@@ -1,0 +1,34 @@
+import { href } from 'react-router';
+
+import { gitCredentials } from '~/models';
+import type { GitCredentials } from '~/models/git-credentials';
+import { createFetcherSubmitHook } from '~/utils/router';
+
+import type { Route } from './+types/git-credentials.$id.update';
+
+export async function clientAction({ request, params }: Route.ClientActionArgs) {
+  const data = (await request.json()) as Partial<GitCredentials>;
+  const { id } = params;
+
+  const credential = await gitCredentials.getById(id);
+  if (!credential) {
+    throw new Error('Credential not found');
+  }
+
+  await gitCredentials.update(credential, data);
+
+  return {
+    success: true,
+  };
+}
+
+export const useGitCredentialsUpdateActionFetcher = createFetcherSubmitHook(
+  submit => (id: string, data: Partial<GitCredentials>) => {
+    return submit(JSON.stringify(data), {
+      method: 'POST',
+      action: href('/git-credentials/:id/update', { id }),
+      encType: 'application/json',
+    });
+  },
+  clientAction,
+);

--- a/packages/insomnia/src/ui/components/git-credentials/git-custom-credential-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-custom-credential-form.tsx
@@ -1,23 +1,31 @@
 import { Form } from 'react-aria-components';
 
 import { Button } from '~/basic-components/button';
+import type { CustomGitCredentialV2 } from '~/models/git-credentials';
+import { useGitCredentialsUpdateActionFetcher } from '~/routes/git-credentials.$id.update';
 import { useGitCredentialsCreateActionFetcher } from '~/routes/git-credentials.create';
 import { Input } from '~/ui/components/base/input';
 
 export const GitCustomCredentialForm = ({
   onCancel,
   onComplete,
+  showTitle = true,
+  gitCredentialToEdit,
 }: {
   onCancel: () => void;
   onComplete?: () => void;
+  showTitle?: boolean;
+  gitCredentialToEdit?: CustomGitCredentialV2;
 }) => {
   const createCredentialFetcher = useGitCredentialsCreateActionFetcher();
+  const updateCredentialFetcher = useGitCredentialsUpdateActionFetcher();
+  const isEditing = !!gitCredentialToEdit;
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const form = event.target as HTMLFormElement;
     const formData = new FormData(form);
-    await createCredentialFetcher.submit({
-      provider: 'custom',
+    const credentialData = {
+      provider: 'custom' as const,
       author: {
         name: (formData.get('authorName') as string) || '',
         email: (formData.get('authorEmail') as string) || '',
@@ -25,13 +33,17 @@ export const GitCustomCredentialForm = ({
       username: (formData.get('username') as string) || '',
       password: (formData.get('password') as string) || '',
       baseURI: (formData.get('baseURI') as string) || '',
-    });
+    };
+
+    await (isEditing && gitCredentialToEdit._id
+      ? updateCredentialFetcher.submit(gitCredentialToEdit._id, credentialData)
+      : createCredentialFetcher.submit(credentialData));
     onComplete?.();
   };
 
   return (
     <Form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-      <div>Add Git credential</div>
+      {showTitle && <div>{isEditing ? 'Edit Git credential' : 'Add Git credential'}</div>}
       <div className="flex flex-col gap-2.5">
         <div className="flex w-full gap-3">
           <Input
@@ -41,17 +53,33 @@ export const GitCustomCredentialForm = ({
             className="w-1/2"
             label="Your Email"
             placeholder="e.g. your-name@acme.com"
+            defaultValue={gitCredentialToEdit?.author.email}
           />
-          <Input isRequired name="authorName" className="w-1/2" label="Your Git Username" placeholder="e.g. git-user" />
+          <Input
+            isRequired
+            name="authorName"
+            className="w-1/2"
+            label="Your Git Username"
+            placeholder="e.g. git-user"
+            defaultValue={gitCredentialToEdit?.author.name}
+          />
         </div>
         <div className="flex w-full gap-3">
-          <Input name="username" isRequired className="w-1/2" label="Username" placeholder="remote username for PAT" />
+          <Input
+            name="username"
+            isRequired
+            className="w-1/2"
+            label="Username"
+            placeholder="remote username for PAT"
+            defaultValue={gitCredentialToEdit?.username}
+          />
           <Input
             className="w-1/2"
             name="password"
             isRequired
             label="Git Access Token"
             placeholder="e.g. github_pat_11A11AAAAa111Aa11a1AA11"
+            defaultValue={gitCredentialToEdit?.password}
           />
         </div>
         <Input
@@ -61,11 +89,12 @@ export const GitCustomCredentialForm = ({
           label="Repository base URL"
           description="Specify the git server base URL that correlates with this access token."
           placeholder="e.g. https://github.your-domain.com/org-name"
+          defaultValue={gitCredentialToEdit?.baseURI}
         />
       </div>
       <div className="flex gap-2">
         <Button primary type="submit">
-          Save Credential
+          {isEditing ? 'Update Credential' : 'Save Credential'}
         </Button>
         <Button onPress={onCancel}>Cancel</Button>
       </div>

--- a/packages/insomnia/src/ui/components/settings/credentials.tsx
+++ b/packages/insomnia/src/ui/components/settings/credentials.tsx
@@ -153,7 +153,7 @@ export const GitCredentialModal = ({
     displayName: string;
     iconName?: IconProp;
   } | null;
-  gitCredentialToEdit: GitCredentials | null;
+  gitCredentialToEdit?: GitCredentials | null;
 }) => {
   return (
     <ModalOverlay
@@ -169,7 +169,9 @@ export const GitCredentialModal = ({
           {({ close }) => (
             <div className="flex flex-col gap-4">
               <div className="flex items-center justify-between gap-2">
-                <Heading className="text-2xl">Add a new {provider?.displayName} Credential</Heading>
+                <Heading className="text-2xl">
+                  {gitCredentialToEdit ? 'Edit' : 'Add a new'} {provider?.displayName} Credential
+                </Heading>
                 <Button
                   className="flex aspect-square h-6 shrink-0 items-center justify-center rounded-xs text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
                   onPress={close}
@@ -187,13 +189,17 @@ export const GitCredentialModal = ({
                   )}
                 </>
               )}
-              {gitCredentialToEdit && isGitCredentialsV2(gitCredentialToEdit) && provider?.type === 'custom' && (
-                <GitCustomCredentialForm
-                  gitCredentialToEdit={gitCredentialToEdit}
-                  onCancel={close}
-                  onComplete={onClose}
-                />
-              )}
+              {gitCredentialToEdit &&
+                isGitCredentialsV2(gitCredentialToEdit) &&
+                gitCredentialToEdit.provider === 'custom' &&
+                provider?.type === 'custom' && (
+                  <GitCustomCredentialForm
+                    gitCredentialToEdit={gitCredentialToEdit}
+                    onCancel={close}
+                    onComplete={onClose}
+                    showTitle={false}
+                  />
+                )}
             </div>
           )}
         </Dialog>
@@ -220,7 +226,7 @@ const GitCredentialsList = () => {
   }, [credentialsFetcher]);
 
   return (
-    <div className="flex flex-col gap-2 py-4">
+    <div className="mb-4 flex flex-col gap-2 py-4">
       <div className="flex items-center justify-between gap-2">
         <Heading className="text-lg font-bold">Git Credentials</Heading>
         <MenuTrigger>
@@ -264,6 +270,10 @@ const GitCredentialsList = () => {
           </Popover>
         </MenuTrigger>
       </div>
+
+      {credentialsFetcher.data?.credentials.length === 0 && (
+        <p className="text-center">No Git credentials configured</p>
+      )}
 
       <GridList
         items={credentialsFetcher.data?.credentials || []}
@@ -311,7 +321,7 @@ const GitCredentialsList = () => {
                       setIsCredentialModalOpen(true);
                     }}
                   >
-                    <Icon icon="edit" /> Edit Expand Down
+                    <Icon icon="edit" /> Edit
                   </Button>
                 )}
                 <Button


### PR DESCRIPTION
1. Add `optionalKeys` field to the git-credentials model so that extral keys can be preserved when initializing the model.
2. Support editing custom git credentials in the preference modal.