### PR TITLE
Fix: Add missing mcp generate sampling response file in build script

### DIFF
--- a/packages/insomnia/scripts/build.ts
+++ b/packages/insomnia/scripts/build.ts
@@ -44,6 +44,7 @@ export const start = async () => {
   await copyFiles('../src/static', path.join(buildFolder, 'static'));
   await copyFiles('../src/icons', buildFolder);
   await copyFiles('../src/main/lint-process.mjs', path.join(buildFolder, 'main/lint-process.mjs'));
+  // copy utility process scripts
   await copyFiles(
     '../src/main/mock-generation-process.mjs',
     path.join(buildFolder, 'main/mock-generation-process.mjs'),
@@ -51,6 +52,10 @@ export const start = async () => {
   await copyFiles(
     '../src/main/git-commit-generation-process.mjs',
     path.join(buildFolder, 'main/git-commit-generation-process.mjs'),
+  );
+  await copyFiles(
+    '../src/main/mcp-generate-sampling-response.mjs',
+    path.join(buildFolder, 'main/mcp-generate-sampling-response.mjs'),
   );
   await copyFiles('../src/hidden-window.html', path.join(buildFolder, 'hidden-window.html'));
 


### PR DESCRIPTION
Adding the missing `mcp-generate-sampling-response.mjs` file to create utility process in build script