### PR TITLE
refactor/git-credential-model

### DIFF
--- a/packages/insomnia/src/models/git-credentials.ts
+++ b/packages/insomnia/src/models/git-credentials.ts
@@ -8,17 +8,6 @@ export type GitRemoteProviderType = 'github' | 'gitlab' | 'custom';
 
 export type GitCredentials = BaseModel & BaseGitCredentials;
 
-// for those keys do not need to add in model init method
-export const optionalKeys = [
-  'lastRenewalAttempt',
-  'expiresAt',
-  'scopes',
-  'emails',
-  'selectedEmail',
-  'username',
-  'password',
-];
-
 export type GitCredentialsV1 = BaseModel & BaseGitCredentialsV1;
 export type GitCredentialsV2 = BaseModel & BaseGitCredentialsV2;
 export type CustomGitCredentialV2 = BaseModel & CustomCredential;
@@ -33,19 +22,16 @@ export const canDuplicate = false;
 
 export const canSync = false;
 
-export function init(): BaseGitCredentials {
+export function init(): Partial<BaseGitCredentials> {
   return {
-    token: '',
-    refreshToken: '',
-    provider: 'github',
+    name: '',
+    provider: undefined,
+    credentials: undefined,
     author: {
       email: '',
       name: '',
       avatarUrl: '',
     },
-    baseURI: '',
-    name: '',
-    renewalAttempts: 0,
   };
 }
 
@@ -84,9 +70,6 @@ interface BaseCredentialData {
     email: string;
     avatarUrl?: string;
   };
-  baseURI?: string;
-  renewalAttempts: number;
-  lastRenewalAttempt?: number;
 }
 
 /**
@@ -94,12 +77,14 @@ interface BaseCredentialData {
  */
 interface GitHubCredential extends BaseCredentialData {
   provider: 'github';
-  token: string;
-  refreshToken?: string;
-  expiresAt?: number;
-  scopes?: string[];
-  emails?: ProviderEmail[];
-  selectedEmail?: string;
+  credentials: {
+    token: string;
+    refreshToken?: string;
+    expiresAt?: number;
+    scopes?: string[];
+    emails?: ProviderEmail[];
+    selectedEmail?: string;
+  };
 }
 
 /**
@@ -107,11 +92,13 @@ interface GitHubCredential extends BaseCredentialData {
  */
 interface GitLabCredential extends BaseCredentialData {
   provider: 'gitlab';
-  token: string;
-  refreshToken: string;
-  expiresAt: number;
-  emails?: ProviderEmail[];
-  selectedEmail?: string;
+  credentials: {
+    token: string;
+    refreshToken: string;
+    expiresAt?: number;
+    emails?: ProviderEmail[];
+    selectedEmail?: string;
+  };
 }
 
 /**
@@ -119,9 +106,11 @@ interface GitLabCredential extends BaseCredentialData {
  */
 interface CustomCredential extends BaseCredentialData {
   provider: 'custom';
-  username: string;
-  password: string; // Personal access token
-  baseURI?: string; // For custom providers
+  credentials: {
+    username: string;
+    password: string; // Personal access token
+    baseURI?: string; // For custom providers
+  };
 }
 
 /**
@@ -137,8 +126,8 @@ type BaseGitCredentials = BaseGitCredentialsV1 | BaseGitCredentialsV2;
 /**
  * Type guard to check if credential is using new unified structure
  */
-export function isGitCredentialsV2(credential: GitCredentials): credential is GitCredentialsV2 {
-  return 'name' in credential && typeof credential.name === 'string' && 'renewalAttempts' in credential;
+export function isGitCredentialsV2(gitCredential: GitCredentials): gitCredential is GitCredentialsV2 {
+  return 'credentials' in gitCredential && typeof gitCredential.credentials === 'object';
 }
 
 /**
@@ -155,8 +144,8 @@ export function migrate(doc: GitCredentials): GitCredentials {
   return doc;
 }
 
-export function create(patch: Partial<GitCredentials> = {}) {
-  return db.docCreate<GitCredentials>(type, patch);
+export function create(patch: Partial<GitCredentialsV2> = {}) {
+  return db.docCreate<GitCredentialsV2>(type, patch);
 }
 
 export async function getById(id: string) {
@@ -164,8 +153,8 @@ export async function getById(id: string) {
   return doc ? migrate(doc) : null;
 }
 
-export function update(credentials: GitCredentials, patch: Partial<GitCredentials>) {
-  return db.docUpdate<GitCredentials>(credentials, patch);
+export function update(credentials: GitCredentialsV2, patch: Partial<GitCredentialsV2>) {
+  return db.docUpdate<GitCredentialsV2>(credentials, patch);
 }
 
 export function remove(credentials: GitCredentials) {
@@ -193,13 +182,13 @@ export function isOAuthCredential(
 /**
  * Type guard for credentials that support renewal
  */
-export function supportsRenewal(credential: GitCredentials): boolean {
-  if (!isGitCredentialsV2(credential)) return false;
-  if (credential.provider === 'gitlab') {
-    return !!credential.refreshToken;
+export function supportsRenewal(gitCredential: GitCredentials): boolean {
+  if (!isGitCredentialsV2(gitCredential)) return false;
+  if (gitCredential.provider === 'gitlab') {
+    return !!gitCredential.credentials?.refreshToken;
   }
-  if (credential.provider === 'github') {
-    return !!credential.refreshToken;
+  if (gitCredential.provider === 'github') {
+    return !!gitCredential.credentials?.refreshToken;
   }
   return false;
 }

--- a/packages/insomnia/src/models/git-credentials.ts
+++ b/packages/insomnia/src/models/git-credentials.ts
@@ -121,7 +121,7 @@ interface CustomCredential extends BaseCredentialData {
 /**
  * Unified credential type (new structure)
  */
-type BaseGitCredentialsV2 = GitHubCredential | GitLabCredential | CustomCredential;
+export type BaseGitCredentialsV2 = GitHubCredential | GitLabCredential | CustomCredential;
 
 /**
  * Combined type supporting both legacy and new credential structures
@@ -149,7 +149,7 @@ export function migrate(doc: GitCredentials): GitCredentials {
   return doc;
 }
 
-export function create(patch: Partial<GitCredentialsV2> = {}) {
+export function create(patch: BaseGitCredentialsV2) {
   return db.docCreate<GitCredentialsV2>(type, patch);
 }
 

--- a/packages/insomnia/src/models/git-credentials.ts
+++ b/packages/insomnia/src/models/git-credentials.ts
@@ -32,6 +32,9 @@ export function init(): Partial<BaseGitCredentials> {
       name: '',
       avatarUrl: '',
     },
+    // Legacy fields: token and refreshToken for backward compatibility
+    token: undefined,
+    refreshToken: undefined,
   };
 }
 
@@ -40,7 +43,9 @@ export function init(): Partial<BaseGitCredentials> {
  * @deprecated Use the new provider-specific credential types
  */
 interface BaseGitCredentialsV1 {
+  /** @deprecated Use provider-specific credentials.token instead */
   token: string;
+  /** @deprecated Use provider-specific credentials.refreshToken instead */
   refreshToken?: string;
   provider: 'githubapp' | 'github' | 'gitlab' | 'custom';
   author: {
@@ -127,11 +132,7 @@ type BaseGitCredentials = BaseGitCredentialsV1 | BaseGitCredentialsV2;
  * Type guard to check if credential is using new unified structure
  */
 export function isGitCredentialsV2(gitCredential: GitCredentials): gitCredential is GitCredentialsV2 {
-  return (
-    'credentials' in gitCredential &&
-    gitCredential.credentials !== null &&
-    typeof gitCredential.credentials === 'object'
-  );
+  return 'credentials' in gitCredential && gitCredential.credentials && typeof gitCredential.credentials === 'object';
 }
 
 /**

--- a/packages/insomnia/src/models/git-credentials.ts
+++ b/packages/insomnia/src/models/git-credentials.ts
@@ -127,7 +127,11 @@ type BaseGitCredentials = BaseGitCredentialsV1 | BaseGitCredentialsV2;
  * Type guard to check if credential is using new unified structure
  */
 export function isGitCredentialsV2(gitCredential: GitCredentials): gitCredential is GitCredentialsV2 {
-  return 'credentials' in gitCredential && typeof gitCredential.credentials === 'object';
+  return (
+    'credentials' in gitCredential &&
+    gitCredential.credentials !== null &&
+    typeof gitCredential.credentials === 'object'
+  );
 }
 
 /**

--- a/packages/insomnia/src/routes/git-credentials.$id.update.tsx
+++ b/packages/insomnia/src/routes/git-credentials.$id.update.tsx
@@ -1,18 +1,21 @@
 import { href } from 'react-router';
 
 import { gitCredentials } from '~/models';
-import type { GitCredentials } from '~/models/git-credentials';
+import { type GitCredentials, type GitCredentialsV2, isGitCredentialsV2 } from '~/models/git-credentials';
 import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git-credentials.$id.update';
 
 export async function clientAction({ request, params }: Route.ClientActionArgs) {
-  const data = (await request.json()) as Partial<GitCredentials>;
+  const data = (await request.json()) as Partial<GitCredentialsV2>;
   const { id } = params;
 
   const credential = await gitCredentials.getById(id);
   if (!credential) {
     throw new Error('Credential not found');
+  }
+  if (!isGitCredentialsV2(credential)) {
+    throw new Error('Invalid credential data structure');
   }
 
   await gitCredentials.update(credential, data);

--- a/packages/insomnia/src/routes/git-credentials.$id.update.tsx
+++ b/packages/insomnia/src/routes/git-credentials.$id.update.tsx
@@ -1,7 +1,7 @@
 import { href } from 'react-router';
 
 import { gitCredentials } from '~/models';
-import { type GitCredentials, type GitCredentialsV2, isGitCredentialsV2 } from '~/models/git-credentials';
+import { type GitCredentialsV2, isGitCredentialsV2 } from '~/models/git-credentials';
 import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git-credentials.$id.update';
@@ -26,7 +26,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
 }
 
 export const useGitCredentialsUpdateActionFetcher = createFetcherSubmitHook(
-  submit => (id: string, data: Partial<GitCredentials>) => {
+  submit => (id: string, data: Partial<GitCredentialsV2>) => {
     return submit(JSON.stringify(data), {
       method: 'POST',
       action: href('/git-credentials/:id/update', { id }),

--- a/packages/insomnia/src/routes/git-credentials.create.tsx
+++ b/packages/insomnia/src/routes/git-credentials.create.tsx
@@ -1,13 +1,13 @@
 import { href } from 'react-router';
 
 import { gitCredentials } from '~/models';
-import type { GitCredentials } from '~/models/git-credentials';
+import type { GitCredentials, GitCredentialsV2 } from '~/models/git-credentials';
 import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git-credentials.create';
 
 export async function clientAction({ request }: Route.ClientActionArgs) {
-  const data = (await request.json()) as Partial<GitCredentials>;
+  const data = (await request.json()) as Partial<GitCredentialsV2>;
 
   await gitCredentials.create(data);
 

--- a/packages/insomnia/src/routes/git-credentials.create.tsx
+++ b/packages/insomnia/src/routes/git-credentials.create.tsx
@@ -1,13 +1,13 @@
 import { href } from 'react-router';
 
 import { gitCredentials } from '~/models';
-import type { GitCredentials, GitCredentialsV2 } from '~/models/git-credentials';
+import type { BaseGitCredentialsV2 } from '~/models/git-credentials';
 import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/git-credentials.create';
 
 export async function clientAction({ request }: Route.ClientActionArgs) {
-  const data = (await request.json()) as Partial<GitCredentialsV2>;
+  const data = (await request.json()) as BaseGitCredentialsV2;
 
   await gitCredentials.create(data);
 
@@ -17,7 +17,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
 }
 
 export const useGitCredentialsCreateActionFetcher = createFetcherSubmitHook(
-  submit => (data: Partial<GitCredentials>) => {
+  submit => (data: BaseGitCredentialsV2) => {
     return submit(JSON.stringify(data), {
       method: 'POST',
       action: href('/git-credentials/create'),

--- a/packages/insomnia/src/sync/git/migrations.ts
+++ b/packages/insomnia/src/sync/git/migrations.ts
@@ -29,7 +29,7 @@ import { initElectronStorage } from '~/main/window-utils';
 import { type GitRepository, isGitCredentialsOAuth } from '~/models/git-repository';
 
 import * as models from '../../models';
-import type { GitCredentials } from '../../models/git-credentials';
+import { type GitCredentials, isGitCredentialsV1 } from '../../models/git-credentials';
 
 const MIGRATION_KEY = 'GIT_CREDENTIALS_MIGRATION';
 
@@ -42,16 +42,19 @@ async function migrateGitHubConnectedRepositories(repositories: GitRepository[])
     provider: 'githubapp',
   });
 
-  if (githubCredentials) {
-    await models.gitCredentials.update(githubCredentials, {
+  if (githubCredentials && 'token' in githubCredentials) {
+    const newCredential = await models.gitCredentials.create({
       name: 'Github Credential',
       provider: 'github',
-      renewalAttempts: 0,
+      credentials: {
+        token: githubCredentials.token,
+      },
     });
+    await models.gitCredentials.remove(githubCredentials);
 
     for (const repo of repositories) {
       await models.gitRepository.update(repo, {
-        credentialsId: githubCredentials._id,
+        credentialsId: newCredential._id,
         credentials: null,
         author: {
           name: '',
@@ -65,12 +68,16 @@ async function migrateGitHubConnectedRepositories(repositories: GitRepository[])
 async function migrateGitLabConnectedRepositories(repositories: GitRepository[]) {
   const gitlabCredentials = await database.findOne<GitCredentials>(models.gitCredentials.type, { provider: 'gitlab' });
 
-  if (gitlabCredentials) {
-    await models.gitCredentials.update(gitlabCredentials, {
+  if (gitlabCredentials && isGitCredentialsV1(gitlabCredentials)) {
+    await models.gitCredentials.create({
       name: 'Gitlab Credential',
       provider: 'gitlab',
-      renewalAttempts: 0,
+      credentials: {
+        token: gitlabCredentials.token,
+        refreshToken: gitlabCredentials.refreshToken || '',
+      },
     });
+    await models.gitCredentials.remove(gitlabCredentials);
 
     for (const repo of repositories) {
       await models.gitRepository.update(repo, {
@@ -92,19 +99,20 @@ async function migrateCustomCredentialsRepositories(repositories: GitRepository[
     }
 
     let credentials = await database.findOne<GitCredentials>(models.gitCredentials.type, {
-      provider: 'custom',
-      username: repo.credentials.username,
-      password: repo.credentials.password,
-    });
+      'provider': 'custom',
+      'credentials.username': repo.credentials.username,
+      'credentials.password': repo.credentials.password,
+    } as any);
 
     if (!credentials) {
       credentials = await models.gitCredentials.create({
         name: 'Custom Git Credential',
         provider: 'custom',
         author: repo.author,
-        renewalAttempts: 0,
-        username: repo.credentials.username,
-        password: repo.credentials.password,
+        credentials: {
+          username: repo.credentials.username,
+          password: repo.credentials.password,
+        },
       });
     }
 

--- a/packages/insomnia/src/sync/git/migrations.ts
+++ b/packages/insomnia/src/sync/git/migrations.ts
@@ -42,13 +42,15 @@ async function migrateGitHubConnectedRepositories(repositories: GitRepository[])
     provider: 'githubapp',
   });
 
-  if (githubCredentials && 'token' in githubCredentials) {
+  if (githubCredentials && isGitCredentialsV1(githubCredentials)) {
     const newCredential = await models.gitCredentials.create({
       name: 'GitHub Credential',
       provider: 'github',
       credentials: {
         token: githubCredentials.token,
+        refreshToken: githubCredentials.refreshToken,
       },
+      author: githubCredentials.author,
     });
     await models.gitCredentials.remove(githubCredentials);
 
@@ -76,6 +78,7 @@ async function migrateGitLabConnectedRepositories(repositories: GitRepository[])
         token: gitlabCredentials.token,
         refreshToken: gitlabCredentials.refreshToken || '',
       },
+      author: gitlabCredentials.author,
     });
     await models.gitCredentials.remove(gitlabCredentials);
 

--- a/packages/insomnia/src/sync/git/migrations.ts
+++ b/packages/insomnia/src/sync/git/migrations.ts
@@ -44,7 +44,7 @@ async function migrateGitHubConnectedRepositories(repositories: GitRepository[])
 
   if (githubCredentials && 'token' in githubCredentials) {
     const newCredential = await models.gitCredentials.create({
-      name: 'Github Credential',
+      name: 'GitHub Credential',
       provider: 'github',
       credentials: {
         token: githubCredentials.token,
@@ -69,8 +69,8 @@ async function migrateGitLabConnectedRepositories(repositories: GitRepository[])
   const gitlabCredentials = await database.findOne<GitCredentials>(models.gitCredentials.type, { provider: 'gitlab' });
 
   if (gitlabCredentials && isGitCredentialsV1(gitlabCredentials)) {
-    await models.gitCredentials.create({
-      name: 'Gitlab Credential',
+    const newCredential = await models.gitCredentials.create({
+      name: 'GitLab Credential',
       provider: 'gitlab',
       credentials: {
         token: gitlabCredentials.token,
@@ -81,7 +81,7 @@ async function migrateGitLabConnectedRepositories(repositories: GitRepository[])
 
     for (const repo of repositories) {
       await models.gitRepository.update(repo, {
-        credentialsId: gitlabCredentials._id,
+        credentialsId: newCredential._id,
         credentials: null,
         author: {
           name: '',

--- a/packages/insomnia/src/sync/git/providers/custom.ts
+++ b/packages/insomnia/src/sync/git/providers/custom.ts
@@ -67,8 +67,8 @@ export class CustomProvider implements GitRemoteProvider<CustomProviderConfig> {
 
     // Basic auth: username and password (PAT)
     return {
-      username: credential.username,
-      password: credential.password,
+      username: credential.credentials?.username,
+      password: credential.credentials?.password,
     };
   }
 

--- a/packages/insomnia/src/sync/git/providers/github.ts
+++ b/packages/insomnia/src/sync/git/providers/github.ts
@@ -131,7 +131,7 @@ export class GitHubProvider implements GitRemoteProvider<GitHubProviderConfig> {
         `${this.config.apiUrl}/user/repos?per_page=${perPage}&page=${page}&sort=updated`,
         {
           headers: {
-            Authorization: `token ${credentials.token}`,
+            Authorization: `token ${credentials.credentials?.token}`,
           },
         },
       );
@@ -176,7 +176,7 @@ export class GitHubProvider implements GitRemoteProvider<GitHubProviderConfig> {
       throw new Error('Invalid credential type for GitHub provider');
     }
 
-    return this.fetchEmails(credential.token);
+    return this.fetchEmails(credential.credentials.token);
   }
 
   /**
@@ -298,9 +298,10 @@ export class GitHubProvider implements GitRemoteProvider<GitHubProviderConfig> {
 
       await models.gitCredentials.create({
         name: 'Github Credential',
-        token: data.access_token,
+        credentials: {
+          token: data.access_token,
+        },
         provider: 'github',
-        renewalAttempts: 0,
         author: {
           email,
           name: user.name || user.username,
@@ -333,7 +334,7 @@ export class GitHubProvider implements GitRemoteProvider<GitHubProviderConfig> {
     // GitHub requires token as username with x-oauth-basic as password
     // https://isomorphic-git.org/docs/en/authentication.html
     return {
-      username: credential.token,
+      username: credential?.credentials?.token,
       password: 'x-oauth-basic',
     };
   }

--- a/packages/insomnia/src/sync/git/providers/github.ts
+++ b/packages/insomnia/src/sync/git/providers/github.ts
@@ -297,7 +297,7 @@ export class GitHubProvider implements GitRemoteProvider<GitHubProviderConfig> {
       const email = emails.find(e => e.primary)?.email ?? userProfileEmail ?? '';
 
       await models.gitCredentials.create({
-        name: 'Github Credential',
+        name: 'GitHub Credential',
         credentials: {
           token: data.access_token,
         },

--- a/packages/insomnia/src/sync/git/providers/gitlab.ts
+++ b/packages/insomnia/src/sync/git/providers/gitlab.ts
@@ -181,7 +181,7 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
         `${this.config.apiUrl}/projects?membership=true&per_page=${perPage}&page=${page}&order_by=last_activity_at`,
         {
           headers: {
-            Authorization: `Bearer ${credential.token}`,
+            Authorization: `Bearer ${credential.credentials?.token}`,
           },
         },
       );
@@ -225,7 +225,7 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
     // Fetch current user to get emails
     const userResponse = await net.fetch(`${this.config.apiUrl}/user`, {
       headers: {
-        Authorization: `Bearer ${credential.token}`,
+        Authorization: `Bearer ${credential.credentials?.token}`,
       },
     });
 
@@ -238,7 +238,7 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
     // Fetch all emails for the user
     const emailsResponse = await net.fetch(`${this.config.apiUrl}/user/emails`, {
       headers: {
-        Authorization: `Bearer ${credential.token}`,
+        Authorization: `Bearer ${credential.credentials?.token}`,
       },
     });
 
@@ -271,7 +271,7 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
       throw new Error('Invalid credential type for GitLab provider');
     }
 
-    const data = await this.fetchUserWithToken(credential.token);
+    const data = await this.fetchUserWithToken(credential.credentials?.token);
 
     return {
       id: String(data.id),
@@ -429,7 +429,7 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
       throw new Error('Invalid credential type for GitLab provider');
     }
 
-    if (!credential.refreshToken) {
+    if (!credential.credentials?.refreshToken) {
       throw new Error('No refresh token available for renewal');
     }
 
@@ -468,7 +468,7 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
       url.search = new URLSearchParams({
         client_id: clientId,
         grant_type: 'refresh_token',
-        refresh_token: credential.refreshToken,
+        refresh_token: credential.credentials?.refreshToken,
         redirect_uri: redirectUri,
       }).toString();
 
@@ -485,8 +485,10 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
 
       // Update the credential in the database with new tokens
       const updatedCredential = await models.gitCredentials.update(credential, {
-        token: access_token,
-        refreshToken: refresh_token,
+        credentials: {
+          token: access_token,
+          refreshToken: refresh_token,
+        },
       });
 
       // Reset renewal tracking on success
@@ -514,7 +516,7 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
     // https://isomorphic-git.org/docs/en/authentication.html
     return {
       username: 'oauth2',
-      password: credential.token,
+      password: credential.credentials?.token,
     };
   }
 
@@ -531,7 +533,7 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
         console.log('[GitLabProvider] Token renewed successfully');
         return {
           username: 'oauth2',
-          password: renewed.token,
+          password: renewed.credentials?.token,
         };
       }
     } catch (error) {

--- a/packages/insomnia/src/sync/git/providers/gitlab.ts
+++ b/packages/insomnia/src/sync/git/providers/gitlab.ts
@@ -7,7 +7,7 @@ import { v4 } from 'uuid';
 
 import { getApiBaseURL, INSOMNIA_GITLAB_CLIENT_ID, INSOMNIA_GITLAB_REDIRECT_URI, PLAYWRIGHT } from '~/common/constants';
 import * as models from '~/models';
-import type { GitCredentials } from '~/models/git-credentials';
+import type { BaseGitCredentialsV2, GitCredentials } from '~/models/git-credentials';
 import { isGitCredentialsV2 } from '~/models/git-credentials';
 
 import type {
@@ -393,15 +393,17 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
       // Create or update credential in database
       const credentialData = {
         name: 'GitLab Credential',
-        token: access_token,
-        refreshToken: refresh_token,
-        provider: 'gitlab' as const,
+        provider: 'gitlab',
         author: {
           email: user.commit_email ?? user.public_email ?? user.email ?? '',
           name: user.username ?? user.name ?? '',
           avatarUrl: user.avatar_url,
         },
-      };
+        credentials: {
+          token: access_token,
+          refreshToken: refresh_token,
+        },
+      } satisfies BaseGitCredentialsV2;
 
       const credential = await models.gitCredentials.create(credentialData);
 

--- a/packages/insomnia/src/ui/components/git-credentials/git-custom-credential-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-custom-credential-form.tsx
@@ -30,9 +30,12 @@ export const GitCustomCredentialForm = ({
         name: (formData.get('authorName') as string) || '',
         email: (formData.get('authorEmail') as string) || '',
       },
-      username: (formData.get('username') as string) || '',
-      password: (formData.get('password') as string) || '',
-      baseURI: (formData.get('baseURI') as string) || '',
+      credentials: {
+        username: (formData.get('username') as string) || '',
+        password: (formData.get('password') as string) || '',
+        baseURI: (formData.get('baseURI') as string) || '',
+      },
+      name: 'Custom Git Credential',
     };
 
     await (isEditing && gitCredentialToEdit._id

--- a/packages/insomnia/src/ui/components/git-credentials/git-custom-credential-form.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-custom-credential-form.tsx
@@ -71,7 +71,7 @@ export const GitCustomCredentialForm = ({
             className="w-1/2"
             label="Username"
             placeholder="remote username for PAT"
-            defaultValue={gitCredentialToEdit?.username}
+            defaultValue={gitCredentialToEdit?.credentials?.username}
           />
           <Input
             className="w-1/2"
@@ -79,7 +79,7 @@ export const GitCustomCredentialForm = ({
             isRequired
             label="Git Access Token"
             placeholder="e.g. github_pat_11A11AAAAa111Aa11a1AA11"
-            defaultValue={gitCredentialToEdit?.password}
+            defaultValue={gitCredentialToEdit?.credentials?.password}
           />
         </div>
         <Input
@@ -89,7 +89,7 @@ export const GitCustomCredentialForm = ({
           label="Repository base URL"
           description="Specify the git server base URL that correlates with this access token."
           placeholder="e.g. https://github.your-domain.com/org-name"
-          defaultValue={gitCredentialToEdit?.baseURI}
+          defaultValue={gitCredentialToEdit?.credentials?.baseURI}
         />
       </div>
       <div className="flex gap-2">

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-repository-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-repository-settings-modal.tsx
@@ -233,9 +233,9 @@ export const GitRepositorySettingsModal = ({
                       selectedCredential &&
                       isGitCredentialsV2(selectedCredential) &&
                       selectedCredential.provider === 'custom' &&
-                      selectedCredential.baseURI
+                      selectedCredential.credentials?.baseURI
                     ) {
-                      prefix = selectedCredential.baseURI.replace(/\/+$/, '') + '/';
+                      prefix = selectedCredential.credentials?.baseURI.replace(/\/+$/, '') + '/';
                     }
 
                     setRepoData(prev => ({ ...prev, uri: prefix + value }));
@@ -247,10 +247,10 @@ export const GitRepositorySettingsModal = ({
                   {selectedCredential &&
                   isGitCredentialsV2(selectedCredential) &&
                   selectedCredential.provider === 'custom' &&
-                  selectedCredential.baseURI ? (
+                  selectedCredential.credentials?.baseURI ? (
                     <div className="flex h-(--line-height-xxs) w-full rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) p-0 pr-7 text-(--color-font) transition-colors placeholder:text-sm placeholder:italic focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden">
                       <div className="flex h-full items-center bg-(--hl-sm) px-2 text-(--color-font)">
-                        {selectedCredential.baseURI.replace(/\/+$/, '')}/
+                        {selectedCredential.credentials?.baseURI.replace(/\/+$/, '')}/
                       </div>
                       <Input className="flex-1 px-2" />
                     </div>

--- a/packages/insomnia/src/ui/components/project/git-repo-form.tsx
+++ b/packages/insomnia/src/ui/components/project/git-repo-form.tsx
@@ -74,7 +74,7 @@ export const GitRepoForm: FC<Props> = ({
     (selectedCredential &&
       isGitCredentialsV2(selectedCredential) &&
       selectedCredential.provider === 'custom' &&
-      selectedCredential.baseURI) ||
+      selectedCredential.credentials?.baseURI) ||
     '';
 
   return (


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Refactor gitcredentials model

- Remove unused fields: `renewalAttempts` `lastRenewalAttempt`
- Refactors the git credential model from a flat structure (V1) to a nested structure (V2) where provider-specific credential data is contained within a credentials object.
- Updates all provider implementations (GitHub, GitLab, Custom) to access credentials through the nested structure