### PR TITLE
fix: Import collection variables as the base environment collection environment.

### DIFF
--- a/packages/insomnia/src/common/__fixtures__/postman/collection-with-variable-v2_1-input.json
+++ b/packages/insomnia/src/common/__fixtures__/postman/collection-with-variable-v2_1-input.json
@@ -1,0 +1,68 @@
+{
+	"info": {
+		"_postman_id": "448e7b5c-554d-4a45-9bd9-aa89d75d10e5",
+		"name": "exportedTest",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "37339712"
+	},
+	"item": [
+		{
+			"name": "defaultRequest",
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "x-from",
+						"value": "{{from}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "https://httpbin.org",
+					"protocol": "https",
+					"host": [
+						"httpbin",
+						"org"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"requests": {},
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"requests": {},
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "from",
+			"value": "variable",
+			"type": "default"
+		},
+    {
+			"key": "foo",
+			"value": "bar",
+			"type": "default"
+		}
+	]
+}

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { base } from '@faker-js/faker';
 import { describe, expect, it } from 'vitest';
 
 import { environment, project, request, requestGroup, workspace } from '../../models';

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -1,10 +1,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { base } from '@faker-js/faker';
 import { describe, expect, it } from 'vitest';
 
-import { project, request, requestGroup, workspace } from '../../models';
+import { environment, project, request, requestGroup, workspace } from '../../models';
+import { EnvironmentKvPairDataType } from '../../models/environment';
 import * as importUtil from '../import';
+import { generateId } from '../misc';
 
 /*
 @vitest-environment jsdom
@@ -160,5 +163,219 @@ describe('importRaw()', () => {
     console.log = disableLogs;
     expect(scanResult[0].type?.id).toBe('openapi3');
     expect(scanResult[0].errors.length).toBe(0);
+  });
+
+  it('should import a postman collection variable to a collection base environment', async () => {
+    const fixturePath = path.join(
+      __dirname,
+      '..',
+      '__fixtures__',
+      'postman',
+      'collection-with-variable-v2_1-input.json',
+    );
+    const content = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    const projectToImportTo = await project.create();
+    const projectId = projectToImportTo._id;
+
+    const scanResult = await importUtil.scanResources([
+      {
+        contentStr: content,
+      },
+    ]);
+
+    expect(scanResult[0].type?.id).toBe('postman');
+    expect(scanResult[0].errors.length).toBe(0);
+
+    await importUtil.importResourcesToProject({
+      projectId: projectToImportTo._id,
+    });
+
+    const projectWorkspaces = await workspace.findByParentId(projectId);
+    const importedWorkspaceId = projectWorkspaces[0]._id;
+    const requestBaseEnvironment = await environment.getByParentId(importedWorkspaceId);
+
+    expect(requestBaseEnvironment).toBeDefined();
+
+    expect(requestBaseEnvironment!.data).toMatchObject({
+      from: 'variable',
+      foo: 'bar',
+    });
+  });
+
+  it('should merge the json base environment from a postman collection variable when imported inside a workspace', async () => {
+    const fixturePath = path.join(
+      __dirname,
+      '..',
+      '__fixtures__',
+      'postman',
+      'collection-with-variable-v2_1-input.json',
+    );
+    const content = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    const existingWorkspace = await workspace.create();
+    const workspaceId = existingWorkspace._id;
+    const baseEnvironment = await environment.getOrCreateForParentId(workspaceId);
+    await environment.update(baseEnvironment, {
+      data: {
+        existingVar: 'exists',
+      },
+    });
+
+    const scanResult = await importUtil.scanResources([
+      {
+        contentStr: content,
+      },
+    ]);
+
+    expect(scanResult[0].type?.id).toBe('postman');
+    expect(scanResult[0].errors.length).toBe(0);
+
+    await importUtil.importResourcesToWorkspace({
+      workspaceId: existingWorkspace._id,
+    });
+
+    const updatedBaseEnvironment = await environment.getByParentId(workspaceId);
+
+    expect(updatedBaseEnvironment?.data).toMatchObject({
+      existingVar: 'exists',
+      from: 'variable',
+      foo: 'bar',
+    });
+  });
+
+  it('should override kv base environment from a postman collection variable when imported inside a workspace', async () => {
+    const fixturePath = path.join(
+      __dirname,
+      '..',
+      '__fixtures__',
+      'postman',
+      'collection-with-variable-v2_1-input.json',
+    );
+    const content = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    const existingWorkspace = await workspace.create();
+    const workspaceId = existingWorkspace._id;
+    const baseEnvironmentPair = [
+      {
+        id: generateId('envPair'),
+        name: 'from',
+        value: 'baseEnv',
+        type: EnvironmentKvPairDataType.STRING,
+        enabled: true,
+      },
+      {
+        id: generateId('envPair'),
+        name: 'disabledItemKey',
+        value: 'disabledItemValue',
+        type: EnvironmentKvPairDataType.STRING,
+        enabled: false,
+      },
+    ];
+    const baseEnvironment = await environment.getOrCreateForParentId(workspaceId);
+    await environment.update(baseEnvironment, {
+      data: {
+        from: 'baseEnv',
+      },
+      environmentType: environment.EnvironmentType.KVPAIR,
+      kvPairData: baseEnvironmentPair,
+    });
+
+    const scanResult = await importUtil.scanResources([
+      {
+        contentStr: content,
+      },
+    ]);
+
+    expect(scanResult[0].type?.id).toBe('postman');
+    expect(scanResult[0].errors.length).toBe(0);
+
+    await importUtil.importResourcesToWorkspace({
+      workspaceId: existingWorkspace._id,
+    });
+
+    const updatedBaseEnvironment = await environment.getByParentId(workspaceId);
+
+    expect(updatedBaseEnvironment?.data).toMatchObject({
+      from: 'variable',
+      foo: 'bar',
+    });
+    const newKvPairData = updatedBaseEnvironment?.kvPairData || [];
+    expect(newKvPairData.length).toBe(3);
+    expect(newKvPairData.filter(pair => pair.enabled).length).toBe(2);
+    expect(newKvPairData.find(pair => pair.name === 'from')?.value).toBe('variable');
+    expect(newKvPairData.find(pair => pair.name === 'foo')?.value).toBe('bar');
+  });
+
+  it('should merge and discard same name variable in kv base environment from a postman collection variable when imported inside a workspace', async () => {
+    const fixturePath = path.join(
+      __dirname,
+      '..',
+      '__fixtures__',
+      'postman',
+      'collection-with-variable-v2_1-input.json',
+    );
+    const content = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    const existingWorkspace = await workspace.create();
+    const workspaceId = existingWorkspace._id;
+    const baseEnvironmentPair = [
+      {
+        id: generateId('envPair'),
+        name: 'from',
+        value: 'disabledValue',
+        type: EnvironmentKvPairDataType.STRING,
+        enabled: false,
+      },
+      {
+        id: generateId('envPair'),
+        name: 'from',
+        value: 'baseEnv',
+        type: EnvironmentKvPairDataType.STRING,
+        enabled: true,
+      },
+      {
+        id: generateId('envPair'),
+        name: 'disabledItemKey',
+        value: 'disabledItemValue',
+        type: EnvironmentKvPairDataType.STRING,
+        enabled: false,
+      },
+    ];
+    const baseEnvironment = await environment.getOrCreateForParentId(workspaceId);
+    await environment.update(baseEnvironment, {
+      data: {
+        from: 'baseEnv',
+      },
+      environmentType: environment.EnvironmentType.KVPAIR,
+      kvPairData: baseEnvironmentPair,
+    });
+
+    const scanResult = await importUtil.scanResources([
+      {
+        contentStr: content,
+      },
+    ]);
+
+    expect(scanResult[0].type?.id).toBe('postman');
+    expect(scanResult[0].errors.length).toBe(0);
+
+    await importUtil.importResourcesToWorkspace({
+      workspaceId: existingWorkspace._id,
+      overrideBaseEnvironmentData: false,
+    });
+
+    const updatedBaseEnvironment = await environment.getByParentId(workspaceId);
+
+    expect(updatedBaseEnvironment?.data).toMatchObject({
+      from: 'baseEnv',
+      foo: 'bar',
+    });
+    const newKvPairData = updatedBaseEnvironment?.kvPairData || [];
+    expect(newKvPairData.length).toBe(4);
+    expect(newKvPairData.filter(pair => pair.enabled).length).toBe(2);
+    expect(newKvPairData.filter(pair => !pair.enabled).length).toBe(2);
+    expect(newKvPairData.find(pair => pair.name === 'from' && pair.enabled)?.value).toBe('baseEnv');
+    expect(newKvPairData.find(pair => pair.name === 'foo')?.value).toBe('bar');
   });
 });

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -1,3 +1,4 @@
+import orderedJSON from 'json-order';
 import { z, type ZodError } from 'zod/v4';
 
 import { insecureReadFile } from '~/main/secure-read-file';
@@ -7,7 +8,7 @@ import type { ImportEntry } from '../main/importers/entities';
 import { id as postmanEnvImporterId } from '../main/importers/importers/postman-env';
 import { type ApiSpec, isApiSpec } from '../models/api-spec';
 import { type CookieJar, isCookieJar } from '../models/cookie-jar';
-import { type BaseEnvironment, type Environment, isEnvironment } from '../models/environment';
+import { type Environment, EnvironmentKvPairDataType, isEnvironment } from '../models/environment';
 import { type GrpcRequest, isGrpcRequest } from '../models/grpc-request';
 import { type AllTypes, type BaseModel, getModel } from '../models/index';
 import * as models from '../models/index';
@@ -21,6 +22,7 @@ import { isUnitTestSuite, type UnitTestSuite } from '../models/unit-test-suite';
 import { isWebSocketRequest, type WebSocketRequest } from '../models/websocket-request';
 import { isWorkspace, type Workspace } from '../models/workspace';
 import { invariant } from '../utils/invariant';
+import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from './constants';
 import { database as db } from './database';
 import { tryImportV5Data } from './insomnia-v5';
 import { generateId } from './misc';
@@ -111,7 +113,7 @@ export async function getFilesFromPostmanExportedDataDump(filePath: string): Pro
 export interface ScanResult {
   requests?: (Request | WebSocketRequest | GrpcRequest | SocketIORequest)[];
   workspaces?: Workspace[];
-  environments?: BaseEnvironment[];
+  environments?: Environment[];
   apiSpecs?: ApiSpec[];
   cookieJars?: CookieJar[];
   unitTests?: UnitTest[];
@@ -420,7 +422,13 @@ const importRequestWithNewIds = (request: Request, ResourceIdMap: Map<string, st
   };
 };
 
-export const importResourcesToWorkspace = async ({ workspaceId }: { workspaceId: string }) => {
+export const importResourcesToWorkspace = async ({
+  workspaceId,
+  overrideBaseEnvironmentData = true,
+}: {
+  workspaceId: string;
+  overrideBaseEnvironmentData?: boolean;
+}) => {
   invariant(resourceCacheList.length > 0, 'No resources to import');
   for (const resourceCacheItem of resourceCacheList) {
     const resources = resourceCacheItem.resources;
@@ -446,7 +454,38 @@ export const importResourcesToWorkspace = async ({ workspaceId }: { workspaceId:
       .filter(isEnvironment)
       .find(env => env.parentId && env.parentId.startsWith('__WORKSPACE_ID__'));
     if (baseEnvironmentFromResources) {
-      await models.environment.update(baseEnvironment, { data: baseEnvironmentFromResources.data });
+      const environmentType = baseEnvironment.environmentType;
+      const originalEnvironmentData = baseEnvironment.data || {};
+      const baseEnvironmentDataFromResources = baseEnvironmentFromResources.data;
+      const newData = overrideBaseEnvironmentData
+        ? {
+            ...originalEnvironmentData,
+            ...baseEnvironmentDataFromResources,
+          }
+        : {
+            ...baseEnvironmentDataFromResources,
+            ...originalEnvironmentData,
+          };
+      const { object, map } = orderedJSON.parse(JSON.stringify(newData), JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR);
+      if (environmentType === 'kv') {
+        const newKvPairs = Object.keys(newData).map(key => ({
+          id: generateId('envPair'),
+          name: key,
+          value: newData[key] || '',
+          type: EnvironmentKvPairDataType.STRING,
+          enabled: true,
+        }));
+        await models.environment.update(baseEnvironment, {
+          kvPairData: newKvPairs,
+          data: object,
+          dataPropertyOrder: map || null,
+        });
+      } else {
+        await models.environment.update(baseEnvironment, {
+          data: object,
+          dataPropertyOrder: map || null,
+        });
+      }
     }
     const subEnvironments = resources.filter(isEnvironment).filter(isSubEnvironmentResource) || [];
 

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -8,7 +8,12 @@ import type { ImportEntry } from '../main/importers/entities';
 import { id as postmanEnvImporterId } from '../main/importers/importers/postman-env';
 import { type ApiSpec, isApiSpec } from '../models/api-spec';
 import { type CookieJar, isCookieJar } from '../models/cookie-jar';
-import { type Environment, EnvironmentKvPairDataType, isEnvironment } from '../models/environment';
+import {
+  type Environment,
+  type EnvironmentKvPairData,
+  EnvironmentKvPairDataType,
+  isEnvironment,
+} from '../models/environment';
 import { type GrpcRequest, isGrpcRequest } from '../models/grpc-request';
 import { type AllTypes, type BaseModel, getModel } from '../models/index';
 import * as models from '../models/index';
@@ -468,13 +473,30 @@ export const importResourcesToWorkspace = async ({
           };
       const { object, map } = orderedJSON.parse(JSON.stringify(newData), JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR);
       if (environmentType === 'kv') {
-        const newKvPairs = Object.keys(newData).map(key => ({
-          id: generateId('envPair'),
-          name: key,
-          value: newData[key] || '',
-          type: EnvironmentKvPairDataType.STRING,
-          enabled: true,
-        }));
+        const originKVPairData = baseEnvironment.kvPairData || [];
+        const originKVPairDataNames = originKVPairData.map(pair => pair.name);
+        const newKvPairs: EnvironmentKvPairData[] = [...originKVPairData];
+        Object.keys(newData).forEach(key => {
+          if (originKVPairDataNames.includes(key)) {
+            // update existing kv pair value
+            const originValue = originalEnvironmentData[key];
+            // find the kv pair with the same name and value in case duplicate names with different values exist
+            const index = newKvPairs.findIndex(pair => pair.name === key && pair.value === originValue);
+            newKvPairs[index] = {
+              ...newKvPairs[index],
+              value: newData[key],
+            };
+          } else {
+            // Create new kv pair since it does not exist in origin
+            newKvPairs.push({
+              id: generateId(models.environment.prefixEnvPair),
+              name: key,
+              value: newData[key],
+              type: EnvironmentKvPairDataType.STRING,
+              enabled: true,
+            });
+          }
+        });
         await models.environment.update(baseEnvironment, {
           kvPairData: newKvPairs,
           data: object,

--- a/packages/insomnia/src/main/importers/convert.ts
+++ b/packages/insomnia/src/main/importers/convert.ts
@@ -47,13 +47,6 @@ export const convert = async (
     }
 
     dotInKeyNameInvariant(resources);
-
-    // Each postman's collection has its variable, we map it to request group's environment in Insomnia
-    // I think it's better to check if the resource's type is 'request_group' rather than to check it by index 0, but let's just leave it as it is
-    if (resources.length > 0 && resources[0].variable) {
-      resources[0].environment = resources[0].variable;
-    }
-
     const convertedResult = {
       type: {
         id: importer.id,

--- a/packages/insomnia/src/main/importers/importers/__snapshots__/index.test.ts.snap
+++ b/packages/insomnia/src/main/importers/importers/__snapshots__/index.test.ts.snap
@@ -6089,18 +6089,11 @@ exports[`Fixtures > Import postman > scripts-import-v2_1-input.json 1`] = `
       "afterResponseScript": "console.log('after')",
       "authentication": {},
       "description": "",
-      "environment": {
-        "bob": "something",
-        "dssx": "{{_['env-var-in-global']}}",
-      },
+      "environment": {},
       "metaSortKey": -1622117984000,
       "name": "New Collection",
       "parentId": "__WORKSPACE_ID__",
       "preRequestScript": "console.log('pre')",
-      "variable": {
-        "bob": "something",
-        "dssx": "{{_['env-var-in-global']}}",
-      },
     },
     {
       "_id": "__REQ_1__",
@@ -6118,6 +6111,17 @@ exports[`Fixtures > Import postman > scripts-import-v2_1-input.json 1`] = `
       "pathParameters": [],
       "preRequestScript": "console.log('this is pre-request script');",
       "url": "httpbin.org/get",
+    },
+    {
+      "_id": "__BASE_ENVIRONMENT_ID__",
+      "_type": "environment",
+      "data": {
+        "bob": "something",
+        "dssx": "{{_['env-var-in-global']}}",
+      },
+      "metaSortKey": -1622117983998,
+      "name": "Variables",
+      "parentId": "__WORKSPACE_ID__",
     },
   ],
 }

--- a/packages/insomnia/src/main/importers/importers/postman.test.ts
+++ b/packages/insomnia/src/main/importers/importers/postman.test.ts
@@ -1,4 +1,3 @@
-import { base } from '@faker-js/faker';
 import { describe, expect, it } from 'vitest';
 
 import { ImportPostman, transformPostmanToNunjucksString } from './postman';

--- a/packages/insomnia/src/main/importers/importers/postman.test.ts
+++ b/packages/insomnia/src/main/importers/importers/postman.test.ts
@@ -1,3 +1,4 @@
+import { base } from '@faker-js/faker';
 import { describe, expect, it } from 'vitest';
 
 import { ImportPostman, transformPostmanToNunjucksString } from './postman';
@@ -7,9 +8,11 @@ describe('postman', () => {
   const postmanSchema = ({
     requests = [],
     version = 'v2.0.0',
+    variables = {},
   }: {
     requests?: Request1[];
     version?: string;
+    variables?: Record<string, any>;
   } = {}) =>
     structuredClone({
       info: {
@@ -29,6 +32,10 @@ describe('postman', () => {
           ],
         },
       ],
+      variable: Object.entries(variables).map(([key, value]) => ({
+        key,
+        value,
+      })),
     }) as HttpsSchemaGetpostmanComJsonCollectionV210;
 
   describe('transformPostmanToNunjucksString', () => {
@@ -533,6 +540,30 @@ describe('postman', () => {
           value: "{% faker 'guid' %}",
         },
       ]);
+    });
+
+    it('should import collection variable as Insomnia base environment', () => {
+      const request: Request1 = {
+        method: 'GET',
+        header: [],
+        url: {
+          raw: 'https://httpbin.org/anything/:path',
+          protocol: 'https',
+          host: ['httpbin', 'org'],
+          path: ['anything', ':path'],
+        },
+      };
+      const variables = {
+        key: 'path',
+        foo: 'bar',
+      };
+      const schema = postmanSchema({ requests: [request], version: 'v2.1.0', variables });
+      const postman = new ImportPostman(schema);
+      const result = postman.importCollection();
+
+      const baseEnvironment = result.find(i => i._type === 'environment' && i.parentId !== null);
+      expect(baseEnvironment).toBeDefined();
+      expect(baseEnvironment?.data).toEqual(variables);
     });
   });
 });

--- a/packages/insomnia/src/main/importers/importers/postman.ts
+++ b/packages/insomnia/src/main/importers/importers/postman.ts
@@ -326,19 +326,18 @@ export class ImportPostman {
       afterResponseScript,
     };
 
-    const baseEnvironment: ImportRequest = {
-      parentId: '__WORKSPACE_ID__',
-      _id: '__BASE_ENVIRONMENT_ID__',
-      _type: 'environment',
-      name: 'Variables',
-    };
-
     if (postmanVariable) {
       // Mapping postman collection variables to collection base environment
-      baseEnvironment.data = postmanVariable;
+      const baseEnvironment: ImportRequest = {
+        parentId: '__WORKSPACE_ID__',
+        _id: '__BASE_ENVIRONMENT_ID__',
+        _type: 'environment',
+        name: 'Variables',
+        data: postmanVariable,
+      };
+      return [collectionFolder, ...this.importItems(item, collectionFolder._id), baseEnvironment];
     }
-
-    return [collectionFolder, ...this.importItems(item, collectionFolder._id), baseEnvironment];
+    return [collectionFolder, ...this.importItems(item, collectionFolder._id)];
   };
 
   importUrl = (url?: Url | string) => {

--- a/packages/insomnia/src/main/importers/importers/postman.ts
+++ b/packages/insomnia/src/main/importers/importers/postman.ts
@@ -338,7 +338,7 @@ export class ImportPostman {
       baseEnvironment.data = postmanVariable;
     }
 
-    return [collectionFolder, baseEnvironment, ...this.importItems(item, collectionFolder._id)];
+    return [collectionFolder, ...this.importItems(item, collectionFolder._id), baseEnvironment];
   };
 
   importUrl = (url?: Url | string) => {

--- a/packages/insomnia/src/main/importers/importers/postman.ts
+++ b/packages/insomnia/src/main/importers/importers/postman.ts
@@ -326,11 +326,19 @@ export class ImportPostman {
       afterResponseScript,
     };
 
+    const baseEnvironment: ImportRequest = {
+      parentId: '__WORKSPACE_ID__',
+      _id: '__BASE_ENVIRONMENT_ID__',
+      _type: 'environment',
+      name: 'Variables',
+    };
+
     if (postmanVariable) {
-      collectionFolder.variable = postmanVariable;
+      // Mapping postman collection variables to collection base environment
+      baseEnvironment.data = postmanVariable;
     }
 
-    return [collectionFolder, ...this.importItems(item, collectionFolder._id)];
+    return [collectionFolder, baseEnvironment, ...this.importItems(item, collectionFolder._id)];
   };
 
   importUrl = (url?: Url | string) => {

--- a/packages/insomnia/src/models/environment.ts
+++ b/packages/insomnia/src/models/environment.ts
@@ -14,6 +14,7 @@ import type { Workspace } from './workspace';
 export const name = 'Environment';
 export const type = 'Environment';
 export const prefix = 'env';
+export const prefixEnvPair = 'envPair';
 // vault environment path when saved in environment data
 export const vaultEnvironmentPath = '__insomnia_vault';
 // vault environment path when used in runtime rendering

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -15,15 +15,21 @@ import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/import.resources';
 
+interface ImportScannedResourcesParams {
+  organizationId: string;
+  projectId: string;
+  workspaceId?: string;
+  options?: {
+    overrideBaseEnvironmentData?: boolean;
+  };
+}
+
 export const importScannedResources = async ({
   organizationId,
   projectId,
   workspaceId,
-}: {
-  organizationId: string;
-  projectId: string;
-  workspaceId?: string;
-}) => {
+  options,
+}: ImportScannedResourcesParams) => {
   invariant(organizationId && typeof organizationId === 'string', 'OrganizationId is required.');
   invariant(projectId && typeof projectId === 'string', 'ProjectId is required.');
 
@@ -33,6 +39,7 @@ export const importScannedResources = async ({
   await (typeof workspaceId === 'string' && workspaceId
     ? importResourcesToWorkspace({
         workspaceId: workspaceId,
+        overrideBaseEnvironmentData: options?.overrideBaseEnvironmentData ?? true,
       })
     : importResourcesToProject({
         projectId: project._id,
@@ -42,15 +49,12 @@ export const importScannedResources = async ({
 
 export async function clientAction({ request }: Route.ClientActionArgs) {
   try {
-    const data = (await request.json()) as {
-      organizationId: string;
-      projectId: string;
-      workspaceId?: string;
-    };
+    const data = (await request.json()) as ImportScannedResourcesParams;
 
     const organizationId = data.organizationId;
     const projectId = data.projectId;
     const workspaceId = data.workspaceId;
+    const options = data.options;
 
     invariant(typeof organizationId === 'string', 'OrganizationId is required.');
     invariant(typeof projectId === 'string', 'ProjectId is required.');
@@ -59,6 +63,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
       organizationId,
       projectId,
       workspaceId,
+      options,
     });
     return { done: true };
   } catch (error) {
@@ -70,7 +75,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
 }
 
 export const useImportResourcesFetcher = createFetcherSubmitHook(
-  submit => (data: { organizationId: string; projectId: string; workspaceId?: string }) => {
+  submit => (data: ImportScannedResourcesParams) => {
     submit(JSON.stringify(data), {
       action: href('/import/resources'),
       method: 'POST',

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React, { type FC, Fragment, type ReactNode, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { type DirectoryDropItem, type FileDropItem, OverlayContainer, useDrop } from 'react-aria';
-import { Heading, Switch } from 'react-aria-components';
+import { Heading } from 'react-aria-components';
 
 import { useImportResourcesFetcher } from '~/routes/import.resources';
 import { useScanResourcesFetcher } from '~/routes/import.scan';

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -5,6 +5,7 @@ import { Heading } from 'react-aria-components';
 
 import { useImportResourcesFetcher } from '~/routes/import.resources';
 import { useScanResourcesFetcher } from '~/routes/import.scan';
+import { Checkbox } from '~/ui/components/base/checkbox';
 
 import type { ScanResult } from '../../../../common/import';
 import { isScratchpadProject } from '../../../../models/project';
@@ -403,23 +404,16 @@ const ImportResourcesForm = ({
         <div className="overflow-y-auto">
           <ScanResultsTable scanResults={scanResults} />
           {isImportingBaseEnvironmentToWorkspace && (
-            <div className="">
-              <label className="flex items-center gap-2">
-                <input
-                  checked={overrideBaseEnvironmentData}
-                  name="overrideBaseEnvironmentData"
-                  onChange={event => {
-                    const isChecked = event.currentTarget.checked;
-                    setOverrideBaseEnvironmentData(isChecked);
-                  }}
-                  type="checkbox"
-                />
-                Override Base Environment On Name Conflict
-                <HelpTooltip className="space-left">
-                  Override the base environment data if environment with same name is found during import.
-                </HelpTooltip>
-              </label>
-            </div>
+            <Checkbox
+              isSelected={overrideBaseEnvironmentData}
+              onChange={checked => setOverrideBaseEnvironmentData(checked)}
+              className="mt-1"
+            >
+              Override Base Environment On Name Conflict
+              <HelpTooltip className="space-left">
+                Override existing variables in the base environment if the same variable names are found during import.
+              </HelpTooltip>
+            </Checkbox>
           )}
         </div>
 

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React, { type FC, Fragment, type ReactNode, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { type DirectoryDropItem, type FileDropItem, OverlayContainer, useDrop } from 'react-aria';
-import { Heading } from 'react-aria-components';
+import { Heading, Switch } from 'react-aria-components';
 
 import { useImportResourcesFetcher } from '~/routes/import.resources';
 import { useScanResourcesFetcher } from '~/routes/import.scan';
@@ -12,6 +12,7 @@ import { invariant } from '../../../../utils/invariant';
 import { SegmentEvent } from '../../../analytics';
 import { Modal, type ModalHandle, type ModalProps } from '../../base/modal';
 import { ModalHeader } from '../../base/modal-header';
+import { HelpTooltip } from '../../help-tooltip';
 import { Icon } from '../../icon';
 import { Button } from '../../themed-button';
 import { disclaimer, ScanResultsTable, SupportedFormats, validImportExtensions } from './shared';
@@ -224,6 +225,12 @@ export const ImportModal: FC<ImportModalProps> = ({
     );
   }, [scanResourcesFetcherData]);
   const shouldImportToWorkspace = !!defaultWorkspaceId && totalWorkspacesCount <= 1;
+  // Check if base environment is being imported to existing workspace
+  const isImportingBaseEnvironmentToWorkspace =
+    shouldImportToWorkspace &&
+    scanResourcesFetcherData?.some(data =>
+      data.environments?.some(env => env.parentId && env.parentId.startsWith('__WORKSPACE_ID__')),
+    );
   // TODO: need to add a more strong way to inform users that resources will be imported into project rather than current workspace
   const header = shouldImportToWorkspace
     ? `Import to "${workspaceName}" Workspace`
@@ -257,13 +264,17 @@ export const ImportModal: FC<ImportModalProps> = ({
             errors={importErrors}
             loading={importFetcher.state !== 'idle'}
             disabled={importErrors.length > 0}
-            onImport={() => {
+            isImportingBaseEnvironmentToWorkspace={isImportingBaseEnvironmentToWorkspace || false}
+            onImport={(overrideBaseEnvironmentData: boolean) => {
               invariant(Array.isArray(scanResourcesFetcherData));
 
               importFetcher.submit({
                 organizationId,
                 projectId: defaultProjectId || '',
                 workspaceId: shouldImportToWorkspace ? defaultWorkspaceId : undefined,
+                options: {
+                  overrideBaseEnvironmentData,
+                },
               });
               scanResourcesFetcherData
                 .filter(({ errors }) => errors.length === 0)
@@ -376,19 +387,42 @@ const ImportResourcesForm = ({
   errors,
   disabled,
   loading,
+  isImportingBaseEnvironmentToWorkspace,
 }: {
   scanResults: ScanResult[];
   errors?: string[];
-  onImport: () => void;
+  onImport: (overrideBaseEnvironmentData: boolean) => void;
   disabled: boolean;
   loading: boolean;
+  isImportingBaseEnvironmentToWorkspace: boolean;
 }) => {
+  const [overrideBaseEnvironmentData, setOverrideBaseEnvironmentData] = useState(true);
   return (
     <Fragment>
       <div className="flex max-h-[50vh] flex-col gap-(--padding-md) overflow-auto">
         <div className="overflow-y-auto">
           <ScanResultsTable scanResults={scanResults} />
+          {isImportingBaseEnvironmentToWorkspace && (
+            <div className="">
+              <label className="flex items-center gap-2">
+                <input
+                  checked={overrideBaseEnvironmentData}
+                  name="overrideBaseEnvironmentData"
+                  onChange={event => {
+                    const isChecked = event.currentTarget.checked;
+                    setOverrideBaseEnvironmentData(isChecked);
+                  }}
+                  type="checkbox"
+                />
+                Override Base Environment On Name Conflict
+                <HelpTooltip className="space-left">
+                  Override the base environment data if environment with same name is found during import.
+                </HelpTooltip>
+              </label>
+            </div>
+          )}
         </div>
+
         <div>
           {errors && errors.length > 0 && (
             <div className="notice error margin-top-sm">
@@ -407,7 +441,7 @@ const ImportResourcesForm = ({
           variant="contained"
           bg="surprise"
           disabled={disabled}
-          onClick={onImport}
+          onClick={() => onImport(overrideBaseEnvironmentData)}
           className="btn h-10 gap-(--padding-sm)"
         >
           {loading ? (

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -264,7 +264,7 @@ export const ImportModal: FC<ImportModalProps> = ({
             errors={importErrors}
             loading={importFetcher.state !== 'idle'}
             disabled={importErrors.length > 0}
-            isImportingBaseEnvironmentToWorkspace={isImportingBaseEnvironmentToWorkspace || false}
+            isImportingBaseEnvironmentToWorkspace={!!isImportingBaseEnvironmentToWorkspace}
             onImport={(overrideBaseEnvironmentData: boolean) => {
               invariant(Array.isArray(scanResourcesFetcherData));
 


### PR DESCRIPTION
### Changes:
- Import collection variable as collection base environment in Insomnia
- When importing within workspace, add a new option to override or discard existing base environment with name conflict.

[INS-873](https://konghq.atlassian.net/browse/INS-873)


[INS-873]: https://konghq.atlassian.net/browse/INS-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ