### PR TITLE
feat: navigate to imported workspace

### DIFF
--- a/packages/insomnia-smoke-test/README.md
+++ b/packages/insomnia-smoke-test/README.md
@@ -17,6 +17,7 @@ This project contains the smoke testing suite for Insomnia App.
     - [Getting traces from CI](#getting-traces-from-ci)
     - [Build and package methods](#build-and-package-methods)
     - [Non recurring tests](#non-recurring-tests)
+    - [Refresh certs](#refresh-certs)
 
 ## Quick-start
 
@@ -27,12 +28,13 @@ Prerequisites:
 
 To run all tests:
 
-- In one terminal run: `npm run watch:app`
+- In one terminal run: `npm run watch:app` OR `npm run dev`
 - In another terminal run: `npm run test:smoke:dev`
 
 To run single tests:
 
 - Filter by the file or test title, e.g. `npm run test:smoke:dev -- oauth`
+- Use playwright UI `npm run test:dev -w insomnia-smoke-test -- --project=Smoke --ui` to show all tests by project
 
 ## Debugging and Developing Tests locally
 

--- a/packages/insomnia-smoke-test/fixtures/vault-environment.yaml
+++ b/packages/insomnia-smoke-test/fixtures/vault-environment.yaml
@@ -8,7 +8,7 @@ resources:
     parentId: proj_668d3ef4abb1456f9926ee9e0adee62b
     modified: 1735021392122
     created: 1735021392122
-    name: Global env with secret vault
+    name: Global env workspace with secret vault
     description: ""
     scope: environment
     _type: workspace

--- a/packages/insomnia-smoke-test/tests/critical/bundling.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/bundling.test.ts
@@ -22,7 +22,6 @@ test('can use bundled plugins, node-libcurl, httpsnippet, hidden browser window'
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('Smoke tests').click();
 
   await page.getByLabel('Request Collection').getByTestId('send JSON request').press('Enter');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
@@ -58,7 +57,6 @@ test('can use external modules in scripts', async ({ app, page }) => {
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
 
   // select request
-  await page.getByLabel('Pre-request Scripts').click();
   await page.getByLabel('Request Collection').getByTestId('use external modules').press('Enter');
 
   // send

--- a/packages/insomnia-smoke-test/tests/critical/certificates.test.ts
+++ b/packages/insomnia-smoke-test/tests/critical/certificates.test.ts
@@ -19,7 +19,6 @@ test('can send request with custom ca root certificate', async ({ app, page }) =
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('Smoke tests').click();
 
   await page.getByLabel('Request Collection').getByTestId('sends request with certs').press('Enter');
 

--- a/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
@@ -6,14 +6,6 @@ import { test } from '../../playwright/test';
 test.describe('after-response script features tests', () => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
   test('all', async ({ page, app }) => {
-    const text = await loadFixture('after-response-collection.yaml');
-    await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
-
-    await page.getByLabel('Import').click();
-    await page.locator('[data-test-id="import-from-clipboard"]').click();
-    await page.getByRole('button', { name: 'Scan' }).click();
-    await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-    await page.getByTestId('project').click();
     // import global environment
     const globalEnvText = await loadFixture('script-global-environment.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), globalEnvText);
@@ -22,7 +14,14 @@ test.describe('after-response script features tests', () => {
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
     await page.getByTestId('project').click();
-    await page.getByLabel('After-response Scripts').click();
+    // import collection with after-response scripts
+    const text = await loadFixture('after-response-collection.yaml');
+    await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+
+    await page.getByLabel('Import').click();
+    await page.locator('[data-test-id="import-from-clipboard"]').click();
+    await page.getByRole('button', { name: 'Scan' }).click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
 
     // set transient var
     const statusTag = page.locator('[data-testid="response-status-tag"]:visible');

--- a/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/after-response-script-features.test.ts
@@ -13,7 +13,7 @@ test.describe('after-response script features tests', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-
+    await page.getByTestId('project').click();
     // import global environment
     const globalEnvText = await loadFixture('script-global-environment.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), globalEnvText);
@@ -21,7 +21,7 @@ test.describe('after-response script features tests', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-
+    await page.getByTestId('project').click();
     await page.getByLabel('After-response Scripts').click();
 
     // set transient var

--- a/packages/insomnia-smoke-test/tests/smoke/app.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/app.test.ts
@@ -16,13 +16,11 @@ test('can send requests', async ({ app, page }) => {
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
 
-  await page.getByRole('button', { name: 'Workspace actions menu button' }).click();
-  await page.getByRole('menuitem', { name: 'Export' }).click();
+  await page.getByTestId('workspace-context-dropdown').click();
+  await page.getByRole('menuitemradio', { name: 'Export' }).click();
   await page.getByRole('button', { name: 'Export' }).click();
   await page.getByText('Which format would you like to export as?').click();
   await page.locator('.app').press('Escape');
-
-  await page.getByLabel('Smoke tests').click();
 
   await page.getByLabel('Create in collection').click();
   await page.getByRole('menuitemradio', { name: 'From Curl' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/chained-responses.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/chained-responses.test.ts
@@ -11,7 +11,6 @@ test('can chain multiple requests', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('test chains').click();
 
   await page.getByLabel('Request Collection').getByTestId('third').press('Enter');
   await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/command-palette.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/command-palette.test.ts
@@ -6,15 +6,6 @@ import { test } from '../../playwright/test';
 test('Command palette - can switch between requests and workspaces', async ({ app, page }) => {
   test.slow(process.platform === 'darwin' || process.platform === 'win32', 'Slow app start on these platforms');
 
-  // Import a collection
-  const text = await loadFixture('smoke-test-collection.yaml');
-  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
-
-  await page.getByLabel('Import').click();
-  await page.locator('[data-test-id="import-from-clipboard"]').click();
-  await page.getByRole('button', { name: 'Scan' }).click();
-  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByTestId('project').click();
   // Import a document
   const swaggerDoc = await loadFixture('swagger2.yaml');
   await app.evaluate(async ({ clipboard }, swaggerDoc) => clipboard.writeText(swaggerDoc), swaggerDoc);
@@ -24,7 +15,16 @@ test('Command palette - can switch between requests and workspaces', async ({ ap
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   await page.getByTestId('project').click();
-  await page.getByLabel('Smoke tests').click();
+
+  // Import a collection
+  const text = await loadFixture('smoke-test-collection.yaml');
+  await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), text);
+
+  await page.getByLabel('Import').click();
+  await page.locator('[data-test-id="import-from-clipboard"]').click();
+  await page.getByRole('button', { name: 'Scan' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+
   await page
     .getByTestId('sends request with cookie and get cookie in response')
     .getByText('GET', { exact: true })
@@ -39,6 +39,7 @@ test('Command palette - can switch between requests and workspaces', async ({ ap
   await page.getByText('200 OK').click();
 
   await page.locator('body').press(process.platform === 'darwin' ? 'Meta+p' : 'Control+p');
+  await page.getByPlaceholder('Search and switch between').press('ArrowUp');
   await page.getByPlaceholder('Search and switch between').press('ArrowUp');
   await page.getByPlaceholder('Search and switch between').press('ArrowUp');
   await page.getByPlaceholder('Search and switch between').press('Enter');

--- a/packages/insomnia-smoke-test/tests/smoke/command-palette.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/command-palette.test.ts
@@ -14,7 +14,7 @@ test('Command palette - can switch between requests and workspaces', async ({ ap
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-
+  await page.getByTestId('project').click();
   // Import a document
   const swaggerDoc = await loadFixture('swagger2.yaml');
   await app.evaluate(async ({ clipboard }, swaggerDoc) => clipboard.writeText(swaggerDoc), swaggerDoc);
@@ -23,7 +23,7 @@ test('Command palette - can switch between requests and workspaces', async ({ ap
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-
+  await page.getByTestId('project').click();
   await page.getByLabel('Smoke tests').click();
   await page
     .getByTestId('sends request with cookie and get cookie in response')

--- a/packages/insomnia-smoke-test/tests/smoke/cookie-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cookie-editor-interactions.test.ts
@@ -11,7 +11,6 @@ test.describe('Cookie editor', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-    await page.getByLabel('simple').click();
   });
 
   test('create and send a cookie', async ({ page }) => {

--- a/packages/insomnia-smoke-test/tests/smoke/debug-sidebar-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/debug-sidebar-interactions.test.ts
@@ -13,7 +13,6 @@ test.describe('Debug-Sidebar', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-    await page.getByLabel('simple').click();
     //Open Properties in Request Sidebar
     await page.getByLabel('Request Collection').getByRole('row', { name: 'example http' }).click();
     await page

--- a/packages/insomnia-smoke-test/tests/smoke/design-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/design-interactions.test.ts
@@ -14,7 +14,6 @@ test.describe('Design interactions', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-    await page.getByText('unit-test.yaml').click();
     // Switch to Test tab
     await page.click('a:has-text("Test")');
 

--- a/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/environment-editor-interactions.test.ts
@@ -11,7 +11,6 @@ test.describe('Environment Editor', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-    await page.getByText('Collectionenvironments').click();
     // Create the environment (which will become active on creation)
     // await page.getByLabel("Select an environment").click();
     await page.getByRole('button', { name: 'Manage Environments' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/external-vault-integration.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/external-vault-integration.test.ts
@@ -15,7 +15,6 @@ test('Setup external vault and used in request', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('Template Tag Collection').click();
   // Nav to cloud credentials page
   await page.getByTestId('settings-button').click();
   await page.getByRole('tab', { name: 'Credentials' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/global-environments.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/global-environments.test.ts
@@ -52,4 +52,5 @@ async function loadFixtureFile(fixture: string, app, page) {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+  await page.getByTestId('project').click();
 }

--- a/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/graphql.test.ts
@@ -15,7 +15,6 @@ test('can render schema and send GraphQL requests', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('Smoke GraphQL').click();
 
   // Open the graphql request
   await page.getByLabel('Request Collection').getByTestId('GraphQL request').press('Enter');
@@ -66,8 +65,6 @@ test('can render schema and send GraphQL requests with object variables', async 
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('Smoke GraphQL').click();
-
   // Open the graphql request
   await page.getByLabel('Request Collection').getByTestId('GraphQL request with variables').press('Enter');
   await page.getByRole('tab', { name: 'Body' }).click();
@@ -106,7 +103,6 @@ test('can render numeric environment', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('Smoke GraphQL').click();
 
   // Open the graphql request
   await page.getByLabel('Request Collection').getByTestId('GraphQL request with number').press('Enter');
@@ -143,7 +139,6 @@ test('can send GraphQL requests after editing and prettifying query', async ({ a
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('Smoke GraphQL').click();
   await page.getByLabel('Request Collection').getByTestId('GraphQL request').press('Enter');
 
   // Edit and prettify query

--- a/packages/insomnia-smoke-test/tests/smoke/grpc-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/grpc-interactions.test.ts
@@ -15,7 +15,6 @@ test.describe('gRPC interactions', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-    await page.getByLabel('PreRelease gRPC').click();
 
     const statusTag = page.locator('[data-testid="response-status-tag"]:visible');
     const responseBody = page.locator('[data-testid="response-pane"] >> [data-testid="CodeEditor"]:visible', {

--- a/packages/insomnia-smoke-test/tests/smoke/grpc-mtls.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/grpc-mtls.test.ts
@@ -19,7 +19,6 @@ test('can send gRPC requests using mTLS requests (with reflection)', async ({ ap
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('grpc').click();
 
   await page.getByLabel('Request Collection').getByTestId('grpcs').press('Enter');
   await expect.soft(page.getByRole('button', { name: 'Select Method' })).toBeDisabled();

--- a/packages/insomnia-smoke-test/tests/smoke/grpc.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/grpc.test.ts
@@ -17,7 +17,6 @@ test('can send gRPC requests with reflection', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('PreRelease gRPC').click();
 
   await page.getByLabel('Request Collection').getByTestId('UnaryWithOutProtoFile').press('Enter');
   await page.getByTestId('button-server-reflection').click();

--- a/packages/insomnia-smoke-test/tests/smoke/header-templates.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/header-templates.test.ts
@@ -18,7 +18,6 @@ test('can requests that contain templated header keys and values', async ({ app,
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('headerTemplates').click();
 
   await page.getByLabel('Request Collection').getByTestId('pet2').press('Enter');
 

--- a/packages/insomnia-smoke-test/tests/smoke/import-from-url.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/import-from-url.test.ts
@@ -11,7 +11,6 @@ test.describe('Import from URL', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-    await page.getByLabel('simple').click();
   });
 
   test('Should work as expected in HTTP request', async ({ page }) => {

--- a/packages/insomnia-smoke-test/tests/smoke/import.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/import.test.ts
@@ -23,7 +23,6 @@ test('Can generate content-type header from imported postman file', async ({ app
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
   // Have generated content-type of application/x-www-form-urlencoded for the request
-  await page.getByRole('link', { name: 'New Collection' }).click();
   await page.getByTestId('New Request').click();
   await page.locator('[data-key="headers"]').click();
   await expect.soft(page.getByText('application/x-www-form-urlencoded')).toBeAttached();

--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
@@ -58,8 +58,6 @@ test.describe('Vault key actions', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-    await page.getByTestId('project').click();
-    await page.getByText('Global env workspace with secret vault').click();
     await page.getByRole('dialog').getByText('Reset Vault Key').dblclick();
     const vaultKeyValueInModal = await page.getByTestId('VaultKeyDisplayPanel').innerText();
     expect.soft(vaultKeyValueInModal.length).toBeGreaterThan(0);

--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
@@ -58,7 +58,8 @@ test.describe('Vault key actions', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-    await page.getByText('Global env with secret vault').click();
+    await page.getByTestId('project').click();
+    await page.getByText('Global env workspace with secret vault').click();
     await page.getByRole('dialog').getByText('Reset Vault Key').dblclick();
     const vaultKeyValueInModal = await page.getByTestId('VaultKeyDisplayPanel').innerText();
     expect.soft(vaultKeyValueInModal.length).toBeGreaterThan(0);
@@ -89,6 +90,8 @@ test.describe('Check vault used in environment', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+    await page.getByTestId('project').click();
+
     // import global environment
     const vaultEnvText = await loadFixture('vault-environment.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), vaultEnvText);
@@ -96,6 +99,7 @@ test.describe('Check vault used in environment', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+    await page.getByTestId('project').click();
 
     // create new global private environment
     await page.getByLabel('Create in project').click();

--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
@@ -171,7 +171,7 @@ test.describe('Check vault used in environment', () => {
     // activate global private vault environment from import
     await page.getByLabel('Manage Environments').click();
     await page.getByPlaceholder('Choose a global environment').click();
-    await page.getByRole('option', { name: 'Global env with secret vault' }).click();
+    await page.getByRole('option', { name: 'Global env workspace with secret vault' }).click();
     await page.getByText('global vault env with secret').click();
 
     // activate legacy array vault environment

--- a/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/insomnia-vault.test.ts
@@ -81,15 +81,6 @@ test.describe('Check vault used in environment', () => {
     await page.getByTestId('dataFolders-btn').click();
     await page.locator('.app').press('Escape');
 
-    // import requests
-    const requestColText = await loadFixture('vault-collection.yaml');
-    await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), requestColText);
-    await page.getByLabel('Import').click();
-    await page.locator('[data-test-id="import-from-clipboard"]').click();
-    await page.getByRole('button', { name: 'Scan' }).click();
-    await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-    await page.getByTestId('project').click();
-
     // import global environment
     const vaultEnvText = await loadFixture('vault-environment.yaml');
     await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), vaultEnvText);
@@ -143,8 +134,14 @@ test.describe('Check vault used in environment', () => {
       .first()
       .click();
 
+    // import requests
+    const requestColText = await loadFixture('vault-collection.yaml');
+    await app.evaluate(async ({ clipboard }, text) => clipboard.writeText(text), requestColText);
+    await page.getByLabel('Import').click();
+    await page.locator('[data-test-id="import-from-clipboard"]').click();
+    await page.getByRole('button', { name: 'Scan' }).click();
+    await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
     // activate existing global private vault environment from import
-    await page.getByText('Vault Collection').click();
     await page.getByLabel('Manage Environments').click();
     await page.getByPlaceholder('Choose a global environment').click();
     await page.getByRole('option', { name: 'New Global Vault Environment' }).click();

--- a/packages/insomnia-smoke-test/tests/smoke/mtls.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/mtls.test.ts
@@ -27,7 +27,6 @@ test('can use client certificate for mTLS', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('client-certs').click();
 
   await page.getByLabel('Request Collection').getByTestId('pet 2 with url var').press('Enter');
 

--- a/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/oauth.test.ts
@@ -17,7 +17,6 @@ test('can make oauth2 requests', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('OAuth Testing').click();
 
   // Test Folder Level Auth propagates to heirs
 

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -17,8 +17,6 @@ test.describe('pre-request features tests', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-
-    await page.getByLabel('Pre-request Scripts').click();
   });
 
   const testCases = [
@@ -524,7 +522,6 @@ test.describe('pre-request features tests', () => {
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
     // go to request collection
-    await page.getByLabel('Pre-request Scripts', { exact: true }).click();
     await page.getByLabel('Request Collection').getByTestId('persist global environment').press('Enter');
     // activate global environment
     await page.getByLabel('Manage Environments').click();

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-features.test.ts
@@ -521,6 +521,9 @@ test.describe('pre-request features tests', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
+    await page.getByTestId('project').click();
+
+    await page.getByLabel('Pre-request Scripts', { exact: true }).click();
     // go to request collection
     await page.getByLabel('Request Collection').getByTestId('persist global environment').press('Enter');
     // activate global environment
@@ -630,8 +633,6 @@ test.describe('unhappy paths', () => {
     await page.locator('[data-test-id="import-from-clipboard"]').click();
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-
-    await page.getByLabel('Pre-request Scripts').click();
   });
 
   test('custom errors are returned', async ({ page }) => {

--- a/packages/insomnia-smoke-test/tests/smoke/pre-request-script-window.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/pre-request-script-window.test.ts
@@ -15,13 +15,11 @@ test.describe('test hidden window handling', () => {
     await page.getByRole('button', { name: 'Scan' }).click();
     await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
 
-    await page.getByRole('button', { name: 'Workspace actions menu button' }).click();
-    await page.getByRole('menuitem', { name: 'Export' }).click();
+    await page.getByTestId('workspace-context-dropdown').click();
+    await page.getByRole('menuitemradio', { name: 'Export' }).click();
     await page.getByRole('button', { name: 'Export' }).click();
     await page.getByText('Which format would you like to export as?').click();
     await page.locator('.app').press('Escape');
-
-    await page.getByText('Pre-request Scripts').click();
 
     await page.getByLabel('Request Collection').getByTestId('Long running task').press('Enter');
     await page.getByTestId('request-pane').getByRole('button', { name: 'Send' }).click();
@@ -59,7 +57,6 @@ test.describe('test hidden window handling', () => {
     await page.getByLabel('Request timeout (ms)').fill('1000');
     await page.getByRole('button', { name: 'Modal Close Button' }).click();
 
-    await page.getByText('Pre-request Scripts').click();
     await page.getByLabel('Request Collection').getByTestId('Long running task - post').press('Enter');
     await page.getByTestId('request-pane').getByRole('button', { name: 'Send', exact: true }).click();
 
@@ -100,7 +97,6 @@ test.describe('test hidden window handling', () => {
     await page.getByRole('button', { name: 'Modal Close Button' }).click();
 
     // send the request with infinite loop script
-    await page.getByText('Pre-request Scripts').click();
     await page.getByLabel('Request Collection').getByTestId('infinite loop').press('Enter');
     await page.getByTestId('request-pane').getByRole('button', { name: 'Send', exact: true }).click();
     // await page.getByText('Timeout: Hidden browser window is not responding').click();

--- a/packages/insomnia-smoke-test/tests/smoke/preferences-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/preferences-interactions.test.ts
@@ -21,7 +21,6 @@ test('Check filter responses by environment preference', async ({ app, page }) =
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('simple').click();
 
   // Send a request
   await page.getByLabel('Request Collection').getByTestId('example http').press('Enter');
@@ -61,7 +60,6 @@ test('Enable http and https proxies', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('simple').click();
 
   // send the request and check timeline
   await page.getByLabel('Request Collection').getByTestId('proxyEnabled').press('Enter');

--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -17,7 +17,6 @@ test.describe('runner features tests', () => {
     await page.getByTestId('settings-button').click();
     await page.getByText('Use vertical layout').click();
     await page.locator('.app').press('Escape');
-    await page.getByLabel('Runner').click();
   });
 
   const verifyResultRows = async (

--- a/packages/insomnia-smoke-test/tests/smoke/socket-io.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/socket-io.test.ts
@@ -17,7 +17,6 @@ test('can make socket.io connection', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('Socket.io Collection').click();
 
   await page.getByLabel('Request Collection').getByTestId('Socket.IO Request').press('Enter');
   await expect.soft(page.locator('.app')).toContainText('http://localhost:4020');

--- a/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/template-tags-interactions.test.ts
@@ -75,7 +75,6 @@ test('Critical Path For Template Tags Interactions', async ({ page, app }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('Template Tag Collection').click();
 
   await page.getByTestId('settings-button').click();
   await page.getByTestId('dataFolders').fill(getFixturePath('files/template-file.txt'));

--- a/packages/insomnia-smoke-test/tests/smoke/websocket.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/websocket.test.ts
@@ -17,7 +17,6 @@ test('can make websocket connection', async ({ app, page }) => {
   await page.locator('[data-test-id="import-from-clipboard"]').click();
   await page.getByRole('button', { name: 'Scan' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Import' }).click();
-  await page.getByLabel('WebSockets').click();
 
   await page.getByLabel('Request Collection').getByTestId('localhost:4010').press('Enter');
   await expect.soft(page.locator('.app')).toContainText('ws://localhost:4010');

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -309,8 +309,9 @@ export async function importResourcesToProject({
 }: {
   projectId: string;
   syncNewWorkspaceIfNeeded?: (workspace: Workspace) => Promise<void>;
-}) {
+}): Promise<Workspace[]> {
   invariant(resourceCacheList.length > 0, 'No resources to import');
+  const importedWorkspaces: Workspace[] = [];
   for (const resourceCacheItem of resourceCacheList) {
     const { resources, importer } = resourceCacheItem;
     const bufferId = await db.bufferChanges();
@@ -320,18 +321,19 @@ export async function importResourcesToProject({
       resource => isRequestGroup(resource) && resource.parentId === '__WORKSPACE_ID__',
     ) as Workspace | undefined;
     if (importer.id === 'postman' && postmanTopLevelFolder) {
-      await importResourcesToNewWorkspace({
+      const newWorkspace = await importResourcesToNewWorkspace({
         projectId,
         resourceCacheItem,
         workspaceToImport: postmanTopLevelFolder,
         syncNewWorkspaceIfNeeded,
       });
+      importedWorkspaces.push(newWorkspace);
       continue;
     }
 
     // if the resource is postman environment,
     if (importer.id === postmanEnvImporterId && resources.find(isEnvironment)) {
-      await Promise.all(
+      const newWorkspaces = await Promise.all(
         resources.filter(isEnvironment).map(resource =>
           importResourcesToNewWorkspace({
             projectId,
@@ -346,6 +348,7 @@ export async function importResourcesToProject({
           }),
         ),
       );
+      importedWorkspaces.push(...newWorkspaces);
       continue;
     }
 
@@ -353,16 +356,17 @@ export async function importResourcesToProject({
 
     // No workspace, so create one
     if (workspaceResources.length === 0) {
-      await importResourcesToNewWorkspace({
+      const newWorkspace = await importResourcesToNewWorkspace({
         projectId,
         resourceCacheItem,
         syncNewWorkspaceIfNeeded,
       });
+      importedWorkspaces.push(newWorkspace);
       continue;
     }
 
     // One or more workspaces in one resourceCacheItem(A resourceCacheItem corresponds to an import file), filter in the resources that belong to each workspace and then import to new workspaces respectively
-    await Promise.all(
+    const newWorkspaces = await Promise.all(
       workspaceResources.map(workspace => {
         if (workspaceResources.filter(({ _id }) => _id === '__WORKSPACE_ID__').length > 1) {
           console.warn(
@@ -386,9 +390,10 @@ export async function importResourcesToProject({
         });
       }),
     );
-
+    importedWorkspaces.push(...newWorkspaces);
     await db.flushChanges(bufferId);
   }
+  return importedWorkspaces;
 }
 
 // Filter resources that belong to the workspace, including the workspace itself
@@ -582,7 +587,7 @@ export const importResourcesToNewWorkspace = async ({
   resourceCacheItem: ResourceCacheType;
   workspaceToImport?: Workspace;
   syncNewWorkspaceIfNeeded?: (workspace: Workspace) => Promise<void>;
-}) => {
+}): Promise<Workspace> => {
   invariant(resourceCacheItem, 'No resources to import');
 
   const project = await models.project.getById(projectId);

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -446,11 +446,12 @@ export const importResourcesToWorkspace = async ({
   overrideBaseEnvironmentData?: boolean;
 }) => {
   invariant(resourceCacheList.length > 0, 'No resources to import');
+  const existingWorkspace = await models.workspace.getById(workspaceId);
+
   for (const resourceCacheItem of resourceCacheList) {
     const resources = resourceCacheItem.resources;
     const bufferId = await db.bufferChanges();
     const ResourceIdMap = new Map();
-    const existingWorkspace = await models.workspace.getById(workspaceId);
 
     invariant(existingWorkspace, `Could not find workspace with id ${workspaceId}`);
     // Map new IDs
@@ -573,6 +574,7 @@ export const importResourcesToWorkspace = async ({
 
     await db.flushChanges(bufferId);
   }
+  return [existingWorkspace];
 };
 
 export const isApiSpecImport = ({ id }: Pick<InsomniaImporter, 'id'>) => id === 'openapi3' || id === 'swagger2';

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -65,7 +65,9 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
       workspaceId,
       options,
     });
-    return { done: true, workspaceId: result?.[0]._id };
+    // Ignore multiple workspace imports
+    const singleImportedWorkspaceId = Array.isArray(result) && result.length === 1 && result[0]?._id;
+    return { done: true, workspaceId: singleImportedWorkspaceId };
   } catch (error) {
     console.error('Failed to import resources:', error);
     return {

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -66,8 +66,8 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
       options,
     });
     // Ignore multiple workspace imports
-    const singleImportedWorkspaceId = Array.isArray(result) && result.length === 1 && result[0]?._id;
-    return { done: true, workspaceId: singleImportedWorkspaceId };
+    const singleImportedWorkspace = Array.isArray(result) && result.length === 1 && result[0];
+    return { done: true, workspace: singleImportedWorkspace };
   } catch (error) {
     console.error('Failed to import resources:', error);
     return {

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -36,7 +36,7 @@ export const importScannedResources = async ({
   const project = await models.project.getById(projectId);
   invariant(project, 'Project not found.');
 
-  await (typeof workspaceId === 'string' && workspaceId
+  return await (typeof workspaceId === 'string' && workspaceId
     ? importResourcesToWorkspace({
         workspaceId: workspaceId,
         overrideBaseEnvironmentData: options?.overrideBaseEnvironmentData ?? true,
@@ -59,13 +59,13 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
     invariant(typeof organizationId === 'string', 'OrganizationId is required.');
     invariant(typeof projectId === 'string', 'ProjectId is required.');
 
-    await importScannedResources({
+    const result = await importScannedResources({
       organizationId,
       projectId,
       workspaceId,
       options,
     });
-    return { done: true };
+    return { done: true, workspaceId: result?.[0]._id };
   } catch (error) {
     console.error('Failed to import resources:', error);
     return {

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
@@ -54,11 +54,11 @@ import { WorkspaceDuplicateModal } from '../modals/workspace-duplicate-modal';
 import { WorkspaceSettingsModal } from '../modals/workspace-settings-modal';
 
 export const WorkspaceDropdown: FC<{}> = () => {
-  const { organizationId, projectId, workspaceId } = useParams<{
+  const { organizationId, projectId, workspaceId } = useParams() as {
     organizationId: string;
     projectId: string;
     workspaceId: string;
-  }>();
+  };
   invariant(organizationId, 'Expected organizationId');
   const { activeWorkspace, activeWorkspaceMeta, activeProject, activeMockServer } = useWorkspaceLoaderData()!;
 

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -168,8 +168,8 @@ interface ImportModalProps extends ModalProps {
   projectName: string;
   // undefined when not using preferences
   workspaceName?: string;
-  // undefined when using insomnia://app/import
-  defaultProjectId?: string;
+  // undefined when logged out, should not happen
+  defaultProjectId: string;
   // undefined when in workspace selection page
   defaultWorkspaceId?: string;
   from:
@@ -218,12 +218,11 @@ export const ImportModal: FC<ImportModalProps> = ({
         },
       });
       const workspace = importFetcher?.data?.workspace;
-      const projectId = defaultProjectId || '';
       workspace
         ? navigate(
-            `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/${scopeToActivity(workspace.scope)}`,
+            `/organization/${organizationId}/project/${defaultProjectId}/workspace/${workspace._id}/${scopeToActivity(workspace.scope)}`,
           )
-        : navigate(`/organization/${organizationId}/project/${projectId}`);
+        : navigate(`/organization/${organizationId}/project/${defaultProjectId}`);
       modalRef.current?.hide();
     }
   }, [defaultProjectId, defaultWorkspaceId, importFetcher?.data, navigate, organizationId, scanResourcesFetcherData]);

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import React, { type FC, Fragment, type ReactNode, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { type DirectoryDropItem, type FileDropItem, OverlayContainer, useDrop } from 'react-aria';
 import { Heading } from 'react-aria-components';
+import { useNavigate } from 'react-router';
 
 import { useImportResourcesFetcher } from '~/routes/import.resources';
 import { useScanResourcesFetcher } from '~/routes/import.scan';
@@ -200,26 +201,29 @@ export const ImportModal: FC<ImportModalProps> = ({
   const scanResourcesFetcher = useScanResourcesFetcher();
   const scanResourcesFetcherData = scanResourcesFetcher.data;
   const importFetcher = useImportResourcesFetcher();
+  const navigate = useNavigate();
   useEffect(() => {
     modalRef.current?.show();
   }, []);
 
+  // Track the import completion event, redirect to the new workspace and close the modal
   useEffect(() => {
-    if (importFetcher?.data?.done === true) {
-      // Track the import completion event
-      if (scanResourcesFetcherData?.length) {
-        window.main.trackSegmentEvent({
-          event: SegmentEvent.importCompleted,
-          properties: {
-            workspaces: scanResourcesFetcherData.map(scanResult => scanResult.workspaces?.length || 0),
-            requests: scanResourcesFetcherData.map(scanResult => scanResult.requests?.length || 0),
-          },
-        });
-      }
-
+    if (importFetcher?.data?.done === true && scanResourcesFetcherData?.length) {
+      window.main.trackSegmentEvent({
+        event: SegmentEvent.importCompleted,
+        properties: {
+          workspaces: scanResourcesFetcherData.map(scanResult => scanResult.workspaces?.length || 0),
+          requests: scanResourcesFetcherData.map(scanResult => scanResult.requests?.length || 0),
+        },
+      });
+      const workspaceId = importFetcher?.data?.workspaceId;
+      const projectId = defaultProjectId || '';
+      workspaceId
+        ? navigate(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug`)
+        : navigate(`/organization/${organizationId}/project/${projectId}`);
       modalRef.current?.hide();
     }
-  }, [importFetcher.data, scanResourcesFetcherData]);
+  }, [defaultProjectId, defaultWorkspaceId, importFetcher?.data, navigate, organizationId, scanResourcesFetcherData]);
   // allow workspace import if there is only one workspace
   const totalWorkspacesCount = useMemo(() => {
     return (
@@ -465,7 +469,7 @@ const ImportResourcesForm = ({
             </div>
           ) : (
             <div>
-              <i className="fa fa-file-import" /> Import
+              <i className="fa fa-file-import" /> Import to new Workspace
             </div>
           )}
         </Button>

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -469,7 +469,7 @@ const ImportResourcesForm = ({
             </div>
           ) : (
             <div>
-              <i className="fa fa-file-import" /> Import to new Workspace
+              <i className="fa fa-file-import" /> Import
             </div>
           )}
         </Button>

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -4,6 +4,7 @@ import { type DirectoryDropItem, type FileDropItem, OverlayContainer, useDrop } 
 import { Heading } from 'react-aria-components';
 import { useNavigate } from 'react-router';
 
+import { scopeToActivity } from '~/models/workspace';
 import { useImportResourcesFetcher } from '~/routes/import.resources';
 import { useScanResourcesFetcher } from '~/routes/import.scan';
 import { Checkbox } from '~/ui/components/base/checkbox';
@@ -216,10 +217,12 @@ export const ImportModal: FC<ImportModalProps> = ({
           requests: scanResourcesFetcherData.map(scanResult => scanResult.requests?.length || 0),
         },
       });
-      const workspaceId = importFetcher?.data?.workspaceId;
+      const workspace = importFetcher?.data?.workspace;
       const projectId = defaultProjectId || '';
-      workspaceId
-        ? navigate(`/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug`)
+      workspace
+        ? navigate(
+            `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/${scopeToActivity(workspace.scope)}`,
+          )
         : navigate(`/organization/${organizationId}/project/${projectId}`);
       modalRef.current?.hide();
     }


### PR DESCRIPTION
motivation: when importing a single workspace, we don't currently navigate to it.
Goal: in order to save a click for most use cases when we receive an import with a single workspace we will redirect to it.

Tested with a single curl request import, and a large collection.

```
insomniadev://app/import?curl=curl 'http://en.wikipedia.org/' \
    -H 'Accept-Encoding: gzip, deflate, sdch' \
    -H 'Accept-Language: en-US,en;q=0.8' \
    -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36' \
    -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' \
    -H 'Referer: http://www.wikipedia.org/' \
    -H 'Connection: keep-alive' --compressed
```

Notes
- Needed to update most of the tests to skip the navigate part after import.
- Renamed a test collection for clarity of debugging
- updated testing docs
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
