### PR TITLE
feat: make commit dialog default state clearer

### DIFF
--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -996,18 +996,16 @@ export const GitProjectStagingModal: FC<{
 
                     {(!generateCommitsFetcher.data ||
                       (generateCommitsFetcher.data && 'error' in generateCommitsFetcher.data)) && (
-                      <>
-                        <ManualCommitForm
-                          projectId={projectId}
-                          mode={mode}
-                          changes={changes}
-                          setShowConfirmDiscardAndPullModal={setShowConfirmDiscardAndPullModal}
-                          onCommitSuccess={handleCommitSuccess}
-                          onPullRequired={handlePullRequired}
-                          diffChanges={diffChanges}
-                          setDiscardData={setDiscardData}
-                        />
-                      </>
+                      <ManualCommitForm
+                        projectId={projectId}
+                        mode={mode}
+                        changes={changes}
+                        setShowConfirmDiscardAndPullModal={setShowConfirmDiscardAndPullModal}
+                        onCommitSuccess={handleCommitSuccess}
+                        onPullRequired={handlePullRequired}
+                        diffChanges={diffChanges}
+                        setDiscardData={setDiscardData}
+                      />
                     )}
                   </div>
                   {previewDiffItem?.diff ? (
@@ -1026,9 +1024,12 @@ export const GitProjectStagingModal: FC<{
                     <div className="flex h-full flex-col items-center justify-center gap-4 p-2">
                       <Heading className="flex items-center justify-center gap-2 text-4xl font-semibold text-(--hl-md)">
                         <Icon icon="code-compare" />
-                        Diff view
+                        View diff
                       </Heading>
-                      <p className="text-(--hl)">Select an item to compare</p>
+                      <p className="text-(--hl)">Select a file to compare changes</p>
+                      <p className="text-sm text-(--hl-md)">
+                        Changes may include modifications you made and automatic updates like timestamps
+                      </p>
                     </div>
                   )}
                 </div>

--- a/packages/insomnia/src/ui/components/modals/git-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-staging-modal.tsx
@@ -457,9 +457,12 @@ export const GitStagingModal: FC<{ onClose: () => void }> = ({ onClose }) => {
                   <div className="flex h-full flex-col items-center justify-center gap-4 p-2">
                     <Heading className="flex items-center justify-center gap-2 text-4xl font-semibold text-(--hl-md)">
                       <Icon icon="code-compare" />
-                      Diff view
+                      View diff
                     </Heading>
-                    <p className="text-(--hl)">Select an item to compare</p>
+                    <p className="text-(--hl)">Select a file to compare changes</p>
+                    <p className="text-sm text-(--hl-md)">
+                      Changes may include modifications you made and automatic updates like timestamps
+                    </p>
                   </div>
                 )}
               </div>

--- a/packages/insomnia/src/ui/components/modals/sync-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/sync-staging-modal.tsx
@@ -398,9 +398,12 @@ export const SyncStagingModal = ({ onClose, status, syncItems }: Props) => {
                   <div className="flex h-full flex-col items-center justify-center gap-4 p-2">
                     <Heading className="flex items-center justify-center gap-2 text-4xl font-semibold text-(--hl-md)">
                       <Icon icon="code-compare" />
-                      Diff view
+                      View diff
                     </Heading>
-                    <p className="text-(--hl)">Select an item to compare</p>
+                    <p className="text-(--hl)">Select a file to compare changes</p>
+                    <p className="text-sm text-(--hl-md)">
+                      Changes may include modifications you made and automatic updates like timestamps
+                    </p>
                   </div>
                 )}
               </div>


### PR DESCRIPTION
minor ux change to the git commit dialogs:

<img width="678" height="251" alt="Screenshot 2026-01-06 at 09 29 06" src="https://github.com/user-attachments/assets/ab4c65d1-190a-45d5-aa64-8e216692a0a2" />
