### PR TITLE
fix: plugin install failed due to mixed usage of runtime api

### DIFF
--- a/packages/insomnia/src/__tests__/install-plugin.test.ts
+++ b/packages/insomnia/src/__tests__/install-plugin.test.ts
@@ -71,6 +71,13 @@ vi.mock('../main/install-plugin', async () => {
   };
 });
 
+vi.mock('../main/analytics', () => ({
+  trackSegmentEvent: vi.fn(),
+  SegmentEvent: {
+    installPlugin: 'Plugin Installed',
+  },
+}));
+
 import installPlugin, {
   buildProxyEnv,
   containsOnlyDeprecationWarnings,

--- a/packages/insomnia/src/main/analytics.ts
+++ b/packages/insomnia/src/main/analytics.ts
@@ -70,6 +70,7 @@ export enum SegmentEvent {
   // TODO(INS-1912): Remove in 12.5
   tempOrganizationOpened = 'temp_organization_opened',
   tempProjectOpened = 'temp_project_opened',
+  installPlugin = 'Plugin Installed',
 }
 
 function hashString(input: string) {

--- a/packages/insomnia/src/main/install-plugin.ts
+++ b/packages/insomnia/src/main/install-plugin.ts
@@ -6,7 +6,7 @@ import { promisify } from 'node:util';
 
 import { app, net } from 'electron';
 
-import { SegmentEvent } from '~/ui/analytics';
+import { SegmentEvent, trackSegmentEvent } from '~/main/analytics';
 
 import { isDevelopment } from '../common/constants';
 import * as models from '../models';
@@ -157,12 +157,9 @@ export default async function installPlugin(pluginName: string, allowScopedPacka
         }),
     );
 
-    window.main.trackSegmentEvent({
-      event: SegmentEvent.installPlugin,
-      properties: {
-        pluginName: moduleName,
-        pluginVersion: info.version,
-      },
+    trackSegmentEvent(SegmentEvent.installPlugin, {
+      pluginName: moduleName,
+      pluginVersion: info.version,
     });
   } catch (err) {
     // Log and rethrow any installation errors

--- a/packages/insomnia/src/ui/analytics.ts
+++ b/packages/insomnia/src/ui/analytics.ts
@@ -65,7 +65,6 @@ export enum SegmentEvent {
   responseToMockClicked = 'Response To Mock Clicked',
   gitSyncButtonClicked = 'Git Sync Button Clicked',
   preferencesViewed = 'Preferences Viewed',
-  installPlugin = 'Plugin Installed',
   copyAsCurl = 'Copied As cURL',
   themeChanged = 'Theme Changed',
   generateCodeClicked = 'Generate Code Clicked',


### PR DESCRIPTION
## Background

`window` only exists in renderer, in the main process, we should use the `trackSegmentEvent` from `~/main/analytics`. 
It causes the plugin install throws an error, but actually the installation is successful.

[INS-1950](https://konghq.atlassian.net/browse/INS-1950)

Introduced by #9464

## Changes

Replace the `window.main.trackSegmentEvent` with `trackSegmentEvent` from `~/main/analytics`

[INS-1950]: https://konghq.atlassian.net/browse/INS-1950?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ