### PR TITLE
Chore: Adding eslint rule to avoid using window and document in main process related code

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -237,14 +237,6 @@ export default defineConfig([
           name: 'document',
           message: '"document" is not available in main process.',
         },
-        {
-          name: 'navigator',
-          message: '"navigator" is not available in main process.',
-        },
-        {
-          name: 'localStorage',
-          message: '"localStorage" is not available in main process.',
-        },
       ],
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -222,4 +222,30 @@ export default defineConfig([
       '**/.react-router/*',
     ],
   },
+  // Main process ESLint rules
+  {
+    files: ['packages/insomnia/src/main/**/*.{ts,tsx,js,mjs}'],
+    rules: {
+      'no-restricted-globals': [
+        'error',
+        // block usage of browser globals in main process code
+        {
+          name: 'window',
+          message: '"window" is not available in main process.',
+        },
+        {
+          name: 'document',
+          message: '"document" is not available in main process.',
+        },
+        {
+          name: 'navigator',
+          message: '"navigator" is not available in main process.',
+        },
+        {
+          name: 'localStorage',
+          message: '"localStorage" is not available in main process.',
+        },
+      ],
+    },
+  },
 ]);

--- a/packages/insomnia/src/main/secure-read-file.ts
+++ b/packages/insomnia/src/main/secure-read-file.ts
@@ -16,8 +16,7 @@ export const isPathAllowed = (filePath: string, userAllowList: string[]) => {
 };
 const securePath = (filePath: string) => path.resolve(decodeURIComponent(filePath));
 const getSecuredFolderAllowList = (userAllowList: string[]) => {
-  const userDataPath = process.type === 'renderer' ? window.app.getPath('userData') : electron.app.getPath('userData');
-  const userdataDirectory = process.env.INSOMNIA_DATA_PATH || userDataPath;
+  const userdataDirectory = process.env.INSOMNIA_DATA_PATH || electron.app.getPath('userData');
   // we use tmpdir for buildMultipart
   // we put the db in userData
   // the user can also specifiy other folders

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -610,6 +610,7 @@ export function createWindow(): ElectronBrowserWindow {
       },
       {
         label: `R${MNEMONIC_SYM}estart`,
+        // eslint-disable-next-line no-restricted-globals
         click: window?.main.restart,
       },
       {

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -610,8 +610,10 @@ export function createWindow(): ElectronBrowserWindow {
       },
       {
         label: `R${MNEMONIC_SYM}estart`,
-        // eslint-disable-next-line no-restricted-globals
-        click: window?.main.restart,
+        click: () => {
+          app.relaunch();
+          app.exit();
+        },
       },
       {
         label: `Set window for ${MNEMONIC_SYM}FHD Screenshot`,

--- a/packages/insomnia/src/templating/base-extension.ts
+++ b/packages/insomnia/src/templating/base-extension.ts
@@ -8,7 +8,6 @@ import { jarFromCookies } from '~/common/cookies';
 import { getBodyBuffer } from '~/models/helpers/response-operations';
 
 import { database as db } from '../common/database';
-import { secureReadFile } from '../main/secure-read-file';
 import * as models from '../models/index';
 import type { Request } from '../models/request';
 import type { RequestGroup } from '../models/request-group';
@@ -123,7 +122,7 @@ export default class BaseExtension {
           };
         },
         readFile: async (path: string) => {
-          return secureReadFile(path);
+          return window.main.secureReadFile({ path });
         },
         decode: async (buffer: Buffer, encoding = 'utf8') => iconv.decode(buffer, encoding),
         encode: async (input: string, encoding: BinaryToTextEncoding) =>

--- a/packages/insomnia/src/templating/base-extension.ts
+++ b/packages/insomnia/src/templating/base-extension.ts
@@ -121,9 +121,7 @@ export default class BaseExtension {
             userInfo: os.userInfo(),
           };
         },
-        readFile: async (path: string) => {
-          return window.main.secureReadFile({ path });
-        },
+        readFile: async (path: string) => window.main.secureReadFile({ path }),
         decode: async (buffer: Buffer, encoding = 'utf8') => iconv.decode(buffer, encoding),
         encode: async (input: string, encoding: BinaryToTextEncoding) =>
           crypto.createHash('md5').update(input).digest(encoding),


### PR DESCRIPTION
**Changes**
- New eslint rule to throw error when using `window` and `document` global object in main process code
- Fix existing usage of `window` object in main process code