### PR TITLE
Fix: MCP workspace sync issue

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
@@ -138,6 +138,26 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
       await models.apiSpec.getOrCreateForParentId(workspace._id);
     }
 
+    if (workspaceData.scope === 'mcp') {
+      const settings = await models.settings.getOrCreate();
+      const defaultHeaders = settings.disableAppVersionUserAgent
+        ? []
+        : [{ name: 'User-Agent', value: `insomnia/${getAppVersion()}` }];
+      // Create mcp request when MCP workspace is created
+      await models.mcpRequest.create({
+        parentId: workspace._id,
+        transportType: 'streamable-http',
+        url: '',
+        name: 'MCP Client',
+        headers: defaultHeaders,
+        description: '',
+      });
+
+      window.main.trackSegmentEvent({
+        event: SegmentEvent.mcpClientAdded,
+      });
+    }
+
     // Create default env, cookie jar, and meta
     await models.environment.getOrCreateForParentId(workspace._id);
     await models.cookieJar.getOrCreateForParentId(workspace._id);
@@ -206,36 +226,6 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
           projectId,
           workspaceId: workspace._id,
           requestId: activeRequestId,
-        }),
-      );
-    }
-
-    if (workspaceData.scope === 'mcp') {
-      const settings = await models.settings.getOrCreate();
-      const defaultHeaders = settings.disableAppVersionUserAgent
-        ? []
-        : [{ name: 'User-Agent', value: `insomnia/${getAppVersion()}` }];
-      // Create mcp request when MCP workspace is created
-      const newMcpRequest = await models.mcpRequest.create({
-        parentId: workspace._id,
-        transportType: 'streamable-http',
-        url: '',
-        name: 'MCP Client',
-        headers: defaultHeaders,
-        description: '',
-      });
-      const requestId = newMcpRequest._id;
-
-      window.main.trackSegmentEvent({
-        event: SegmentEvent.mcpClientAdded,
-      });
-
-      return redirect(
-        href('/organization/:organizationId/project/:projectId/workspace/:workspaceId/debug/request/:requestId', {
-          organizationId,
-          projectId,
-          workspaceId: workspace._id,
-          requestId,
         }),
       );
     }


### PR DESCRIPTION
# Changes
Fix an issue that when creating MCP working, the MCP request under workspace has not beed committed during initial snapshot.
Exception will throw when sync MCP workspace without the MCP request.

Adjust the logic to create MCP request before initialize cloud sync initial snapshot

[INS-1972](https://konghq.atlassian.net/browse/INS-1972)

[INS-1972]: https://konghq.atlassian.net/browse/INS-1972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ