### PR TITLE
feat(git): select commit email from git provider per repo [INS-1474]

### DIFF
--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -143,6 +143,7 @@ const git: GitServiceAPI = {
   initSignInToGitProvider: options => ipcRenderer.invoke('git.initSignInToGitProvider', options),
   completeSignInToGitProvider: options => ipcRenderer.invoke('git.completeSignInToGitProvider', options),
   getGitProviderRepositories: options => ipcRenderer.invoke('git.getGitProviderRepositories', options),
+  getGitProviderEmails: options => ipcRenderer.invoke('git.getGitProviderEmails', options),
   getCurrentBranchByRepositoryId: options => ipcRenderer.invoke('git.getCurrentBranchByRepositoryId', options),
 };
 

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -23,7 +23,12 @@ import YAML, { parse } from 'yaml';
 import { type GitRemoteProviderType, isGitCredentialsV2 } from '~/models/git-credentials';
 import { EMPTY_GIT_PROJECT_ID, isEmptyGitProject } from '~/models/project';
 import { GitVCSOperationErrors } from '~/sync/git/git-vcs-operation-errors';
-import { gitRemoteProviderRegistry, initializeGitRemoteProviders, type ProviderRepository } from '~/sync/git/providers';
+import {
+  gitRemoteProviderRegistry,
+  initializeGitRemoteProviders,
+  type ProviderEmail,
+  type ProviderRepository,
+} from '~/sync/git/providers';
 
 import { INSOMNIA_GITLAB_API_URL } from '../common/constants';
 import { database } from '../common/database';
@@ -762,6 +767,7 @@ export const cloneGitRepoAction = async ({
   name,
   uri,
   ref,
+  selectedAuthorEmail,
 }: {
   organizationId: string;
   projectId?: string;
@@ -770,12 +776,16 @@ export const cloneGitRepoAction = async ({
   name?: string;
   uri: string;
   ref?: string;
+  selectedAuthorEmail?: string | null;
 }) => {
   try {
     const repoSettingsPatch: Partial<GitRepository> = {};
     repoSettingsPatch.uri = parseGitToHttpsURL(uri);
 
     repoSettingsPatch.credentialsId = credentialsId;
+    if (selectedAuthorEmail !== undefined) {
+      repoSettingsPatch.selectedAuthorEmail = selectedAuthorEmail;
+    }
 
     let provider = 'custom';
     if (credentialsId) {
@@ -1131,15 +1141,18 @@ export const updateGitRepoAction = async ({
   credentialsId,
   uri,
   ref,
+  selectedAuthorEmail,
 }: {
   projectId: string;
   workspaceId?: string;
   credentialsId: string | null;
   uri: string;
   ref?: string;
+  selectedAuthorEmail?: string | null;
 }) => {
   try {
     let gitRepositoryId: string | null | undefined = null;
+    const gitURI = parseGitToHttpsURL(uri);
 
     if (workspaceId) {
       const workspace = await models.workspace.getById(workspaceId);
@@ -1153,30 +1166,22 @@ export const updateGitRepoAction = async ({
       gitRepositoryId = project.gitRepositoryId;
     }
 
-    const repoSettingsPatch: Partial<GitRepository> = {};
+    let gitRepository: GitRepository | undefined;
 
-    // URI
-    repoSettingsPatch.uri = parseGitToHttpsURL(uri);
-
-    // Git Credentials
-    repoSettingsPatch.credentialsId = credentialsId;
-
-    async function setupGitRepository() {
-      if (gitRepositoryId && gitRepositoryId !== EMPTY_GIT_PROJECT_ID) {
-        const gitRepository = await models.gitRepository.getById(gitRepositoryId);
-        invariant(gitRepository, 'GitRepository not found');
-        await models.gitRepository.update(gitRepository, repoSettingsPatch);
-
-        return gitRepository;
+    if (gitRepositoryId && gitRepositoryId !== EMPTY_GIT_PROJECT_ID) {
+      gitRepository = await models.gitRepository.getById(gitRepositoryId);
+      invariant(gitRepository, 'GitRepository not found');
+    } else {
+      const newRepo: Partial<GitRepository> = {
+        uri: gitURI,
+        credentialsId: credentialsId,
+        needsFullClone: true,
+      };
+      if (selectedAuthorEmail !== undefined) {
+        newRepo.selectedAuthorEmail = selectedAuthorEmail;
       }
-
-      repoSettingsPatch.needsFullClone = true;
-      const gitRepository = await models.gitRepository.create(repoSettingsPatch);
-
-      return gitRepository;
+      gitRepository = await models.gitRepository.create(newRepo);
     }
-
-    const gitRepository = await setupGitRepository();
 
     if (workspaceId) {
       await models.workspaceMeta.updateByParentId(workspaceId, {
@@ -1196,7 +1201,7 @@ export const updateGitRepoAction = async ({
       directory: GIT_CLONE_DIR,
       fs: await getGitFSClient({ projectId, workspaceId, gitRepositoryId: gitRepository._id }),
       gitDirectory: GIT_INTERNAL_DIR,
-      credentialsId: gitRepository.credentialsId,
+      credentialsId: credentialsId,
       legacyDiff: Boolean(workspaceId),
       ref,
     });
@@ -1205,12 +1210,21 @@ export const updateGitRepoAction = async ({
     await GitVCS.addRemote(uri);
 
     const { hasUncommittedChanges } = await getGitChanges();
-    const hasUnpushedChanges = await GitVCS.canPush(gitRepository.credentialsId);
+    const hasUnpushedChanges = await GitVCS.canPush(credentialsId);
 
-    await models.gitRepository.update(gitRepository, {
+    const updatePatch: Partial<GitRepository> = {
+      uri: gitURI,
+      credentialsId: credentialsId,
       hasUncommittedChanges,
       hasUnpushedChanges,
-    });
+    };
+
+    if (selectedAuthorEmail !== undefined) {
+      updatePatch.selectedAuthorEmail = selectedAuthorEmail;
+    }
+
+    await models.gitRepository.update(gitRepository, updatePatch);
+    await database.flushChanges();
 
     return null;
   } catch (e) {
@@ -1262,6 +1276,7 @@ export const commitToGitRepoAction = async ({
 }): Promise<CommitToGitRepoResult> => {
   try {
     const gitRepository = await getGitRepository({ workspaceId, projectId });
+    await GitVCS.setAuthor();
     await GitVCS.commit(message);
 
     let providerName = 'custom';
@@ -1306,6 +1321,7 @@ export const multipleCommitToGitRepoAction = async ({
   }[];
 }) => {
   await getGitRepository({ projectId, workspaceId });
+  await GitVCS.setAuthor();
 
   for (const commit of commits) {
     // Get current git status
@@ -1374,6 +1390,7 @@ export const commitAndPushToGitRepoAction = async ({
 }): Promise<CommitToGitRepoResult> => {
   const repo = await getGitRepository({ workspaceId, projectId });
   try {
+    await GitVCS.setAuthor();
     await GitVCS.commit(message);
 
     let providerName = 'custom';
@@ -2381,6 +2398,41 @@ async function getGitProviderRepositories({
   }
 }
 
+async function getGitProviderEmails({ credentialsId }: { credentialsId: string }): Promise<{
+  emails: ProviderEmail[];
+  errors: string[];
+}> {
+  try {
+    const credentials = await models.gitCredentials.getById(credentialsId);
+    invariant(credentials, 'Git credentials not found');
+    invariant(isGitCredentialsV2(credentials), 'Invalid Git credentials');
+
+    const provider = gitRemoteProviderRegistry.get(credentials.provider);
+    if (!provider?.supportsFetchEmails || !provider.fetchUserEmails) {
+      return {
+        errors: [`${credentials.provider} provider does not support fetching emails.`],
+        emails: [],
+      };
+    }
+
+    const emails = await provider.fetchUserEmails(credentials);
+
+    if (credentials.credentials) {
+      await models.gitCredentials.update(credentials, {
+        credentials: {
+          ...credentials.credentials,
+          emails,
+        },
+      } as any);
+    }
+
+    return { emails, errors: [] };
+  } catch (error) {
+    const errorMessage = `Failed to fetch emails from Git provider. ${getErrorMessage(error)}`;
+    return { emails: [], errors: [errorMessage] };
+  }
+}
+
 export const getGitLabOauthApiURL = () => INSOMNIA_GITLAB_API_URL || 'https://gitlab.com';
 
 async function getCurrentBranchByRepositoryId({
@@ -2433,6 +2485,7 @@ export interface GitServiceAPI {
   getCurrentBranchByRepositoryId: typeof getCurrentBranchByRepositoryId;
 
   getGitProviderRepositories: typeof getGitProviderRepositories;
+  getGitProviderEmails: typeof getGitProviderEmails;
   listGitProviders: typeof listGitProviders;
 }
 
@@ -2519,6 +2572,9 @@ export const registerGitServiceAPI = () => {
   ipcMainHandle('git.listGitProviders', () => listGitProviders());
   ipcMainHandle('git.getGitProviderRepositories', (_, options: Parameters<typeof getGitProviderRepositories>[0]) =>
     getGitProviderRepositories(options),
+  );
+  ipcMainHandle('git.getGitProviderEmails', (_, options: Parameters<typeof getGitProviderEmails>[0]) =>
+    getGitProviderEmails(options),
   );
   ipcMainHandle(
     'git.getCurrentBranchByRepositoryId',

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -72,6 +72,7 @@ export type HandleChannels =
   | 'git.initSignInToGitProvider'
   | 'git.completeSignInToGitProvider'
   | 'git.getGitProviderRepositories'
+  | 'git.getGitProviderEmails'
   | 'grpc.loadMethods'
   | 'grpc.loadMethodsFromReflection'
   | 'insecureReadFile'

--- a/packages/insomnia/src/models/git-repository.ts
+++ b/packages/insomnia/src/models/git-repository.ts
@@ -21,6 +21,7 @@ export function init(): BaseGitRepository {
     uri: '',
     credentials: null,
     credentialsId: null,
+    selectedAuthorEmail: null,
     author: {
       name: '',
       email: '',
@@ -42,6 +43,11 @@ export interface BaseGitRepository {
    */
   credentials: GitCredentials | null;
   credentialsId: string | null;
+  /**
+   * Optional override for the author email address used for commits
+   * Must be a value from the emails list of the corresponding credential
+   */
+  selectedAuthorEmail: string | null;
   /**
    * @deprecated Use the author in the corresponding credential
    */

--- a/packages/insomnia/src/routes/git-provider.emails.tsx
+++ b/packages/insomnia/src/routes/git-provider.emails.tsx
@@ -1,0 +1,33 @@
+import { href } from 'react-router';
+
+import { createFetcherLoadHook } from '~/utils/router';
+
+import type { Route } from './+types/git-provider.emails';
+
+interface GitProviderEmailsInput {
+  credentialsId: string;
+}
+
+export async function clientLoader({ request }: Route.ClientLoaderArgs) {
+  const url = new URL(request.url);
+  const credentialsId = url.searchParams.get('credentialsId') || '';
+
+  if (!credentialsId) {
+    return { emails: [], errors: ['No credential provided'] };
+  }
+
+  const emailsResult = await window.main.git.getGitProviderEmails({ credentialsId });
+
+  return emailsResult;
+}
+
+export const useGitProviderEmailsLoaderFetcher = createFetcherLoadHook(
+  load =>
+    ({ credentialsId }: GitProviderEmailsInput) => {
+      const params = new URLSearchParams();
+      params.append('credentialsId', credentialsId);
+
+      return load(`${href('/git-provider/emails')}?${params.toString()}`);
+    },
+  clientLoader,
+);

--- a/packages/insomnia/src/routes/git.clone.tsx
+++ b/packages/insomnia/src/routes/git.clone.tsx
@@ -15,6 +15,7 @@ interface CloneGitRepoData {
   };
   credentialsId: string | null;
   ref: string;
+  selectedAuthorEmail?: string | null;
 }
 
 export async function clientAction({ request }: Route.ClientActionArgs) {

--- a/packages/insomnia/src/routes/git.update.tsx
+++ b/packages/insomnia/src/routes/git.update.tsx
@@ -9,6 +9,7 @@ interface UpdateGitRepoData {
   uri: string;
   workspaceId?: string;
   projectId: string;
+  selectedAuthorEmail?: string | null;
 }
 
 export async function clientAction({ request }: Route.ClientActionArgs) {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.update.tsx
@@ -21,6 +21,7 @@ interface UpdateProjectInputData {
   uri?: string;
   ref?: string;
   connectRepositoryLater?: boolean;
+  selectedAuthorEmail?: string | null;
 }
 
 export async function clientAction({ request, params }: Route.ClientActionArgs) {
@@ -259,6 +260,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
           credentialsId: projectData.credentialsId,
           ref: projectData.ref,
           name,
+          selectedAuthorEmail: projectData.selectedAuthorEmail,
         });
 
         const projectWorkspaces = await models.workspace.findByParentId(project._id);
@@ -315,6 +317,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
         uri: projectData.uri ?? '',
         credentialsId: projectData.credentialsId,
         ref: projectData.ref,
+        selectedAuthorEmail: projectData.selectedAuthorEmail,
       });
 
       showToast({
@@ -335,6 +338,29 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
       await models.project.update(project, { name, gitRepositoryId: null });
 
       reportGitProjectCount(organizationId, sessionId);
+
+      showToast({
+        title: 'Project updated',
+        status: 'success',
+      });
+
+      return {
+        success: true,
+      };
+    }
+
+    // update existing git repository settings (author email override)
+    if (storageType === 'git' && gitRepository?.credentialsId) {
+      await window.main.git.updateGitRepo({
+        projectId: project._id,
+        uri: gitRepository.uri,
+        credentialsId: gitRepository.credentialsId,
+        selectedAuthorEmail: projectData.selectedAuthorEmail ?? null,
+      });
+
+      if (name !== project.name) {
+        await models.project.update(project, { name });
+      }
 
       showToast({
         title: 'Project updated',

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.update.tsx
@@ -25,7 +25,12 @@ interface UpdateProjectInputData {
 }
 
 export async function clientAction({ request, params }: Route.ClientActionArgs) {
-  const { name, storageType, ...projectData } = (await request.json()) as UpdateProjectInputData;
+  const {
+    name,
+    storageType,
+    selectedAuthorEmail = null,
+    ...projectData
+  } = (await request.json()) as UpdateProjectInputData;
 
   invariant(typeof name === 'string', 'Name is required');
   invariant(storageType === 'local' || storageType === 'remote' || storageType === 'git', 'Project type is required');
@@ -260,7 +265,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
           credentialsId: projectData.credentialsId,
           ref: projectData.ref,
           name,
-          selectedAuthorEmail: projectData.selectedAuthorEmail,
+          selectedAuthorEmail,
         });
 
         const projectWorkspaces = await models.workspace.findByParentId(project._id);
@@ -317,7 +322,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
         uri: projectData.uri ?? '',
         credentialsId: projectData.credentialsId,
         ref: projectData.ref,
-        selectedAuthorEmail: projectData.selectedAuthorEmail,
+        selectedAuthorEmail,
       });
 
       showToast({
@@ -351,12 +356,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
 
     // update existing git repository settings (author email override)
     if (storageType === 'git' && gitRepository?.credentialsId) {
-      await window.main.git.updateGitRepo({
-        projectId: project._id,
-        uri: gitRepository.uri,
-        credentialsId: gitRepository.credentialsId,
-        selectedAuthorEmail: projectData.selectedAuthorEmail ?? null,
-      });
+      models.gitRepository.update(gitRepository, { selectedAuthorEmail });
 
       if (name !== project.name) {
         await models.project.update(project, { name });

--- a/packages/insomnia/src/routes/organization.$organizationId.project.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.new.tsx
@@ -25,6 +25,7 @@ export interface CreateProjectData {
   credentialsId?: string | null;
   connectRepositoryLater?: boolean;
   ref?: string;
+  selectedAuthorEmail?: string | null;
 }
 
 export const reportGitProjectCount = async (organizationId: string, sessionId: string, maxRetries = 3) => {
@@ -84,6 +85,7 @@ const createProjectImpl = async (organizationId: string, newProjectData: CreateP
       credentialsId: newProjectData.credentialsId,
       name: newProjectData.name,
       ref: newProjectData.ref || '',
+      selectedAuthorEmail: newProjectData.selectedAuthorEmail,
     });
 
     if (errors) {

--- a/packages/insomnia/src/sync/git/providers/github.ts
+++ b/packages/insomnia/src/sync/git/providers/github.ts
@@ -300,6 +300,7 @@ export class GitHubProvider implements GitRemoteProvider<GitHubProviderConfig> {
         name: 'GitHub Credential',
         credentials: {
           token: data.access_token,
+          emails,
         },
         provider: 'github',
         author: {

--- a/packages/insomnia/src/sync/git/providers/gitlab.ts
+++ b/packages/insomnia/src/sync/git/providers/gitlab.ts
@@ -134,8 +134,6 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
   readonly supportsFetchEmails = true;
   readonly supportsAutoRenew = true; // GitLab supports refresh tokens
 
-  private repositoryCache = new Map<string, ProviderRepository[]>();
-
   constructor(config: GitLabProviderConfig) {
     this.config = config;
   }
@@ -169,14 +167,9 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
   /**
    * Fetch projects (repositories) accessible by the credential
    */
-  async fetchRepositories(credential: GitCredentials, refresh?: boolean): Promise<ProviderRepository[]> {
+  async fetchRepositories(credential: GitCredentials): Promise<ProviderRepository[]> {
     if (!isGitCredentialsV2(credential) || credential.provider !== 'gitlab') {
       throw new Error('Invalid credential type for GitLab provider');
-    }
-
-    const cachedRepos = this.repositoryCache.get(credential._id);
-    if (!refresh && cachedRepos && cachedRepos.length > 0) {
-      return cachedRepos;
     }
 
     const repos: ProviderRepository[] = [];
@@ -217,8 +210,6 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
       if (data.length < perPage) break;
       page++;
     }
-
-    this.repositoryCache.set(credential._id, repos);
 
     return repos;
   }
@@ -267,6 +258,7 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
     });
 
     if (!response.ok) {
+      console.error('[gitlab] Failed to fetch gitlab user with token:', response.statusText);
       throw new Error(`GitLab API error: ${response.statusText}`);
     }
 
@@ -284,6 +276,7 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
     });
 
     if (!emailsResponse.ok) {
+      console.error('[gitlab] Failed to fetch gitlab user emails:', emailsResponse.statusText);
       return [
         {
           email: userData.commit_email || userData.email,

--- a/packages/insomnia/src/sync/git/providers/gitlab.ts
+++ b/packages/insomnia/src/sync/git/providers/gitlab.ts
@@ -131,8 +131,10 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
   readonly config: GitLabProviderConfig;
   readonly supportsOAuth = true;
   readonly supportsFetchRepos = false;
-  readonly supportsFetchEmails = false;
+  readonly supportsFetchEmails = true;
   readonly supportsAutoRenew = true; // GitLab supports refresh tokens
+
+  private repositoryCache = new Map<string, ProviderRepository[]>();
 
   constructor(config: GitLabProviderConfig) {
     this.config = config;
@@ -167,9 +169,14 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
   /**
    * Fetch projects (repositories) accessible by the credential
    */
-  async fetchRepositories(credential: GitCredentials): Promise<ProviderRepository[]> {
+  async fetchRepositories(credential: GitCredentials, refresh?: boolean): Promise<ProviderRepository[]> {
     if (!isGitCredentialsV2(credential) || credential.provider !== 'gitlab') {
       throw new Error('Invalid credential type for GitLab provider');
+    }
+
+    const cachedRepos = this.repositoryCache.get(credential._id);
+    if (!refresh && cachedRepos && cachedRepos.length > 0) {
+      return cachedRepos;
     }
 
     const repos: ProviderRepository[] = [];
@@ -211,6 +218,8 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
       page++;
     }
 
+    this.repositoryCache.set(credential._id, repos);
+
     return repos;
   }
 
@@ -222,44 +231,9 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
       throw new Error('Invalid credential type for GitLab provider');
     }
 
-    // Fetch current user to get emails
-    const userResponse = await net.fetch(`${this.config.apiUrl}/user`, {
-      headers: {
-        Authorization: `Bearer ${credential.credentials?.token}`,
-      },
-    });
+    const userData = await this.fetchUserWithToken(credential.credentials?.token);
 
-    if (!userResponse.ok) {
-      throw new Error(`GitLab API error: ${userResponse.statusText}`);
-    }
-
-    const userData = await userResponse.json();
-
-    // Fetch all emails for the user
-    const emailsResponse = await net.fetch(`${this.config.apiUrl}/user/emails`, {
-      headers: {
-        Authorization: `Bearer ${credential.credentials?.token}`,
-      },
-    });
-
-    if (!emailsResponse.ok) {
-      // If emails endpoint fails, return the commit_email from user profile
-      return [
-        {
-          email: userData.commit_email || userData.email,
-          primary: true,
-          verified: true,
-        },
-      ];
-    }
-
-    const emailsData = (await emailsResponse.json()) as GitLabEmailApiResponse[];
-
-    return emailsData.map(email => ({
-      email: email.email,
-      primary: email.email === userData.email,
-      verified: true, // GitLab doesn't provide verified status via API
-    }));
+    return this.fetchEmailsWithToken(credential.credentials?.token, userData);
   }
 
   /**
@@ -284,7 +258,6 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
 
   /**
    * Fetch user info with token directly
-   * Convenience method for OAuth completion
    */
   async fetchUserWithToken(token: string): Promise<GitLabUserApiResponse> {
     const response = await net.fetch(`${this.config.apiUrl}/user`, {
@@ -298,6 +271,35 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
     }
 
     return response.json() as Promise<GitLabUserApiResponse>;
+  }
+
+  /**
+   * Fetch user's email addresses with token directly
+   */
+  async fetchEmailsWithToken(token: string, userData: GitLabUserApiResponse): Promise<ProviderEmail[]> {
+    const emailsResponse = await net.fetch(`${this.config.apiUrl}/user/emails`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    if (!emailsResponse.ok) {
+      return [
+        {
+          email: userData.commit_email || userData.email,
+          primary: true,
+          verified: true,
+        },
+      ];
+    }
+
+    const emailsData = (await emailsResponse.json()) as GitLabEmailApiResponse[];
+
+    return emailsData.map(email => ({
+      email: email.email,
+      primary: email.email === userData.email,
+      verified: true,
+    }));
   }
 
   /**
@@ -387,8 +389,9 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
 
       gitlabStatesCache.delete(state);
 
-      // Fetch user details
+      // Fetch user details and emails
       const user = await this.fetchUserWithToken(access_token);
+      const emails = await this.fetchEmailsWithToken(access_token, user);
 
       // Create or update credential in database
       const credentialData = {
@@ -396,12 +399,13 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
         provider: 'gitlab',
         author: {
           email: user.commit_email ?? user.public_email ?? user.email ?? '',
-          name: user.username ?? user.name ?? '',
+          name: user.name || user.username || '',
           avatarUrl: user.avatar_url,
         },
         credentials: {
           token: access_token,
           refreshToken: refresh_token,
+          emails,
         },
       } satisfies BaseGitCredentialsV2;
 

--- a/packages/insomnia/src/sync/git/providers/registry.ts
+++ b/packages/insomnia/src/sync/git/providers/registry.ts
@@ -65,6 +65,7 @@ export class GitRemoteProviderRegistry {
       iconName: provider.config.iconName,
       supportsOAuth: provider.supportsOAuth,
       supportsFetchRepos: provider.supportsFetchRepos,
+      supportsFetchEmails: provider.supportsFetchEmails,
       supportsAutoRenew: provider.supportsAutoRenew,
     }));
   }

--- a/packages/insomnia/src/sync/git/providers/types.ts
+++ b/packages/insomnia/src/sync/git/providers/types.ts
@@ -188,5 +188,6 @@ export interface GitProviderOption {
   iconName?: IconProp;
   supportsOAuth: boolean;
   supportsFetchRepos: boolean;
+  supportsFetchEmails: boolean;
   supportsAutoRenew: boolean;
 }

--- a/packages/insomnia/src/sync/git/utils.ts
+++ b/packages/insomnia/src/sync/git/utils.ts
@@ -98,7 +98,10 @@ export const getAuthorFromGitRepository = async (gitRepositoryId: string): Promi
     };
   }
 
-  return credentials.author;
+  return {
+    name: credentials.author.name,
+    email: gitRepo.selectedAuthorEmail || credentials.author.email,
+  };
 };
 
 export const gitCallbacks = (credentialsId?: string | null) => {

--- a/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-remote-branch-select.tsx
@@ -74,10 +74,8 @@ export const GitRemoteBranchSelect = ({
         Boolean(fuzzyMatch(inputValue, branch, { splitSpace: true, loose: false })?.indexes)
       }
     >
-      <Label className="flex flex-col pt-0">
-        <span className="text-sm">Branch</span>
-      </Label>
-      <div className="flex w-full items-center gap-2">
+      <Label className="mb-1 pt-0 text-sm">Branch</Label>
+      <div className="flex w-full items-start gap-2">
         <div className="group flex h-(--line-height-xs) flex-1 items-center gap-2 rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) text-(--color-font) transition-colors focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden">
           <Input
             aria-label="Search branches"
@@ -94,7 +92,7 @@ export const GitRemoteBranchSelect = ({
         <button
           type="button"
           disabled={isRefetchButtonDisabled}
-          className="m-2 mr-0 flex aspect-square size-(--line-height-xs) items-center justify-center gap-2 truncate rounded-xs border border-solid border-(--hl-sm) p-2 text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset active:bg-(--hl-sm) disabled:opacity-30"
+          className="flex aspect-square size-(--line-height-xs) items-center justify-center gap-2 truncate rounded-xs border border-solid border-(--hl-sm) p-2 text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset active:bg-(--hl-sm) disabled:opacity-30"
           aria-label="Refresh repositories"
           onClick={() => {
             if (uri && !isLoadingRemoteBranches) {

--- a/packages/insomnia/src/ui/components/git-credentials/git-repository-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-repository-select.tsx
@@ -66,13 +66,9 @@ export const GitRepositorySelect = ({
           Boolean(fuzzyMatch(inputValue, repoName, { splitSpace: true, loose: false })?.indexes)
         }
       >
-        <Label className="flex flex-col">
-          <div className="flex items-center gap-2">
-            <span className="flex-1 text-sm">Repository</span>
-          </div>
-        </Label>
-        <div className="flex w-full items-center gap-2">
-          <div className="group flex h-(--line-height-xs) flex-1 items-center gap-2 rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) text-(--color-font) transition-colors focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden">
+        <Label className="mb-1 pt-0 text-sm">Repository</Label>
+        <div className="flex w-full items-start gap-2">
+          <div className="group flex h-(--line-height-xs) flex-1 items-start gap-2 rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) text-(--color-font) transition-colors focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden">
             <Input
               aria-label="Repository Search"
               placeholder={loading ? 'Fetching...' : 'Find a repository...'}
@@ -90,7 +86,7 @@ export const GitRepositorySelect = ({
           <button
             type="button"
             disabled={loading || !credentialsId}
-            className="m-2 mr-0 flex aspect-square size-(--line-height-xs) items-center justify-center gap-2 truncate rounded-xs border border-solid border-(--hl-sm) p-2 text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset active:bg-(--hl-sm)"
+            className="mr-0 flex aspect-square size-(--line-height-xs) items-center justify-center gap-2 truncate rounded-xs border border-solid border-(--hl-sm) p-2 text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset active:bg-(--hl-sm)"
             aria-label="Refresh repositories"
             onClick={() => {
               if (credentialsId) {

--- a/packages/insomnia/src/ui/components/git-credentials/git-repository-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-repository-select.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Button, ComboBox, FieldError, Input, Label, ListBox, ListBoxItem, Popover } from 'react-aria-components';
 
 import { fuzzyMatch } from '~/common/misc';
@@ -18,13 +18,15 @@ export const GitRepositorySelect = ({
   allConnectedRepoURIProjectNameMap?: Record<string, string> | undefined;
 }) => {
   const getGitProviderRepositoriesFetcher = useGitProviderRepositoriesLoaderFetcher();
+  const lastLoadedCredentialsIdRef = useRef<string | undefined>();
 
   useEffect(() => {
-    if (
-      getGitProviderRepositoriesFetcher.state === 'idle' &&
-      !getGitProviderRepositoriesFetcher.data &&
-      credentialsId
-    ) {
+    const hasData = getGitProviderRepositoriesFetcher.data;
+    const credentialsChanged = lastLoadedCredentialsIdRef.current !== credentialsId;
+    const shouldLoad = credentialsId && (credentialsChanged || !hasData);
+
+    if (getGitProviderRepositoriesFetcher.state === 'idle' && shouldLoad) {
+      lastLoadedCredentialsIdRef.current = credentialsId;
       getGitProviderRepositoriesFetcher.load({ credentialsId });
     }
   }, [credentialsId, getGitProviderRepositoriesFetcher]);

--- a/packages/insomnia/src/ui/components/git/connection-info.tsx
+++ b/packages/insomnia/src/ui/components/git/connection-info.tsx
@@ -33,7 +33,7 @@ export const GitConnectionInfo = ({
   const repoUrl = gitRepository?.uri;
 
   return (
-    <div className="text-[12px]">
+    <div className="rounded-xs border border-solid border-(--hl-sm) p-2">
       <div className="mb-6 font-semibold text-(--hl)">Connection Info</div>
       <div className="flex flex-col gap-4">
         <dl className="flex">

--- a/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-repository-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-repository-settings-modal/git-repository-settings-modal.tsx
@@ -38,6 +38,8 @@ export const GitRepositorySettingsModal = ({
     modalRef.current?.show();
   }, []);
 
+  const authorEmail = gitRepository.selectedAuthorEmail || selectedCredential?.author.email;
+
   return (
     <OverlayContainer>
       <Modal ref={modalRef} {...modalProps}>
@@ -51,6 +53,12 @@ export const GitRepositorySettingsModal = ({
         </ModalHeader>
         <ModalBody>
           {selectedProvider && <GitConnectionInfo gitRepository={gitRepository} providerInfo={selectedProvider} />}
+          {authorEmail && (
+            <div className="mt-4 flex text-[12px]">
+              <div className="w-[110px] font-semibold">Author Email</div>
+              <div>{authorEmail}</div>
+            </div>
+          )}
         </ModalBody>
         <ModalFooter>
           <div

--- a/packages/insomnia/src/ui/components/project/git-repo-form.tsx
+++ b/packages/insomnia/src/ui/components/project/git-repo-form.tsx
@@ -14,7 +14,7 @@ import {
 import { Icon } from '~/basic-components/icon';
 import { useAllConnectedReposLoaderFetcher } from '~/routes/git.all-connected-repos';
 import type { useGitProjectInitCloneActionFetcher } from '~/routes/git.init-clone';
-import type { GitProviderOption } from '~/sync/git/providers/types';
+import type { GitProviderOption, ProviderEmail } from '~/sync/git/providers/types';
 import { Checkbox } from '~/ui/components/base/checkbox';
 import { Input } from '~/ui/components/base/input';
 import { GitCredentialSetup } from '~/ui/components/git-credentials/credential-setup';
@@ -104,7 +104,7 @@ export const GitRepoForm: FC<Props> = ({
         <Form
           aria-label="Git Setup Form"
           id={formId}
-          className="flex flex-col gap-4"
+          className="flex flex-col gap-3"
           onSubmit={async e => {
             e.preventDefault();
             const formData = new FormData(e.currentTarget);
@@ -215,21 +215,19 @@ export const GitRepoForm: FC<Props> = ({
               onSelectionChange={email => {
                 setProjectData(prev => ({
                   ...prev,
-                  selectedAuthorEmail: email as string,
+                  selectedAuthorEmail: email,
                 }));
               }}
             >
               <Label className="mb-2 px-0.5 pt-0 text-sm">Author Email</Label>
               <Button className="flex w-full flex-1 items-center justify-between gap-2 rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) px-2 py-1 text-(--color-font) ring-1 ring-transparent transition-colors placeholder:italic hover:bg-(--hl-xs) focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden focus:ring-inset aria-pressed:bg-(--hl-sm)">
-                <SelectValue className="flex items-center justify-center gap-2 truncate">
+                <SelectValue<ProviderEmail> className="flex items-center justify-center gap-2 truncate">
                   {({ selectedItem }) => {
                     if (selectedItem) {
                       return (
                         <Fragment>
-                          <span>{(selectedItem as { email: string }).email}</span>
-                          {(selectedItem as { primary?: boolean }).primary && (
-                            <span className="text-xs text-(--hl-lg)">(primary)</span>
-                          )}
+                          <span>{selectedItem.email}</span>
+                          {selectedItem.primary && <span className="text-xs text-(--hl-lg)">(primary)</span>}
                         </Fragment>
                       );
                     }
@@ -274,7 +272,7 @@ export const GitRepoForm: FC<Props> = ({
                       uri,
                     }))
                   }
-                  credentialsId={projectData.credentialsId || selectedCredentialsId}
+                  credentialsId={selectedCredentialsId}
                 />
               ) : (
                 <Input

--- a/packages/insomnia/src/ui/components/project/git-repo-form.tsx
+++ b/packages/insomnia/src/ui/components/project/git-repo-form.tsx
@@ -22,7 +22,7 @@ import { GitRemoteBranchSelect } from '~/ui/components/git-credentials/git-remot
 import { GitRepositorySelect } from '~/ui/components/git-credentials/git-repository-select';
 import { showSettingsModal } from '~/ui/components/modals/settings-modal';
 
-import { type GitCredentials, isGitCredentialsV2 } from '../../../models/git-credentials';
+import { type GitCredentials, isGitCredentialsV2, isOAuthCredential } from '../../../models/git-credentials';
 import { ErrorBoundary } from '../error-boundary';
 import type { ActiveView, ProjectData } from './utils';
 
@@ -32,6 +32,13 @@ const getDisplayValue = (fullUri: string | undefined, prefix: string | undefined
     return fullUri.slice(prefix.length);
   }
   return fullUri;
+};
+
+const getCredentialEmails = (credential: GitCredentials | undefined) => {
+  if (credential && isGitCredentialsV2(credential) && isOAuthCredential(credential)) {
+    return credential.credentials?.emails || [];
+  }
+  return [];
 };
 
 interface Props {
@@ -77,6 +84,10 @@ export const GitRepoForm: FC<Props> = ({
       selectedCredential.credentials?.baseURI) ||
     '';
 
+  const availableEmails = getCredentialEmails(selectedCredential);
+  const showEmailSelector = availableEmails.length > 1;
+  const [isEmailSelectOpen, setIsEmailSelectOpen] = useState(false);
+
   return (
     <ErrorBoundary>
       <Checkbox
@@ -118,7 +129,6 @@ export const GitRepoForm: FC<Props> = ({
             setActiveView('git-results');
           }}
         >
-          {/* TODO support custom children in base select component and replace this one */}
           <Select
             onOpenChange={setIsCredentialSelectOpen}
             isOpen={isCredentialSelectOpen}
@@ -145,7 +155,6 @@ export const GitRepoForm: FC<Props> = ({
                         <span>{provider?.displayName}</span>
                         <Separator orientation="vertical" className="mx-2 h-4 border-l border-(--color-font)" />
                         <span className="truncate">{selectedItem.author.name}</span>
-                        <span className="truncate">{selectedItem.author.email}</span>
                       </Fragment>
                     );
                   }
@@ -175,7 +184,6 @@ export const GitRepoForm: FC<Props> = ({
                           <span>{provider?.displayName}</span>
                           <Separator orientation="vertical" className="mx-2 h-4 border-l border-(--color-font)" />
                           <span className="truncate">{item.author.name}</span>
-                          <span className="truncate">{item.author.email}</span>
                           {isSelected && <Icon icon="check" className="justify-self-end text-(--color-success)" />}
                         </Fragment>
                       );
@@ -198,6 +206,62 @@ export const GitRepoForm: FC<Props> = ({
               </div>
             </Popover>
           </Select>
+          {showEmailSelector && (
+            <Select
+              onOpenChange={setIsEmailSelectOpen}
+              isOpen={isEmailSelectOpen}
+              aria-label="Author Email"
+              selectedKey={projectData.selectedAuthorEmail || selectedCredential?.author.email}
+              onSelectionChange={email => {
+                setProjectData(prev => ({
+                  ...prev,
+                  selectedAuthorEmail: email as string,
+                }));
+              }}
+            >
+              <Label className="mb-2 px-0.5 pt-0 text-sm">Author Email</Label>
+              <Button className="flex w-full flex-1 items-center justify-between gap-2 rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) px-2 py-1 text-(--color-font) ring-1 ring-transparent transition-colors placeholder:italic hover:bg-(--hl-xs) focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden focus:ring-inset aria-pressed:bg-(--hl-sm)">
+                <SelectValue className="flex items-center justify-center gap-2 truncate">
+                  {({ selectedItem }) => {
+                    if (selectedItem) {
+                      return (
+                        <Fragment>
+                          <span>{(selectedItem as { email: string }).email}</span>
+                          {(selectedItem as { primary?: boolean }).primary && (
+                            <span className="text-xs text-(--hl-lg)">(primary)</span>
+                          )}
+                        </Fragment>
+                      );
+                    }
+                    return projectData.selectedAuthorEmail || selectedCredential?.author.email || 'Select an email';
+                  }}
+                </SelectValue>
+                <Icon icon="caret-down" />
+              </Button>
+              <Popover className="isolate flex w-(--trigger-width) min-w-max flex-col overflow-hidden rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) text-sm shadow-lg select-none">
+                <ListBox items={availableEmails} className="min-w-max overflow-y-auto py-2 focus:outline-hidden">
+                  {item => (
+                    <ListBoxItem
+                      id={item.email}
+                      key={item.email}
+                      className="flex h-(--line-height-xs) w-full items-center gap-2 bg-transparent px-(--padding-md) whitespace-nowrap text-(--color-font) transition-colors hover:bg-(--hl-sm) focus:bg-(--hl-xs) focus:outline-hidden disabled:cursor-not-allowed aria-selected:font-bold"
+                      aria-label={item.email}
+                      textValue={item.email}
+                      value={item}
+                    >
+                      {({ isSelected }) => (
+                        <Fragment>
+                          <span>{item.email}</span>
+                          {item.primary && <span className="text-xs text-(--hl-lg)">(primary)</span>}
+                          {isSelected && <Icon icon="check" className="justify-self-end text-(--color-success)" />}
+                        </Fragment>
+                      )}
+                    </ListBoxItem>
+                  )}
+                </ListBox>
+              </Popover>
+            </Select>
+          )}
           {selectedProvider && (
             <>
               {selectedProvider.supportsFetchRepos ? (
@@ -210,12 +274,12 @@ export const GitRepoForm: FC<Props> = ({
                       uri,
                     }))
                   }
-                  credentialsId={selectedCredentialsId}
+                  credentialsId={projectData.credentialsId || selectedCredentialsId}
                 />
               ) : (
                 <Input
-                  label="Path to Repository"
-                  description="Note: Some repo should include “.git” at the end of the path."
+                  label="Repository URL"
+                  description={'Note: Some repo should include ".git" at the end of the path.'}
                   prefix={baseURI}
                   key={selectedCredentialsId}
                   defaultValue={getDisplayValue(projectData.uri, baseURI)}

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -11,7 +11,7 @@ import {
   SelectValue,
   TextField,
 } from 'react-aria-components';
-import { useParams, useRevalidator } from 'react-router';
+import { useParams } from 'react-router';
 
 import { Banner } from '~/basic-components/banner';
 import { Divider } from '~/basic-components/divider';
@@ -120,7 +120,6 @@ export const ProjectSettingsForm: FC<Props> = ({
 
   const initCloneGitRepositoryFetcher = useGitProjectInitCloneActionFetcher();
   const updateProjectFetcher = useProjectUpdateActionFetcher();
-  const revalidator = useRevalidator();
 
   const insomniaFiles =
     initCloneGitRepositoryFetcher.data && 'files' in initCloneGitRepositoryFetcher.data
@@ -128,13 +127,10 @@ export const ProjectSettingsForm: FC<Props> = ({
       : [];
 
   useEffect(() => {
-    if (updateProjectFetcher?.data && updateProjectFetcher?.data?.success) {
-      revalidator.revalidate();
-      if (onSuccessUpdate) {
-        onSuccessUpdate();
-      }
+    if (updateProjectFetcher?.data && updateProjectFetcher?.data?.success && onSuccessUpdate) {
+      onSuccessUpdate();
     }
-  }, [onSuccessUpdate, updateProjectFetcher.data, revalidator]);
+  }, [onSuccessUpdate, updateProjectFetcher.data]);
 
   useEffect(() => {
     if (updateProjectFetcher.state === 'idle' && updateProjectFetcher.data && updateProjectFetcher.data?.error) {
@@ -150,7 +146,6 @@ export const ProjectSettingsForm: FC<Props> = ({
         projectData: {
           ...projectData,
           storageType,
-          selectedAuthorEmail: projectData.selectedAuthorEmail,
         },
       });
     }
@@ -201,15 +196,6 @@ export const ProjectSettingsForm: FC<Props> = ({
       emailsFetcher.load({ credentialsId: selectedCredential._id });
     }
   }, [canFetchEmails, selectedCredential, emailsFetcher]);
-
-  useEffect(() => {
-    if (gitRepository && project?._id) {
-      setProjectData(prev => ({
-        ...prev,
-        selectedAuthorEmail: gitRepository.selectedAuthorEmail ?? null,
-      }));
-    }
-  }, [project?._id, gitRepository]);
 
   return (
     <>
@@ -321,7 +307,7 @@ export const ProjectSettingsForm: FC<Props> = ({
                       onSelectionChange={email => {
                         setProjectData(prev => ({
                           ...prev,
-                          selectedAuthorEmail: email as string,
+                          selectedAuthorEmail: email,
                         }));
                       }}
                     >

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -1,14 +1,30 @@
 import type { FC } from 'react';
-import { useEffect, useMemo, useState } from 'react';
-import { Button, Input, Label, TextField } from 'react-aria-components';
-import { useParams } from 'react-router';
+import { Fragment, useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  Input,
+  Label,
+  ListBox,
+  ListBoxItem,
+  Popover,
+  Select,
+  SelectValue,
+  TextField,
+} from 'react-aria-components';
+import { useParams, useRevalidator } from 'react-router';
 
 import { Banner } from '~/basic-components/banner';
 import { Divider } from '~/basic-components/divider';
 import { LearnMoreLink } from '~/basic-components/link';
-import type { GitCredentials } from '~/models/git-credentials';
+import {
+  type GitCredentials,
+  isGitCredentialsV2,
+  isOAuthCredential,
+  type ProviderEmail,
+} from '~/models/git-credentials';
 import type { StorageRules } from '~/models/organization';
 import { useGitProjectInitCloneActionFetcher } from '~/routes/git.init-clone';
+import { useGitProviderEmailsLoaderFetcher } from '~/routes/git-provider.emails';
 import type { GitProviderOption } from '~/sync/git/providers/types';
 import { GitConnectionInfo } from '~/ui/components/git/connection-info';
 import { GitRepoForm } from '~/ui/components/project/git-repo-form';
@@ -93,15 +109,18 @@ export const ProjectSettingsForm: FC<Props> = ({
     ref?: string;
     credentialsId?: string;
     connectRepositoryLater?: boolean;
+    selectedAuthorEmail?: string | null;
   }>({
     name: project?.name || defaultProjectName,
     uri: gitRepository?.uri || '',
     credentialsId: gitRepository?.credentialsId ?? undefined,
     connectRepositoryLater: false,
+    selectedAuthorEmail: gitRepository?.selectedAuthorEmail ?? null,
   });
 
   const initCloneGitRepositoryFetcher = useGitProjectInitCloneActionFetcher();
   const updateProjectFetcher = useProjectUpdateActionFetcher();
+  const revalidator = useRevalidator();
 
   const insomniaFiles =
     initCloneGitRepositoryFetcher.data && 'files' in initCloneGitRepositoryFetcher.data
@@ -109,10 +128,13 @@ export const ProjectSettingsForm: FC<Props> = ({
       : [];
 
   useEffect(() => {
-    if (updateProjectFetcher.data && updateProjectFetcher.data.success && onSuccessUpdate) {
-      onSuccessUpdate();
+    if (updateProjectFetcher?.data && updateProjectFetcher?.data?.success) {
+      revalidator.revalidate();
+      if (onSuccessUpdate) {
+        onSuccessUpdate();
+      }
     }
-  }, [onSuccessUpdate, updateProjectFetcher.data]);
+  }, [onSuccessUpdate, updateProjectFetcher.data, revalidator]);
 
   useEffect(() => {
     if (updateProjectFetcher.state === 'idle' && updateProjectFetcher.data && updateProjectFetcher.data?.error) {
@@ -128,6 +150,7 @@ export const ProjectSettingsForm: FC<Props> = ({
         projectData: {
           ...projectData,
           storageType,
+          selectedAuthorEmail: projectData.selectedAuthorEmail,
         },
       });
     }
@@ -149,6 +172,44 @@ export const ProjectSettingsForm: FC<Props> = ({
     storageType === 'git' &&
     ((isGitSyncEnabled && isSwitchingStorageType(project!, storageType)) ||
       (!isSwitchingStorageType(project!, storageType) && project?.gitRepositoryId === EMPTY_GIT_PROJECT_ID));
+
+  const emailsFetcher = useGitProviderEmailsLoaderFetcher();
+  const isLoadingEmails = emailsFetcher.state !== 'idle';
+
+  const availableEmails = useMemo(() => {
+    const fetchedEmails = emailsFetcher.data?.emails || [];
+    if (fetchedEmails.length > 0) {
+      return fetchedEmails;
+    }
+    if (selectedCredential && isGitCredentialsV2(selectedCredential) && isOAuthCredential(selectedCredential)) {
+      return selectedCredential.credentials?.emails || [];
+    }
+    return [];
+  }, [selectedCredential, emailsFetcher.data?.emails]);
+
+  const canFetchEmails =
+    selectedCredential &&
+    isGitCredentialsV2(selectedCredential) &&
+    isOAuthCredential(selectedCredential) &&
+    selectedProvider?.supportsFetchEmails;
+
+  const showEmailSelector = showGitConnectionInfo && canFetchEmails;
+  const [isEmailSelectOpen, setIsEmailSelectOpen] = useState(false);
+
+  useEffect(() => {
+    if (canFetchEmails && selectedCredential && emailsFetcher.state === 'idle' && !emailsFetcher.data) {
+      emailsFetcher.load({ credentialsId: selectedCredential._id });
+    }
+  }, [canFetchEmails, selectedCredential, emailsFetcher]);
+
+  useEffect(() => {
+    if (gitRepository && project?._id) {
+      setProjectData(prev => ({
+        ...prev,
+        selectedAuthorEmail: gitRepository.selectedAuthorEmail ?? null,
+      }));
+    }
+  }, [project?._id, gitRepository]);
 
   return (
     <>
@@ -244,6 +305,85 @@ export const ProjectSettingsForm: FC<Props> = ({
                 providerInfo={selectedProvider}
                 projectId={project!._id}
               />
+              {showEmailSelector && (
+                <div className="flex flex-col gap-2">
+                  {isLoadingEmails ? (
+                    <div className="flex items-center gap-2 text-sm">
+                      <Icon icon="spinner" className="animate-spin" />
+                      <span>Loading emails...</span>
+                    </div>
+                  ) : availableEmails.length > 1 ? (
+                    <Select
+                      onOpenChange={setIsEmailSelectOpen}
+                      isOpen={isEmailSelectOpen}
+                      aria-label="Author Email"
+                      selectedKey={projectData.selectedAuthorEmail || selectedCredential?.author.email}
+                      onSelectionChange={email => {
+                        setProjectData(prev => ({
+                          ...prev,
+                          selectedAuthorEmail: email as string,
+                        }));
+                      }}
+                    >
+                      <Label className="mb-2 px-0.5 pt-0 text-sm">Author Email</Label>
+                      <Button className="flex w-full flex-1 items-center justify-between gap-2 rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) px-2 py-1 text-(--color-font) ring-1 ring-transparent transition-colors placeholder:italic hover:bg-(--hl-xs) focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden focus:ring-inset aria-pressed:bg-(--hl-sm)">
+                        <SelectValue<ProviderEmail> className="flex items-center justify-center gap-2 truncate">
+                          {({ selectedItem }) => {
+                            if (selectedItem) {
+                              return (
+                                <Fragment>
+                                  <span>{selectedItem.email}</span>
+                                  {selectedItem.primary && <span className="text-xs text-(--hl-lg)">(primary)</span>}
+                                </Fragment>
+                              );
+                            }
+                            return (
+                              projectData.selectedAuthorEmail || selectedCredential?.author.email || 'Select an email'
+                            );
+                          }}
+                        </SelectValue>
+                        <Icon icon="caret-down" />
+                      </Button>
+                      <Popover className="isolate flex w-(--trigger-width) min-w-max flex-col overflow-hidden rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) text-sm shadow-lg select-none">
+                        <ListBox
+                          items={availableEmails}
+                          className="min-w-max overflow-y-auto py-2 focus:outline-hidden"
+                        >
+                          {item => (
+                            <ListBoxItem
+                              id={item.email}
+                              key={item.email}
+                              className="flex h-(--line-height-xs) w-full items-center gap-2 bg-transparent px-(--padding-md) whitespace-nowrap text-(--color-font) transition-colors hover:bg-(--hl-sm) focus:bg-(--hl-xs) focus:outline-hidden disabled:cursor-not-allowed aria-selected:font-bold"
+                              aria-label={item.email}
+                              textValue={item.email}
+                              value={item}
+                            >
+                              {({ isSelected }) => (
+                                <Fragment>
+                                  <span>{item.email}</span>
+                                  {item.primary && <span className="text-xs text-(--hl-lg)">(primary)</span>}
+                                  {isSelected && (
+                                    <Icon icon="check" className="justify-self-end text-(--color-success)" />
+                                  )}
+                                </Fragment>
+                              )}
+                            </ListBoxItem>
+                          )}
+                        </ListBox>
+                      </Popover>
+                    </Select>
+                  ) : (
+                    <div className="text-[12px]">
+                      <div className="flex">
+                        <div className="w-[110px] font-semibold">Author Email</div>
+                        <div>
+                          {projectData.selectedAuthorEmail || selectedCredential?.author.email || 'No email available'}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
             </>
           )}
           {showGitRepoForm && (
@@ -300,7 +440,9 @@ export const ProjectSettingsForm: FC<Props> = ({
                 onPress={onUpsertProject}
                 isDisabled={
                   updateProjectFetcher.state !== 'idle' ||
-                  (!isSwitchingStorageType(project!, storageType) && project?.name.trim() === projectData.name.trim())
+                  (!isSwitchingStorageType(project!, storageType) &&
+                    project?.name.trim() === projectData.name.trim() &&
+                    (gitRepository?.selectedAuthorEmail ?? null) === (projectData.selectedAuthorEmail ?? null))
                 }
                 className="flex h-full w-[10ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >

--- a/packages/insomnia/src/ui/components/project/utils.tsx
+++ b/packages/insomnia/src/ui/components/project/utils.tsx
@@ -14,6 +14,7 @@ export interface ProjectData {
   ref?: string;
   credentialsId?: string;
   connectRepositoryLater?: boolean;
+  selectedAuthorEmail?: string | null;
 }
 
 export type ProjectType = 'local' | 'remote' | 'git';

--- a/packages/insomnia/src/ui/components/settings/credentials.tsx
+++ b/packages/insomnia/src/ui/components/settings/credentials.tsx
@@ -275,7 +275,7 @@ const GitCredentialsList = () => {
         showModal(AlertModal, {
           title: 'Delete Git Credential',
           message:
-            'Are you sure you want to delete this Git credential? You won’t be able to use it to connect new Git Sync projects to the repositories it provides access to.',
+            "Are you sure you want to delete this Git credential? You won't be able to use it to connect new Git Sync projects to the repositories it provides access to.",
           okLabel: 'Delete',
           addCancel: true,
           onConfirm: async () => {
@@ -341,61 +341,61 @@ const GitCredentialsList = () => {
       <GridList
         items={credentialsFetcher.data?.credentials || []}
         aria-label="Git credentials list"
-        className="grid grid-cols-[min-content_1fr_min-content] gap-4"
+        className="flex flex-col gap-4"
       >
         {item => {
           const provider = credentialsFetcher.data?.providers.find(p => p.type === item.provider);
           return (
             <GridListItem
               id={item._id}
-              className="col-span-full grid grid-cols-subgrid grid-rows-subgrid"
+              className="flex flex-col gap-2 rounded-md border border-solid border-(--hl-sm) p-2"
               textValue={item.name || 'Credentials Item'}
             >
-              <div className="flex items-center gap-2">
-                {provider?.iconName && <Icon icon={provider.iconName} className="size-5" />}
-                <span className="text-nowrap">{provider?.displayName}</span>
-              </div>
-              <div className="flex gap-2">
-                {item.author.avatarUrl ? (
-                  <img
-                    src={item.author.avatarUrl}
-                    alt={item.author.name || 'Avatar'}
-                    className="h-6 w-6 rounded-full"
-                  />
-                ) : (
-                  <div className="flex h-6 w-6 items-center justify-center rounded-full bg-(--hl-sm) text-xs font-bold text-(--color-font-muted)">
-                    {item.author.name ? item.author.name.charAt(0).toUpperCase() : '?'}
-                  </div>
-                )}
-                <span>{item.author.name}</span>
-                <span>{item.author.email}</span>
-              </div>
-              <div className="flex items-center justify-end gap-2">
-                {isGitCredentialsV2(item) && provider && !provider.supportsOAuth && (
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  {provider?.iconName && <Icon icon={provider.iconName} className="size-5" />}
+                  <span className="font-semibold text-nowrap">{provider?.displayName}</span>
+                  {item.author.avatarUrl ? (
+                    <img
+                      src={item.author.avatarUrl}
+                      alt={item.author.name || 'Avatar'}
+                      className="h-6 w-6 rounded-full"
+                    />
+                  ) : (
+                    <div className="flex h-6 w-6 items-center justify-center rounded-full bg-(--hl-sm) text-xs font-bold text-(--color-font-muted)">
+                      {item.author.name ? item.author.name.charAt(0).toUpperCase() : '?'}
+                    </div>
+                  )}
+                  <span>{item.author.name}</span>
+                  <span>{item.author.email}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  {isGitCredentialsV2(item) && provider && !provider.supportsOAuth && (
+                    <Button
+                      className="h-7 rounded-xs px-2 py-1 text-sm text-(--color-font) transition-all hover:bg-(--hl-xs) disabled:opacity-50 aria-pressed:bg-(--hl-sm)"
+                      onPress={() => {
+                        setSelectedProvider({
+                          type: provider.type,
+                          displayName: provider.displayName,
+                          iconName: provider.iconName,
+                        });
+                        setGitCredentialToEdit(item);
+                        setIsCredentialModalOpen(true);
+                      }}
+                    >
+                      <Icon icon="edit" /> Edit
+                    </Button>
+                  )}
                   <Button
-                    className="h-7 rounded-xs px-2 py-1 text-sm text-(--color-font) transition-all hover:bg-(--hl-xs) disabled:opacity-50 aria-pressed:bg-(--hl-sm)"
                     onPress={() => {
-                      setSelectedProvider({
-                        type: provider.type,
-                        displayName: provider.displayName,
-                        iconName: provider.iconName,
-                      });
-                      setGitCredentialToEdit(item);
-                      setIsCredentialModalOpen(true);
+                      pendingDeleteCredentialIdRef.current = item._id;
+                      relatedProjectsFetcher.load({ gitCredentialsId: item._id });
                     }}
+                    className="h-7 rounded-xs px-2 py-1 text-sm text-(--color-font) transition-all hover:bg-(--hl-xs) disabled:opacity-50 aria-pressed:bg-(--hl-sm)"
                   >
-                    <Icon icon="edit" /> Edit
+                    <Icon icon="trash" /> Delete
                   </Button>
-                )}
-                <Button
-                  onPress={() => {
-                    pendingDeleteCredentialIdRef.current = item._id;
-                    relatedProjectsFetcher.load({ gitCredentialsId: item._id });
-                  }}
-                  className="h-7 rounded-xs px-2 py-1 text-sm text-(--color-font) transition-all hover:bg-(--hl-xs) disabled:opacity-50 aria-pressed:bg-(--hl-sm)"
-                >
-                  <Icon icon="trash" /> Delete
-                </Button>
+                </div>
               </div>
             </GridListItem>
           );


### PR DESCRIPTION
- Adds the ability to override the default author email address used in commits provided by GitHub/GitLab on the project setup/settings modal
  - It does not change the default email address on the _credential_ itself, as users may want/need to use different email addresses for commits on different projects/repos
  - Doesn't apply to custom credentials
- Updates styles on the credential list in preferences to clearly distinguish credential rows
- Only fetches from the provider when changing the author email