### PR TITLE
Prevent users from deleting git credentials in use. [INS-1900]

### DIFF
--- a/packages/insomnia/src/models/project.ts
+++ b/packages/insomnia/src/models/project.ts
@@ -83,6 +83,12 @@ export function getByRemoteId(remoteId: string) {
   return db.findOne<Project>(type, { remoteId });
 }
 
+export function getAllByGitRepositoryIds(gitRepositoryIds: string[]) {
+  return db.find<Project>(type, {
+    gitRepositoryId: { $in: gitRepositoryIds },
+  });
+}
+
 export function remove(project: Project) {
   return db.remove(project);
 }

--- a/packages/insomnia/src/routes/git-credentials.$id.related-projects.tsx
+++ b/packages/insomnia/src/routes/git-credentials.$id.related-projects.tsx
@@ -1,0 +1,28 @@
+import { href } from 'react-router';
+
+import { gitRepository, project } from '~/models';
+import { createFetcherLoadHook } from '~/utils/router';
+
+import type { Route } from './+types/git-credentials.$id.related-projects';
+
+export async function clientLoader({ params }: Route.ClientLoaderArgs) {
+  const { id: gitCredentialsId } = params;
+
+  const relatedGitRepositories = await gitRepository.getAllByCredentialId(gitCredentialsId);
+
+  const gitRepositoryIds = relatedGitRepositories.map(repo => repo._id);
+
+  const relatedProjects = await project.getAllByGitRepositoryIds(gitRepositoryIds);
+
+  return {
+    projects: relatedProjects,
+  };
+}
+
+export const useRelatedProjectsByGitCredentialsIdLoaderFetcher = createFetcherLoadHook(
+  load =>
+    ({ gitCredentialsId }: { gitCredentialsId: string }) => {
+      return load(href('/git-credentials/:id/related-projects', { id: gitCredentialsId }));
+    },
+  clientLoader,
+);

--- a/packages/insomnia/src/ui/components/settings/credentials.tsx
+++ b/packages/insomnia/src/ui/components/settings/credentials.tsx
@@ -23,6 +23,7 @@ import {
 } from '~/models/git-credentials';
 import { useGitCredentialsLoaderFetcher } from '~/routes/git-credentials';
 import { useGitCredentialsDeleteActionFetcher } from '~/routes/git-credentials.$id.delete';
+import { useRelatedProjectsByGitCredentialsIdLoaderFetcher } from '~/routes/git-credentials.$id.related-projects';
 import { useGitProviderCompleteSignInFetcher } from '~/routes/git-credentials.complete-sign-in';
 import { useInitSignInToGitProviderFetcher } from '~/routes/git-credentials.init-sign-in';
 import { GitCustomCredentialForm } from '~/ui/components/git-credentials/git-custom-credential-form';
@@ -212,7 +213,9 @@ const GitCredentialsList = () => {
   const [gitCredentialToEdit, setGitCredentialToEdit] = useState<GitCredentialsV2 | null>(null);
   const credentialsFetcher = useGitCredentialsLoaderFetcher();
   const deleteCredentialFetcher = useGitCredentialsDeleteActionFetcher();
+  const relatedProjectsFetcher = useRelatedProjectsByGitCredentialsIdLoaderFetcher();
   const [isCredentialModalOpen, setIsCredentialModalOpen] = useState(false);
+  const [pendingDeleteCredentialId, setPendingDeleteCredentialId] = useState<string | null>(null);
   const [selectedProvider, setSelectedProvider] = useState<{
     type: GitRemoteProviderType;
     displayName: string;
@@ -234,6 +237,50 @@ const GitCredentialsList = () => {
     }
     previousCredentialsLengthRef.current = currentLength;
   }, [credentialsFetcher.data?.credentials.length]);
+
+  // Handle delete confirmation when related projects data is loaded
+  useEffect(() => {
+    if (pendingDeleteCredentialId && relatedProjectsFetcher.state === 'idle' && relatedProjectsFetcher.data) {
+      const projectNames = relatedProjectsFetcher.data.projects?.map(p => p.name) || [];
+
+      if (projectNames.length > 0) {
+        showModal(AlertModal, {
+          title: 'Cannot Delete Git Credential',
+          message: (
+            <div className="flex flex-col gap-4">
+              <p>This git credential is currently being used by the following projects:</p>
+              <ul className="flex flex-col gap-2 rounded-md border border-solid border-(--hl-md) bg-(--hl-xs) p-4">
+                {projectNames.map(name => (
+                  <li key={name} className="flex items-center gap-2">
+                    <Icon icon="folder" className="text-(--color-font)" />
+                    <span className="font-medium">{name}</span>
+                  </li>
+                ))}
+              </ul>
+              <p className="text-(--color-font-muted)">
+                Please disconnect or delete these projects before removing this credential.
+              </p>
+            </div>
+          ),
+          okLabel: 'OK',
+          addCancel: false,
+        });
+      } else {
+        showModal(AlertModal, {
+          title: 'Delete Git Credential',
+          message:
+            'Are you sure you want to delete this git credential? This will remove the credential from any connected repositories.',
+          okLabel: 'Delete',
+          addCancel: true,
+          onConfirm: async () => {
+            deleteCredentialFetcher.submit({ id: pendingDeleteCredentialId });
+          },
+        });
+      }
+
+      setPendingDeleteCredentialId(null);
+    }
+  }, [pendingDeleteCredentialId, relatedProjectsFetcher.state, relatedProjectsFetcher.data, deleteCredentialFetcher]);
 
   return (
     <div className="mb-4 flex flex-col gap-2 py-4">
@@ -336,16 +383,8 @@ const GitCredentialsList = () => {
                 )}
                 <Button
                   onPress={() => {
-                    showModal(AlertModal, {
-                      title: 'Delete Git Credential',
-                      message:
-                        'Are you sure you want to delete this git credential? This will remove the credential from any connected repositories.',
-                      okLabel: 'Delete',
-                      addCancel: true,
-                      onConfirm: async () => {
-                        deleteCredentialFetcher.submit({ id: item._id });
-                      },
-                    });
+                    setPendingDeleteCredentialId(item._id);
+                    relatedProjectsFetcher.load({ gitCredentialsId: item._id });
                   }}
                   className="h-7 rounded-xs px-2 py-1 text-sm text-(--color-font) transition-all hover:bg-(--hl-xs) disabled:opacity-50 aria-pressed:bg-(--hl-sm)"
                 >

--- a/packages/insomnia/src/ui/components/settings/credentials.tsx
+++ b/packages/insomnia/src/ui/components/settings/credentials.tsx
@@ -213,6 +213,7 @@ const GitCredentialsList = () => {
   const [gitCredentialToEdit, setGitCredentialToEdit] = useState<GitCredentialsV2 | null>(null);
   const credentialsFetcher = useGitCredentialsLoaderFetcher();
   const deleteCredentialFetcher = useGitCredentialsDeleteActionFetcher();
+  const deleteCredentialFetcherSubmit = deleteCredentialFetcher.submit;
   const relatedProjectsFetcher = useRelatedProjectsByGitCredentialsIdLoaderFetcher();
   const [isCredentialModalOpen, setIsCredentialModalOpen] = useState(false);
   const [pendingDeleteCredentialId, setPendingDeleteCredentialId] = useState<string | null>(null);
@@ -269,18 +270,23 @@ const GitCredentialsList = () => {
         showModal(AlertModal, {
           title: 'Delete Git Credential',
           message:
-            'Are you sure you want to delete this git credential? This will remove the credential from any connected repositories.',
+            'Are you sure you want to delete this Git credential? You won’t be able to use it to connect new Git Sync projects to the repositories it provides access to.',
           okLabel: 'Delete',
           addCancel: true,
           onConfirm: async () => {
-            deleteCredentialFetcher.submit({ id: pendingDeleteCredentialId });
+            deleteCredentialFetcherSubmit({ id: pendingDeleteCredentialId });
           },
         });
       }
 
       setPendingDeleteCredentialId(null);
     }
-  }, [pendingDeleteCredentialId, relatedProjectsFetcher.state, relatedProjectsFetcher.data, deleteCredentialFetcher]);
+  }, [
+    pendingDeleteCredentialId,
+    relatedProjectsFetcher.state,
+    relatedProjectsFetcher.data,
+    deleteCredentialFetcherSubmit,
+  ]);
 
   return (
     <div className="mb-4 flex flex-col gap-2 py-4">

--- a/packages/insomnia/src/ui/components/settings/credentials.tsx
+++ b/packages/insomnia/src/ui/components/settings/credentials.tsx
@@ -216,7 +216,7 @@ const GitCredentialsList = () => {
   const deleteCredentialFetcherSubmit = deleteCredentialFetcher.submit;
   const relatedProjectsFetcher = useRelatedProjectsByGitCredentialsIdLoaderFetcher();
   const [isCredentialModalOpen, setIsCredentialModalOpen] = useState(false);
-  const [pendingDeleteCredentialId, setPendingDeleteCredentialId] = useState<string | null>(null);
+  const pendingDeleteCredentialIdRef = useRef<string | null>(null);
   const [selectedProvider, setSelectedProvider] = useState<{
     type: GitRemoteProviderType;
     displayName: string;
@@ -241,18 +241,23 @@ const GitCredentialsList = () => {
 
   // Handle delete confirmation when related projects data is loaded
   useEffect(() => {
-    if (pendingDeleteCredentialId && relatedProjectsFetcher.state === 'idle' && relatedProjectsFetcher.data) {
-      const projectNames = relatedProjectsFetcher.data.projects?.map(p => p.name) || [];
+    if (
+      pendingDeleteCredentialIdRef.current &&
+      relatedProjectsFetcher.state === 'idle' &&
+      relatedProjectsFetcher.data
+    ) {
+      const credentialIdToDelete = pendingDeleteCredentialIdRef.current;
+      const projects = relatedProjectsFetcher.data.projects || [];
 
-      if (projectNames.length > 0) {
+      if (projects.length > 0) {
         showModal(AlertModal, {
           title: 'Cannot Delete Git Credential',
           message: (
             <div className="flex flex-col gap-4">
               <p>This git credential is currently being used by the following projects:</p>
               <ul className="flex flex-col gap-2 rounded-md border border-solid border-(--hl-md) bg-(--hl-xs) p-4">
-                {projectNames.map(name => (
-                  <li key={name} className="flex items-center gap-2">
+                {projects.map(({ name, _id }) => (
+                  <li key={_id} className="flex items-center gap-2">
                     <Icon icon="folder" className="text-(--color-font)" />
                     <span className="font-medium">{name}</span>
                   </li>
@@ -274,19 +279,14 @@ const GitCredentialsList = () => {
           okLabel: 'Delete',
           addCancel: true,
           onConfirm: async () => {
-            deleteCredentialFetcherSubmit({ id: pendingDeleteCredentialId });
+            deleteCredentialFetcherSubmit({ id: credentialIdToDelete });
           },
         });
       }
 
-      setPendingDeleteCredentialId(null);
+      pendingDeleteCredentialIdRef.current = null;
     }
-  }, [
-    pendingDeleteCredentialId,
-    relatedProjectsFetcher.state,
-    relatedProjectsFetcher.data,
-    deleteCredentialFetcherSubmit,
-  ]);
+  }, [relatedProjectsFetcher.state, relatedProjectsFetcher.data, deleteCredentialFetcherSubmit]);
 
   return (
     <div className="mb-4 flex flex-col gap-2 py-4">
@@ -389,7 +389,7 @@ const GitCredentialsList = () => {
                 )}
                 <Button
                   onPress={() => {
-                    setPendingDeleteCredentialId(item._id);
+                    pendingDeleteCredentialIdRef.current = item._id;
                     relatedProjectsFetcher.load({ gitCredentialsId: item._id });
                   }}
                   className="h-7 rounded-xs px-2 py-1 text-sm text-(--color-font) transition-all hover:bg-(--hl-xs) disabled:opacity-50 aria-pressed:bg-(--hl-sm)"


### PR DESCRIPTION
Add the logic to check if there are any connected git-sync projects when deleting a git credential in the preference modal.

- If if there are any connected git-sync projects, it lists the connected project names to prevent deleting.
- If if there are no connected git-sync projects, it asks the user to double confirm before deleting.