### PR TITLE
feat: support deeplink curl import

### DIFF
--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -30,6 +30,7 @@ import { useDefaultBrowserRedirectActionFetcher } from '~/routes/auth.default-br
 import { useLogoutFetcher } from '~/routes/auth.logout';
 import { useCreateCloudCredentialActionFetcher } from '~/routes/cloud-credentials.create';
 import { useGitProviderCompleteSignInFetcher } from '~/routes/git-credentials.complete-sign-in';
+import type { SourceType } from '~/routes/import.scan';
 import { SegmentEvent } from '~/ui/analytics';
 import { getLoginUrl } from '~/ui/auth-session-provider.client';
 import { CopyButton } from '~/ui/components/base/copy-button';
@@ -302,7 +303,10 @@ const Root = () => {
     projectId: string;
   };
 
-  const [importUri, setImportUri] = useState('');
+  const [importObject, setImportObject] = useState({ type: 'clipboard', defaultValue: '' } as {
+    type: SourceType;
+    defaultValue: string;
+  });
   const { submit: createCloudCredentials } = useCreateCloudCredentialActionFetcher();
   const { submit: authorizeSubmit } = useAuthorizeActionFetcher();
   const { submit: logoutSubmit } = useLogoutFetcher();
@@ -346,8 +350,12 @@ const Root = () => {
             source: 'import-url',
           },
         });
-
-        return setImportUri(params.uri);
+        if (params.uri) {
+          return setImportObject({ type: 'uri', defaultValue: params.uri });
+        }
+        if (params.curl) {
+          return setImportObject({ type: 'curl', defaultValue: params.curl });
+        }
       }
       if (urlWithoutParams === 'insomnia://plugins/install') {
         if (!params.name || params.name.trim() === '') {
@@ -557,13 +565,13 @@ const Root = () => {
       <Modals />
       <AppHooks />
       {/* triggered by insomnia://app/import */}
-      {importUri && (
+      {importObject.defaultValue && (
         <ImportModal
-          onHide={() => setImportUri('')}
+          onHide={() => setImportObject({ type: 'clipboard', defaultValue: '' })}
           projectName="Insomnia"
           defaultProjectId={projectId}
           organizationId={organizationId}
-          from={{ type: 'uri', defaultValue: importUri }}
+          from={importObject}
         />
       )}
     </>

--- a/packages/insomnia/src/routes/import.scan.tsx
+++ b/packages/insomnia/src/routes/import.scan.tsx
@@ -9,18 +9,19 @@ import { SegmentEvent } from '~/ui/analytics';
 import { invariant } from '~/utils/invariant';
 import { createFetcherSubmitHook } from '~/utils/router';
 
-type SourceType = 'file' | 'uri' | 'clipboard';
+export type SourceType = 'file' | 'uri' | 'curl' | 'clipboard';
 
 export const scanImportResources = async (data: {
   source: SourceType;
   uri?: string;
+  curl?: string;
   filePaths?: string | string[];
   postmanArchiveFile?: string | null;
 }): Promise<ScanResult[]> => {
   const { source, postmanArchiveFile } = data;
 
   invariant(typeof source === 'string', 'Source is required.');
-  invariant(['file', 'uri', 'clipboard'].includes(source), 'Unsupported import type');
+  invariant(['file', 'uri', 'curl', 'clipboard'].includes(source), 'Unsupported import type');
 
   window.main.trackSegmentEvent({
     event: SegmentEvent.importScanned,
@@ -39,6 +40,20 @@ export const scanImportResources = async (data: {
       contentStr: await fetchImportContentFromURI({ uri }),
       oriFileName: uri,
     });
+  } else if (source === 'curl') {
+    const { curl } = data;
+    invariant(typeof curl === 'string' && curl.length, 'cURL command is required');
+    contentList.push({
+      contentStr: curl,
+    });
+    // const { data } = await window.main.parseImport(
+    //   {
+    //     contentStr: curl || '',
+    //   },
+    //   {
+    //     importerId: 'curl',
+    //   },
+    // );
   } else if (source === 'file') {
     let filePaths: string[];
     try {

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -16,7 +16,7 @@ import { ModalHeader } from '../../base/modal-header';
 import { HelpTooltip } from '../../help-tooltip';
 import { Icon } from '../../icon';
 import { Button } from '../../themed-button';
-import { disclaimer, ScanResultsTable, SupportedFormats, validImportExtensions } from './shared';
+import { CurlIcon, disclaimer, ScanResultsTable, SupportedFormats, validImportExtensions } from './shared';
 
 export const Radio: FC<{
   name: string;
@@ -176,6 +176,10 @@ interface ImportModalProps extends ModalProps {
       }
     | {
         type: 'uri';
+        defaultValue?: string;
+      }
+    | {
+        type: 'curl';
         defaultValue?: string;
       }
     | {
@@ -339,6 +343,10 @@ const ScanResourcesForm = ({
                 <i className="fa fa-link" />
                 Url
               </Radio>
+              <Radio onChange={() => setImportFrom('curl')} name="source" value="curl" checked={importFrom === 'curl'}>
+                <CurlIcon />
+                cURL
+              </Radio>
               <Radio
                 onChange={() => setImportFrom('clipboard')}
                 name="source"
@@ -360,6 +368,19 @@ const ScanResourcesForm = ({
                   name="uri"
                   defaultValue={from?.type === 'uri' ? from.defaultValue : undefined}
                   placeholder="https://website.com/insomnia-import.json"
+                />
+              </label>
+            </div>
+          )}
+          {importFrom === 'curl' && (
+            <div className="form-control form-control--outlined">
+              <label>
+                cURL:
+                <input
+                  type="text"
+                  name="curl"
+                  defaultValue={from?.type === 'curl' ? from.defaultValue : undefined}
+                  placeholder="curl --request GET --url http://insomnia.rest/"
                 />
               </label>
             </div>

--- a/packages/insomnia/src/ui/components/modals/import-modal/shared.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/shared.tsx
@@ -90,7 +90,7 @@ const OpenAPIIcon = (props: React.SVGProps<SVGSVGElement>) => {
   );
 };
 
-const CurlIcon = (props: React.SVGProps<SVGSVGElement>) => {
+export const CurlIcon = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg xmlns="http://www.w3.org/2000/svg" width={18} height={18} viewBox="0 0 123.184 102.926" {...props}>
       <defs>


### PR DESCRIPTION
todo

- add curl form
- add types
- change uri default
- test 

works with this link

`insomniadev://app/import?label=adsda&curl=curl --request GET --url http://google.com/ --header 'User-Agent: insomnia/12.2.0'`


<img width="811" height="345" alt="image" src="https://github.com/user-attachments/assets/e0270d44-75d3-436a-9729-bfcbd908b86e" />


future work

- navigate to new request
- use label param to search for existing workspace
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
