### PR TITLE
Fix: Environment variable in MCP OAuth settings in not working

### DIFF
--- a/packages/insomnia/src/main/mcp/oauth-client-provider.ts
+++ b/packages/insomnia/src/main/mcp/oauth-client-provider.ts
@@ -63,12 +63,15 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     const newAuthentication = {
       ...mcpRequest.authentication,
       ...auth,
-    } as RequestAuthentication;
+    };
     await models.mcpRequest.update(mcpRequest, {
       authentication: newAuthentication,
     });
     // update local authentication copy
-    this.authentication = newAuthentication;
+    this.authentication = {
+      ...this.authentication,
+      ...auth,
+    } as RequestAuthentication;
   }
   // It's called when auth tries to get client information for authorization, use as a starting point for MCP Auth Flow
   // See: https://github.com/modelcontextprotocol/typescript-sdk/blob/1d475bb3f75674a46d81dba881ea743a763cbc12/src/client/auth.ts#L349
@@ -109,6 +112,7 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     return;
   }
   async saveClientInformation(clientInformation: OAuthClientInformationFull) {
+    console.log('saveClientInformation called with', clientInformation);
     const parsedClientInformation = OAuthClientInformationSchema.parse(clientInformation);
     await this.updateAuthentication({
       clientId: parsedClientInformation.client_id,

--- a/packages/insomnia/src/main/mcp/oauth-client-provider.ts
+++ b/packages/insomnia/src/main/mcp/oauth-client-provider.ts
@@ -60,12 +60,11 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
   private async updateAuthentication(auth: Partial<RequestAuthentication>) {
     const mcpRequest = await models.mcpRequest.getById(this.requestId);
     invariant(mcpRequest, 'MCP Request not found');
-    const newAuthentication = {
-      ...mcpRequest.authentication,
-      ...auth,
-    };
     await models.mcpRequest.update(mcpRequest, {
-      authentication: newAuthentication,
+      authentication: {
+        ...mcpRequest.authentication,
+        ...auth,
+      },
     });
     // update local authentication copy
     this.authentication = {
@@ -112,7 +111,6 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     return;
   }
   async saveClientInformation(clientInformation: OAuthClientInformationFull) {
-    console.log('saveClientInformation called with', clientInformation);
     const parsedClientInformation = OAuthClientInformationSchema.parse(clientInformation);
     await this.updateAuthentication({
       clientId: parsedClientInformation.client_id,

--- a/packages/insomnia/src/main/mcp/oauth-client-provider.ts
+++ b/packages/insomnia/src/main/mcp/oauth-client-provider.ts
@@ -11,7 +11,6 @@ import { getOauthRedirectUrl } from '~/common/constants';
 import { authorizeUserInDefaultBrowser } from '~/main/authorize-user-in-default-browser';
 import type { ConnectionContext } from '~/main/mcp/common';
 import * as models from '~/models';
-import type { McpRequest } from '~/models/mcp-request';
 import type { RequestAuthentication } from '~/models/request';
 import { encryptOAuthUrl } from '~/network/o-auth-2/utils';
 import { invariant } from '~/utils/invariant';
@@ -32,7 +31,9 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
   private _resourceMetadataUrl?: URL;
   private _redirectEndListener: ((authorizationCode: string) => void) | null = null;
   constructor(
-    private mcpRequest: McpRequest,
+    private requestId: string,
+    // Use rendered authentication value from connection options: INS-1942
+    private authentication: RequestAuthentication,
     private context: ConnectionContext,
   ) {}
   get redirectUrl() {
@@ -46,26 +47,28 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
       response_types: ['code'],
       client_name: 'Insomnia MCP Client',
       client_uri: 'https://github.com/Kong/insomnia',
-      scope: 'scope' in this.mcpRequest.authentication ? this.mcpRequest.authentication.scope : undefined,
+      scope: 'scope' in this.authentication ? this.authentication.scope : undefined,
     };
   }
-  private async refreshMcpRequest() {
-    const _mcpRequest = await models.mcpRequest.getById(this.mcpRequest._id);
-    invariant(_mcpRequest, 'MCP Request not found');
-    this.mcpRequest = _mcpRequest;
-  }
   private isUsingMcpAuthFlow() {
-    const { authentication } = this.mcpRequest;
-    return 'grantType' in authentication && authentication.grantType === 'mcp_auth_flow' && !authentication.disabled;
+    return (
+      'grantType' in this.authentication &&
+      this.authentication.grantType === 'mcp_auth_flow' &&
+      !this.authentication.disabled
+    );
   }
   private async updateAuthentication(auth: Partial<RequestAuthentication>) {
-    await models.mcpRequest.update(this.mcpRequest, {
-      authentication: {
-        ...this.mcpRequest.authentication,
-        ...auth,
-      },
+    const mcpRequest = await models.mcpRequest.getById(this.requestId);
+    invariant(mcpRequest, 'MCP Request not found');
+    const newAuthentication = {
+      ...mcpRequest.authentication,
+      ...auth,
+    } as RequestAuthentication;
+    await models.mcpRequest.update(mcpRequest, {
+      authentication: newAuthentication,
     });
-    await this.refreshMcpRequest();
+    // update local authentication copy
+    this.authentication = newAuthentication;
   }
   // It's called when auth tries to get client information for authorization, use as a starting point for MCP Auth Flow
   // See: https://github.com/modelcontextprotocol/typescript-sdk/blob/1d475bb3f75674a46d81dba881ea743a763cbc12/src/client/auth.ts#L349
@@ -90,9 +93,8 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
         });
       });
     }
-
-    if ('clientId' in this.mcpRequest.authentication && this.mcpRequest.authentication.clientId) {
-      const { clientId, clientSecret, clientIdIssuedAt, clientSecretExpiresAt } = this.mcpRequest.authentication;
+    if ('clientId' in this.authentication && this.authentication.clientId) {
+      const { clientId, clientSecret, clientIdIssuedAt, clientSecretExpiresAt } = this.authentication;
 
       // https://github.com/modelcontextprotocol/typescript-sdk/blob/6b4d99f10b975d65392bb777cc8cb1151c20c972/packages/client/src/client/auth.ts#L223%20
       // Set client_secret to undefined if it's not set or empty string
@@ -108,55 +110,46 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
   }
   async saveClientInformation(clientInformation: OAuthClientInformationFull) {
     const parsedClientInformation = OAuthClientInformationSchema.parse(clientInformation);
-    await models.mcpRequest.update(this.mcpRequest, {
-      authentication: {
-        ...this.mcpRequest.authentication,
-        clientId: parsedClientInformation.client_id,
-        clientSecret: parsedClientInformation.client_secret,
-        clientIdIssuedAt: parsedClientInformation.client_id_issued_at,
-        clientSecretExpiresAt: parsedClientInformation.client_secret_expires_at,
-      },
+    await this.updateAuthentication({
+      clientId: parsedClientInformation.client_id,
+      clientSecret: parsedClientInformation.client_secret,
+      clientIdIssuedAt: parsedClientInformation.client_id_issued_at,
+      clientSecretExpiresAt: parsedClientInformation.client_secret_expires_at,
     });
-    await this.refreshMcpRequest();
   }
   async tokens(): Promise<OAuthTokens | undefined> {
-    const { authentication } = this.mcpRequest;
     // Don't return tokens if not using MCP Auth Flow or if disabled
     if (this.isUsingMcpAuthFlow()) {
-      const token = await models.oAuth2Token.getOrCreateByParentId(this.mcpRequest._id);
+      const token = await models.oAuth2Token.getOrCreateByParentId(this.requestId);
       if (token.accessToken) {
         return {
           access_token: token.accessToken,
           refresh_token: token.refreshToken,
           id_token: token.identityToken,
           expires_in: token.expiresAt ? Math.floor(token.expiresAt / 1000) : undefined,
-          token_type: ('tokenPrefix' in authentication && authentication.tokenPrefix) || 'Bearer',
+          token_type: ('tokenPrefix' in this.authentication && this.authentication.tokenPrefix) || 'Bearer',
         };
       }
     }
     return undefined;
   }
   async saveTokens(tokens: OAuthTokens) {
-    const token = await models.oAuth2Token.getOrCreateByParentId(this.mcpRequest._id);
+    const token = await models.oAuth2Token.getOrCreateByParentId(this.requestId);
     await models.oAuth2Token.update(token, {
       accessToken: tokens.access_token,
       refreshToken: tokens.refresh_token || '',
       identityToken: tokens.id_token || '',
       expiresAt: tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : null,
     });
-    await models.mcpRequest.update(this.mcpRequest, {
-      authentication: {
-        ...this.mcpRequest.authentication,
-        scope: tokens.scope,
-        tokenPrefix: tokens.token_type,
-      },
+    await this.updateAuthentication({
+      tokenPrefix: tokens.token_type,
+      scope: tokens.scope,
     });
-    await this.refreshMcpRequest();
   }
   // add state parameter to authorization url if present in authentication
   async state() {
-    if ('state' in this.mcpRequest.authentication && this.mcpRequest.authentication.state) {
-      return this.mcpRequest.authentication.state;
+    if ('state' in this.authentication && this.authentication.state) {
+      return this.authentication.state;
     }
     return '';
   }

--- a/packages/insomnia/src/main/mcp/oauth-client-provider.ts
+++ b/packages/insomnia/src/main/mcp/oauth-client-provider.ts
@@ -143,7 +143,6 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     });
     await this.updateAuthentication({
       tokenPrefix: tokens.token_type,
-      scope: tokens.scope,
     });
   }
   // add state parameter to authorization url if present in authentication

--- a/packages/insomnia/src/main/mcp/oauth-client-provider.ts
+++ b/packages/insomnia/src/main/mcp/oauth-client-provider.ts
@@ -30,12 +30,18 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
   private _codeVerifier?: string;
   private _resourceMetadataUrl?: URL;
   private _redirectEndListener: ((authorizationCode: string) => void) | null = null;
-  constructor(
-    private requestId: string,
-    // Use rendered authentication value from connection options: INS-1942
-    private authentication: RequestAuthentication,
-    private context: ConnectionContext,
-  ) {}
+  private context: ConnectionContext;
+  private authentication: RequestAuthentication;
+  constructor(context: ConnectionContext) {
+    this.context = context;
+    const { options } = context;
+    if ('authentication' in options) {
+      // clone the origin authentication
+      this.authentication = { ...options.authentication };
+    } else {
+      throw new Error('McpOAuthClientProvider requires request authentication in context');
+    }
+  }
   get redirectUrl() {
     return getOauthRedirectUrl();
   }
@@ -58,7 +64,7 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     );
   }
   private async updateAuthentication(auth: Partial<RequestAuthentication>) {
-    const mcpRequest = await models.mcpRequest.getById(this.requestId);
+    const mcpRequest = await models.mcpRequest.getById(this.context.requestId);
     invariant(mcpRequest, 'MCP Request not found');
     await models.mcpRequest.update(mcpRequest, {
       authentication: {
@@ -122,7 +128,7 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
   async tokens(): Promise<OAuthTokens | undefined> {
     // Don't return tokens if not using MCP Auth Flow or if disabled
     if (this.isUsingMcpAuthFlow()) {
-      const token = await models.oAuth2Token.getOrCreateByParentId(this.requestId);
+      const token = await models.oAuth2Token.getOrCreateByParentId(this.context.requestId);
       if (token.accessToken) {
         return {
           access_token: token.accessToken,
@@ -136,7 +142,7 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     return undefined;
   }
   async saveTokens(tokens: OAuthTokens) {
-    const token = await models.oAuth2Token.getOrCreateByParentId(this.requestId);
+    const token = await models.oAuth2Token.getOrCreateByParentId(this.context.requestId);
     await models.oAuth2Token.update(token, {
       accessToken: tokens.access_token,
       refreshToken: tokens.refresh_token || '',

--- a/packages/insomnia/src/main/mcp/transport-streamable-http.ts
+++ b/packages/insomnia/src/main/mcp/transport-streamable-http.ts
@@ -46,7 +46,7 @@ export const createStreamableHTTPTransport = async (
     requestInit: {
       headers: lowerCasedEnabledHeaders,
     },
-    fetch: (url, init) => wrappedFetch(url, init || {}, context, authProvider),
+    fetch: (url, init) => wrappedFetch(url, init || {}, context, options, authProvider),
     reconnectionOptions: {
       maxReconnectionDelay: 30_000,
       initialReconnectionDelay: 1000,
@@ -80,6 +80,7 @@ const wrappedFetch = async (
   url: string | URL,
   init: RequestInit,
   context: ConnectionContext,
+  connectionOptions: OpenMcpHTTPClientConnectionOptions,
   authProvider: McpOAuthClientProvider,
   calledByAuth?: boolean,
 ) => {
@@ -146,9 +147,8 @@ const wrappedFetch = async (
   // DELETE method is used to terminate the MCP request, it should not trigger auth flow to keep consistent with the SDK behavior.
   // See: https://github.com/modelcontextprotocol/typescript-sdk/blob/058b87c163996b31d5cda744085ecf3c13c5c56a/src/client/streamableHttp.ts#L529-L537
   if (!calledByAuth && statusCode === 401 && method !== 'DELETE') {
-    const mcpRequest = await models.mcpRequest.getById(requestId);
-    invariant(mcpRequest, 'MCP Request not found');
-    const { authentication } = mcpRequest;
+    // use authentication from connection options rather than from db directly to get rendered values
+    const { authentication } = connectionOptions;
     // By default no authentication is set, authentication is an empty object. Proceed to oauth workflow.
     const isDefaultAuth = !('type' in authentication);
     // Continue to oauth workflow only when the auth type is mcp oauth and enable it.
@@ -279,7 +279,7 @@ const wrappedFetch = async (
       // cleanup the oauth client provider listener
       unsubscribe();
     }
-    return await wrappedFetch(url, init, context, authProvider, true);
+    return await wrappedFetch(url, init, context, connectionOptions, authProvider, true);
   }
   return response;
 };

--- a/packages/insomnia/src/main/mcp/transport-streamable-http.ts
+++ b/packages/insomnia/src/main/mcp/transport-streamable-http.ts
@@ -16,7 +16,6 @@ import * as models from '~/models';
 import { TRANSPORT_TYPES } from '~/models/mcp-request';
 import type { McpResponse } from '~/models/mcp-response';
 import type { RequestHeader } from '~/models/request';
-import { invariant } from '~/utils/invariant';
 
 // Extend undici RequestInit to include dispatcher, it's in node.js fetch but not in dom fetch.
 interface NodeRequestInit extends RequestInit {

--- a/packages/insomnia/src/main/mcp/transport-streamable-http.ts
+++ b/packages/insomnia/src/main/mcp/transport-streamable-http.ts
@@ -45,7 +45,7 @@ export const createStreamableHTTPTransport = async (
     requestInit: {
       headers: lowerCasedEnabledHeaders,
     },
-    fetch: (url, init) => wrappedFetch(url, init || {}, context, options, authProvider),
+    fetch: (url, init) => wrappedFetch(url, init || {}, context, authProvider),
     reconnectionOptions: {
       maxReconnectionDelay: 30_000,
       initialReconnectionDelay: 1000,
@@ -79,11 +79,10 @@ const wrappedFetch = async (
   url: string | URL,
   init: RequestInit,
   context: ConnectionContext,
-  connectionOptions: OpenMcpHTTPClientConnectionOptions,
   authProvider: McpOAuthClientProvider,
   calledByAuth?: boolean,
 ) => {
-  const { requestId, responseId, environmentId, timelinePath, eventLogPath } = context;
+  const { requestId, responseId, environmentId, timelinePath, eventLogPath, options } = context;
   const { method = 'GET' } = init;
 
   const reqHeader = new Headers(init?.headers || {});
@@ -146,8 +145,8 @@ const wrappedFetch = async (
   // DELETE method is used to terminate the MCP request, it should not trigger auth flow to keep consistent with the SDK behavior.
   // See: https://github.com/modelcontextprotocol/typescript-sdk/blob/058b87c163996b31d5cda744085ecf3c13c5c56a/src/client/streamableHttp.ts#L529-L537
   if (!calledByAuth && statusCode === 401 && method !== 'DELETE') {
+    const { authentication } = options as OpenMcpHTTPClientConnectionOptions;
     // use authentication from connection options rather than from db directly to get rendered values
-    const { authentication } = connectionOptions;
     // By default no authentication is set, authentication is an empty object. Proceed to oauth workflow.
     const isDefaultAuth = !('type' in authentication);
     // Continue to oauth workflow only when the auth type is mcp oauth and enable it.
@@ -278,7 +277,7 @@ const wrappedFetch = async (
       // cleanup the oauth client provider listener
       unsubscribe();
     }
-    return await wrappedFetch(url, init, context, connectionOptions, authProvider, true);
+    return await wrappedFetch(url, init, context, authProvider, true);
   }
   return response;
 };

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -239,10 +239,12 @@ const createTransportAndConnect = async (context: ConnectionContext, mcpClient: 
     wrapTransport();
     await mcpClient.connect(transport);
   } else {
-    const mcpRequest = await models.mcpRequest.getById(connectionOptions.requestId);
-    invariant(mcpRequest, 'MCP Request not found');
-
-    const authProvider = new McpOAuthClientProvider(mcpRequest, context);
+    const authProvider = new McpOAuthClientProvider(
+      connectionOptions.requestId,
+      // deep clone the origin authentication
+      { ...connectionOptions.authentication },
+      context,
+    );
     transport = await createStreamableHTTPTransport(context, connectionOptions, authProvider);
     wrapTransport();
     // Use a longer timeout for initial connection to allow for auth flow to complete

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -239,12 +239,7 @@ const createTransportAndConnect = async (context: ConnectionContext, mcpClient: 
     wrapTransport();
     await mcpClient.connect(transport);
   } else {
-    const authProvider = new McpOAuthClientProvider(
-      connectionOptions.requestId,
-      // Clone the origin authentication object
-      { ...connectionOptions.authentication },
-      context,
-    );
+    const authProvider = new McpOAuthClientProvider(context);
     transport = await createStreamableHTTPTransport(context, connectionOptions, authProvider);
     wrapTransport();
     // Use a longer timeout for initial connection to allow for auth flow to complete

--- a/packages/insomnia/src/main/network/mcp.ts
+++ b/packages/insomnia/src/main/network/mcp.ts
@@ -241,7 +241,7 @@ const createTransportAndConnect = async (context: ConnectionContext, mcpClient: 
   } else {
     const authProvider = new McpOAuthClientProvider(
       connectionOptions.requestId,
-      // deep clone the origin authentication
+      // Clone the origin authentication object
       { ...connectionOptions.authentication },
       context,
     );


### PR DESCRIPTION
## Background
When using environment variables in MCP OAuth settings, the setting values are not rendered

## Changes
- Using the rendered authentication value in OAuth client provider rather than read the value from database
- Fix a minor issue that token scope will override user's scope setting

[INS-1942](https://konghq.atlassian.net/browse/INS-1942)

[INS-1942]: https://konghq.atlassian.net/browse/INS-1942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ