### PR TITLE
fix: Tooltip action is not clickable when render in modal

### DIFF
--- a/packages/insomnia/src/ui/components/settings/plugins.tsx
+++ b/packages/insomnia/src/ui/components/settings/plugins.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, useEffect, useState } from 'react';
+import React, { type FC, useEffect, useRef, useState } from 'react';
 import {
   Button,
   Checkbox,
@@ -40,6 +40,7 @@ interface State {
 export const Plugins: FC = () => {
   const { settings } = useRootLoaderData()!;
   const [showCreatePluginModal, setShowCreatePluginModal] = useState(false);
+  const containerRef = useRef(null);
 
   const [
     {
@@ -92,7 +93,7 @@ export const Plugins: FC = () => {
   const patchSettings = useSettingsPatcher();
 
   return (
-    <div>
+    <div ref={containerRef}>
       <p className="notice info no-margin-top">
         Plugins is still an experimental feature. See <Link href={docsPlugins}>Documentation</Link> for more info.
       </p>
@@ -231,6 +232,7 @@ export const Plugins: FC = () => {
 
               <Tooltip
                 className="cursor-pointer pt-2"
+                portalContainer={containerRef.current}
                 message={
                   <span>
                     You can bundle multiple root certificates into a single file.{' '}

--- a/packages/insomnia/src/ui/components/settings/plugins.tsx
+++ b/packages/insomnia/src/ui/components/settings/plugins.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, useEffect, useRef, useState } from 'react';
+import React, { type FC, useEffect, useState } from 'react';
 import {
   Button,
   Checkbox,
@@ -40,7 +40,6 @@ interface State {
 export const Plugins: FC = () => {
   const { settings } = useRootLoaderData()!;
   const [showCreatePluginModal, setShowCreatePluginModal] = useState(false);
-  const containerRef = useRef(null);
 
   const [
     {
@@ -93,7 +92,7 @@ export const Plugins: FC = () => {
   const patchSettings = useSettingsPatcher();
 
   return (
-    <div ref={containerRef}>
+    <div>
       <p className="notice info no-margin-top">
         Plugins is still an experimental feature. See <Link href={docsPlugins}>Documentation</Link> for more info.
       </p>
@@ -232,7 +231,6 @@ export const Plugins: FC = () => {
 
               <Tooltip
                 className="cursor-pointer pt-2"
-                portalContainer={containerRef.current}
                 message={
                   <span>
                     You can bundle multiple root certificates into a single file.{' '}

--- a/packages/insomnia/src/ui/components/tooltip.tsx
+++ b/packages/insomnia/src/ui/components/tooltip.tsx
@@ -65,7 +65,8 @@ export const Tooltip = (props: Props) => {
       </div>
       {state.isOpen &&
         (portalContainer ? (
-          // Render tooltip inside customized portal(used in modal); otherwise the overlay container becomes inert and breaks hover
+          // Render tooltip inside customized portal,
+          // Mainly used in when render in modal, the overlayContainer becomes inert and breaks hover
           createPortal(overlayContent, portalContainer)
         ) : (
           <OverlayContainer>{overlayContent}</OverlayContainer>

--- a/packages/insomnia/src/ui/components/tooltip.tsx
+++ b/packages/insomnia/src/ui/components/tooltip.tsx
@@ -14,13 +14,12 @@ interface Props {
   wide?: boolean;
   style?: CSSProperties;
   onClick?: () => void;
-  portalContainer?: HTMLElement | null;
 }
 
 export const Tooltip = (props: Props) => {
-  const { children, message, className, wide, selectable, delay = 400, position, style, portalContainer } = props;
-  const triggerRef = React.useRef(null);
-  const overlayRef = React.useRef(null);
+  const { children, message, className, wide, selectable, delay = 400, position, style } = props;
+  const triggerRef = React.useRef<HTMLDivElement>(null);
+  const overlayRef = React.useRef<HTMLDivElement>(null);
 
   const state = useTooltipTriggerState({ delay });
   const trigger = useTooltipTrigger(props, state, triggerRef);
@@ -52,6 +51,8 @@ export const Tooltip = (props: Props) => {
     </div>
   );
 
+  const modalContainer = triggerRef.current?.closest('[aria-label="Modal"]');
+
   return (
     <>
       <div
@@ -64,10 +65,10 @@ export const Tooltip = (props: Props) => {
         {children}
       </div>
       {state.isOpen &&
-        (portalContainer ? (
-          // Render tooltip inside customized portal,
-          // Mainly used in when render in modal, the overlayContainer becomes inert and breaks hover
-          createPortal(overlayContent, portalContainer)
+        (modalContainer ? (
+          // Render tooltip inside modal if exists.
+          // Otherwise OverlayContainer becomes inert and breaks hover event listener: INS-1930
+          createPortal(overlayContent, modalContainer)
         ) : (
           <OverlayContainer>{overlayContent}</OverlayContainer>
         ))}

--- a/packages/insomnia/src/ui/components/tooltip.tsx
+++ b/packages/insomnia/src/ui/components/tooltip.tsx
@@ -1,6 +1,7 @@
 import classnames from 'classnames';
 import React, { type CSSProperties, type ReactNode } from 'react';
 import { mergeProps, OverlayContainer, useOverlayPosition, useTooltip, useTooltipTrigger } from 'react-aria';
+import { createPortal } from 'react-dom';
 import { useTooltipTriggerState } from 'react-stately';
 
 interface Props {
@@ -13,10 +14,11 @@ interface Props {
   wide?: boolean;
   style?: CSSProperties;
   onClick?: () => void;
+  portalContainer?: HTMLElement | null;
 }
 
 export const Tooltip = (props: Props) => {
-  const { children, message, className, wide, selectable, delay = 400, position, style } = props;
+  const { children, message, className, wide, selectable, delay = 400, position, style, portalContainer } = props;
   const triggerRef = React.useRef(null);
   const overlayRef = React.useRef(null);
 
@@ -39,6 +41,17 @@ export const Tooltip = (props: Props) => {
     selectable,
   });
 
+  const overlayContent = (
+    <div
+      ref={overlayRef}
+      onClick={e => e.stopPropagation()}
+      {...mergeProps(tooltip.tooltipProps, positionProps)}
+      className={bubbleClasses}
+    >
+      {message}
+    </div>
+  );
+
   return (
     <>
       <div
@@ -50,18 +63,13 @@ export const Tooltip = (props: Props) => {
       >
         {children}
       </div>
-      {state.isOpen && (
-        <OverlayContainer>
-          <div
-            ref={overlayRef}
-            onClick={e => e.stopPropagation()}
-            {...mergeProps(tooltip.tooltipProps, positionProps)}
-            className={bubbleClasses}
-          >
-            {message}
-          </div>
-        </OverlayContainer>
-      )}
+      {state.isOpen &&
+        (portalContainer ? (
+          // Render tooltip inside customized portal(used in modal); otherwise the overlay container becomes inert and breaks hover
+          createPortal(overlayContent, portalContainer)
+        ) : (
+          <OverlayContainer>{overlayContent}</OverlayContainer>
+        ))}
     </>
   );
 };


### PR DESCRIPTION
## Background:
When rendering a Tooltip using `OverlayContainer` inside a Modal, the tooltip content disappears on hover and cannot be interacted with.

`OverlayContainer` portals the tooltip to `document.body`. Modal treats everything outside itself as background content and applies `inert` attribute.

Because of inert, the tooltip cannot receive mouse events. Events never fires on the tooltip, causing react-stately to close it immediately after the mouse leaves the trigger.

## Solution
Detect if `Tooltip` in rendered inside React aria Modal. If so, the tooltip will be rendered inside modal rather than `document.body`

[INS-1930](https://konghq.atlassian.net/browse/INS-1930)

[INS-1930]: https://konghq.atlassian.net/browse/INS-1930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ