### PR TITLE
refactor: move enterprise apis to insomnia-api

### DIFF
--- a/packages/insomnia-api/src/enterprise.ts
+++ b/packages/insomnia-api/src/enterprise.ts
@@ -1,0 +1,69 @@
+import { fetch } from './fetch';
+
+// GET /v1/user/resource-usage
+interface ResourceUsage {
+  mocks: {
+    quota: number;
+    calls: number;
+    autoPurchase: {
+      enabled: boolean;
+      unit: number;
+    };
+  };
+}
+
+export const getResourceUsage = ({ sessionId }: { sessionId: string }) => {
+  return fetch<ResourceUsage>({
+    method: 'GET',
+    path: '/v1/user/resource-usage',
+    sessionId,
+  });
+};
+
+// GET /v1/user/enterprises
+interface EnterpriseOwner {
+  id: string;
+  name: string;
+  role: string;
+}
+
+export const getOwnEnterprises = ({ sessionId }: { sessionId: string }) => {
+  return fetch<EnterpriseOwner[]>({
+    method: 'GET',
+    path: '/v1/user/enterprises',
+    sessionId,
+  });
+};
+
+// GET /v1/accounts/seats
+interface AccountUsedSeats {
+  memberCount: number;
+  inviteCount: number;
+  used: number;
+  total: number;
+}
+
+export const getAccountUsedSeats = ({ sessionId }: { sessionId: string }) => {
+  return fetch<AccountUsedSeats>({
+    method: 'GET',
+    path: '/v1/accounts/seats',
+    sessionId,
+  });
+};
+
+// GET /v1/enterprise/:enterpriseId/license-usage
+interface LicenseUsage {
+  used: number;
+  total: number;
+  memberCount: number;
+  inviteCount: number;
+  free: number;
+}
+
+export const getEnterpriseLicenseUsage = ({ sessionId, enterpriseId }: { sessionId: string; enterpriseId: string }) => {
+  return fetch<LicenseUsage>({
+    method: 'GET',
+    path: `/v1/enterprise/${enterpriseId}/license-usage`,
+    sessionId,
+  });
+};

--- a/packages/insomnia-api/src/index.ts
+++ b/packages/insomnia-api/src/index.ts
@@ -1,5 +1,6 @@
 export * from './user';
 export * from './vault';
+export * from './enterprise';
 export * from './trial';
 
 export { configureFetch, type FetchConfig } from './fetch';

--- a/packages/insomnia/src/routes/resource.usage.tsx
+++ b/packages/insomnia/src/routes/resource.usage.tsx
@@ -1,84 +1,26 @@
-import { type CurrentPlan, getTrialEligibility } from 'insomnia-api';
+import {
+  type CurrentPlan,
+  getAccountUsedSeats,
+  getEnterpriseLicenseUsage,
+  getOwnEnterprises,
+  getResourceUsage,
+  getTrialEligibility,
+} from 'insomnia-api';
 import { href } from 'react-router';
 
 import { userSession } from '~/models';
-import { insomniaFetch } from '~/ui/insomnia-fetch';
 import { createFetcherLoadHook } from '~/utils/router';
 
-interface ResourceUsage {
-  mocks: {
-    quota: number;
-    calls: number;
-    autoPurchase: {
-      enabled: boolean;
-      unit: number;
-    };
-  };
-}
-
-interface EnterpriseOwner {
-  id: string;
-  name: string;
-  role: string;
-}
-
-interface AccountUsedSeats {
-  memberCount: number;
-  inviteCount: number;
-  used: number;
-  total: number;
-}
-
-interface LicenseUsage {
-  used: number;
-  total: number;
-  memberCount: number;
-  inviteCount: number;
-  free: number;
-}
-
-function getResourceUsage(sessionId: string) {
-  return insomniaFetch<ResourceUsage>({
-    method: 'GET',
-    path: '/v1/user/resource-usage',
-    sessionId,
-  });
-}
-
-function getOwnEnterprises(sessionId: string) {
-  return insomniaFetch<EnterpriseOwner[]>({
-    method: 'GET',
-    path: '/v1/user/enterprises',
-    sessionId,
-  });
-}
-
 async function getCurrentEnterprise(sessionId: string) {
-  const enterprises = await getOwnEnterprises(sessionId);
+  const enterprises = await getOwnEnterprises({ sessionId });
   if (!Array.isArray(enterprises)) {
     return null;
   }
   return enterprises.find(ent => ent.role === 'owner') ?? enterprises[0];
 }
 
-function getAccountUsedSeats(sessionId: string) {
-  return insomniaFetch<AccountUsedSeats>({
-    method: 'GET',
-    path: '/v1/accounts/seats',
-    sessionId,
-  });
-}
-
-function getEnterpriseLicenseUsage(sessionId: string, enterpriseId: string) {
-  return insomniaFetch<LicenseUsage>({
-    method: 'GET',
-    path: `/v1/enterprise/${enterpriseId}/license-usage`,
-    sessionId,
-  });
-}
-
 function getLicenseUsage(sessionId: string, enterpriseId?: string | null) {
-  return enterpriseId ? getEnterpriseLicenseUsage(sessionId, enterpriseId) : getAccountUsedSeats(sessionId);
+  return enterpriseId ? getEnterpriseLicenseUsage({ sessionId, enterpriseId }) : getAccountUsedSeats({ sessionId });
 }
 
 export async function clientLoader() {
@@ -95,7 +37,7 @@ export async function clientLoader() {
   const currentPlan = JSON.parse(localStorage.getItem(`${accountId}:currentPlan`) || '{}') as CurrentPlan;
   const enterpriseId = currentPlan?.type === 'enterprise' ? (await getCurrentEnterprise(sessionId))?.id : null;
   const [resourceUsage, licenseUsage, trialEligibility] = await Promise.allSettled([
-    getResourceUsage(sessionId),
+    getResourceUsage({ sessionId }),
     getLicenseUsage(sessionId, enterpriseId),
     getTrialEligibility({ sessionId }),
   ]);


### PR DESCRIPTION
## Background

[INS-1878](https://konghq.atlassian.net/browse/INS-1878)

Move enterprise related apis to insomnia-api

## Changes

- /v1/user/resource-usage
- /v1/user/enterprises
- /v1/accounts/seats
- /v1/enterprise/:enterpriseId/license-usage

[INS-1878]: https://konghq.atlassian.net/browse/INS-1878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ