### PR TITLE
fix: socket.io body tab refresh - [INS-1997]

### DIFF
--- a/packages/insomnia/src/ui/components/socket-io/event-tab-pane.tsx
+++ b/packages/insomnia/src/ui/components/socket-io/event-tab-pane.tsx
@@ -187,9 +187,9 @@ export const SocketIOEventTabPane = ({ request, eventListeners }: Props) => {
                   return (
                     <div
                       className={classNames(
-                        "h-4.5 w-[30px] rounded-full border border-solid border-(--hl) bg-(--color-bg) transition-all duration-200 before:m-0.5 before:block before:h-3.5 before:w-3.5 before:rounded-full before:transition-all before:duration-200 before:content-['']",
+                        "flex h-4.5 w-[30px] items-center rounded-full border border-solid border-(--hl) bg-(--color-bg) transition-all duration-200 before:m-0.5 before:block before:h-3.5 before:w-3.5 before:rounded-full before:transition-all before:duration-200 before:content-['']",
                         {
-                          'bg-(--color-surprise) before:translate-x-full before:bg-(--color-bg)': isSelected,
+                          'bg-(--color-surprise) before:translate-x-full before:bg-white': isSelected,
                           'before:bg-(--color-surprise)': !isSelected,
                           'cursor-not-allowed border-(--hl) before:bg-(--hl)': isDisabled,
                         },

--- a/packages/insomnia/src/ui/components/socket-io/request-pane.tsx
+++ b/packages/insomnia/src/ui/components/socket-io/request-pane.tsx
@@ -288,6 +288,7 @@ export const SocketIORequestPane: FC<Props> = ({ environment }) => {
         </TabPanel>
         <TabPanel className="flex h-full w-full flex-1 flex-col" id="body">
           <SocketIOBodyTabPane
+            key={uniqueKey}
             request={activeRequest}
             requestPayload={requestPayload}
             environmentId={environment?._id || ''}

--- a/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
@@ -234,13 +234,11 @@ export const EventLogView: FC<Props> = ({
                 isSelectedRow && autoSelectLatestEvent
                   ? 'bg-(--hl-sm) outline-hidden'
                   : 'focus-within:bg-(--hl-sm) focus:outline-hidden';
+              const icon = getIcon(event);
               return (
                 <Row className={`group transition-colors ${rowExtraClasses}`}>
                   <Cell className="border-b border-solid border-(--hl-sm) pl-2 align-middle text-sm font-medium whitespace-nowrap group-last-of-type:border-none focus:outline-hidden">
-                    <SvgIcon
-                      icon={getIcon(event)}
-                      style={getIcon(event) === 'info' ? { fill: 'var(--color-font)' } : {}}
-                    />
+                    <SvgIcon icon={icon} style={icon === 'info' ? { fill: 'var(--color-font)' } : {}} />
                   </Cell>
                   <Cell className="border-b border-solid border-(--hl-sm) align-middle text-sm font-medium whitespace-nowrap group-last-of-type:border-none focus:outline-hidden">
                     {getMessage(event, isLoading)}

--- a/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
+++ b/packages/insomnia/src/ui/components/websockets/event-log-view.tsx
@@ -236,8 +236,11 @@ export const EventLogView: FC<Props> = ({
                   : 'focus-within:bg-(--hl-sm) focus:outline-hidden';
               return (
                 <Row className={`group transition-colors ${rowExtraClasses}`}>
-                  <Cell className="border-b border-solid border-(--hl-sm) align-middle text-sm font-medium whitespace-nowrap group-last-of-type:border-none focus:outline-hidden">
-                    <SvgIcon icon={getIcon(event)} />
+                  <Cell className="border-b border-solid border-(--hl-sm) pl-2 align-middle text-sm font-medium whitespace-nowrap group-last-of-type:border-none focus:outline-hidden">
+                    <SvgIcon
+                      icon={getIcon(event)}
+                      style={getIcon(event) === 'info' ? { fill: 'var(--color-font)' } : {}}
+                    />
                   </Cell>
                   <Cell className="border-b border-solid border-(--hl-sm) align-middle text-sm font-medium whitespace-nowrap group-last-of-type:border-none focus:outline-hidden">
                     {getMessage(event, isLoading)}


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

Close #9578 

**Changes:**

- add `uniqueKey` for socket.io body tab so the body panel can re-render when payload changes
- minor UI improvements