### PR TITLE
Clarify macOS entitlements for local testing

### DIFF
--- a/packages/insomnia-smoke-test/README.md
+++ b/packages/insomnia-smoke-test/README.md
@@ -119,10 +119,7 @@ npm run app-package
 npm run test:smoke:package
 ```
 
-> Note: for local testing of the packaged app on macOS you need to change the entitlements temporarily to allow unsigned apps to run. You can do this by changing the `com.apple.security.cs.disable-library-validation` key in `entitlements.mac.inherit.plist` file to
-> to ` <key>com.apple.security.cs.disable-library-validation</key>
-
-    <false/>`
+> Note: for local testing of the packaged app on macOS you need to change the entitlements temporarily to allow unsigned apps to run. You can do this by changing the `com.apple.security.cs.disable-library-validation` key in `entitlements.mac.inherit.plist` file to `true`. (Remember do not commit to the origin repo!)
 
 Each of the above commands will automatically run the Express server, so you do not need to take any extra steps.
 


### PR DESCRIPTION
Fix markdown format
Updated instructions for macOS local testing of the packaged app to set the library validation key to true.

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
