### PR TITLE
fix(mcp): minor ux improvements

### DIFF
--- a/packages/insomnia/src/ui/components/mcp/event-view.tsx
+++ b/packages/insomnia/src/ui/components/mcp/event-view.tsx
@@ -122,10 +122,7 @@ export const MessageEventView = ({ event }: Props) => {
         }
       }
     }
-    // Escape tabs and new lines for CodeMirror display
-    pretty = JSON.stringify(parsed, null, '\t')
-      .replace(/\\n|\\r\\n|\\r/g, '\n')
-      .replace(/\\t/g, '\t');
+    pretty = JSON.stringify(parsed, null, '\t');
   } catch {
     // Can't parse as JSON.
   }
@@ -200,7 +197,7 @@ export const MessageEventView = ({ event }: Props) => {
         )}
       </div>
       {viewMode === 'raw' && (
-        <div className="h-full grow p-4">
+        <div className="h-full grow">
           <CodeEditor
             id="mcp-data-preview"
             hideLineNumbers

--- a/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
@@ -15,7 +15,7 @@ import { type IconId, SvgIcon } from '../svg-icon';
 
 type EventTypes = WebSocketEvent | CurlEvent | SocketIOEvent | McpEvent;
 const Timestamp: FC<{ time: Date | number }> = ({ time }) => {
-  const date = format(time, 'HH:mm:ss');
+  const date = format(time, 'HH:mm:ss.SSS');
   return <>{date}</>;
 };
 
@@ -236,13 +236,13 @@ export const EventLogView: FC<Props> = ({
                   : 'focus-within:bg-(--hl-sm) focus:outline-hidden';
               return (
                 <Row className={`group transition-colors ${rowExtraClasses}`}>
-                  <Cell className="border-b border-solid border-(--hl-sm) p-2 text-sm font-medium whitespace-nowrap group-last-of-type:border-none focus:outline-hidden">
+                  <Cell className="border-b border-solid border-(--hl-sm) align-middle text-sm font-medium whitespace-nowrap group-last-of-type:border-none focus:outline-hidden">
                     <SvgIcon icon={getIcon(event)} />
                   </Cell>
-                  <Cell className="border-b border-solid border-(--hl-sm) text-sm font-medium whitespace-nowrap group-last-of-type:border-none focus:outline-hidden">
+                  <Cell className="border-b border-solid border-(--hl-sm) align-middle text-sm font-medium whitespace-nowrap group-last-of-type:border-none focus:outline-hidden">
                     {getMessage(event, isLoading)}
                   </Cell>
-                  <Cell className="border-b border-solid border-(--hl-sm) text-sm font-medium whitespace-nowrap group-last-of-type:border-none focus:outline-hidden">
+                  <Cell className="border-b border-solid border-(--hl-sm) align-middle text-sm font-medium whitespace-nowrap group-last-of-type:border-none focus:outline-hidden">
                     <Timestamp time={event.timestamp} />
                   </Cell>
                 </Row>

--- a/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/realtime-response-pane.tsx
@@ -317,7 +317,7 @@ const RealtimeActiveResponsePane: FC<RealtimeActiveResponsePaneProps & { readySt
               <ResponseErrorViewer url={response.url} error={response.error} isMcpResponse={isMcpResponse(response)} />
             ) : (
               <>
-                <Panel minSize={10} defaultSize={50} className="box-border flex w-full flex-1 flex-col overflow-hidden">
+                <Panel minSize={10} defaultSize={36} className="box-border flex w-full flex-1 flex-col overflow-hidden">
                   <div
                     style={{
                       display: 'flex',


### PR DESCRIPTION
- adds milliseconds to the event log timestamps
- removes padding around the response preview
- fixes broken JSONPath due to extra preview formatting
- reduces default event pane size (~3 rows on 720px viewport)
- aligns event log status icons to middle of row