### PR TITLE
feat: Support delete cloud sync workspace locally or remotely

### DIFF
--- a/packages/insomnia-smoke-test/server/cloud-sync-api.ts
+++ b/packages/insomnia-smoke-test/server/cloud-sync-api.ts
@@ -287,6 +287,7 @@ const rawBlobs: Record<string, string> = {
     '{"_id":"mcp-req_18ee6d8bec7645ada7c4ac48d416bdb0","authentication":{},"connected":false,"created":1769408435331,"description":"","env":[],"headers":[{"name":"User-Agent","value":"insomnia/12.3.0"}],"mcpStdioAccess":false,"parentId":"wrk_efab8e758b97459bab2659d8fdcf8627","roots":[],"sslValidation":true,"subscribeResources":[],"transportType":"streamable-http","type":"McpRequest","url":"http://localhost:4010/mcp"}',
 };
 const defaultBranches = [{ name: 'master' }, { name: 'develop' }];
+const deletedProjectIds: string[] = [];
 let cloudSyncApiEnabled = false;
 let remoteHasNewCommit = false;
 
@@ -469,7 +470,7 @@ export default function setup(app: Application) {
           case 'projects': {
             return res.status(200).json({
               data: {
-                projects: cloudSyncProject,
+                projects: cloudSyncProject.filter(p => !deletedProjectIds.includes(p.id)),
               },
             });
           }
@@ -512,6 +513,10 @@ export default function setup(app: Application) {
         switch (operationName) {
           // delete project
           case 'projectArchive': {
+            const projectId = variables.id;
+            if (!deletedProjectIds.includes(projectId)) {
+              deletedProjectIds.push(projectId);
+            }
             return res.status(200).json({
               data: {
                 projectArchive: true,

--- a/packages/insomnia-smoke-test/server/cloud-sync-api.ts
+++ b/packages/insomnia-smoke-test/server/cloud-sync-api.ts
@@ -287,7 +287,7 @@ const rawBlobs: Record<string, string> = {
     '{"_id":"mcp-req_18ee6d8bec7645ada7c4ac48d416bdb0","authentication":{},"connected":false,"created":1769408435331,"description":"","env":[],"headers":[{"name":"User-Agent","value":"insomnia/12.3.0"}],"mcpStdioAccess":false,"parentId":"wrk_efab8e758b97459bab2659d8fdcf8627","roots":[],"sslValidation":true,"subscribeResources":[],"transportType":"streamable-http","type":"McpRequest","url":"http://localhost:4010/mcp"}',
 };
 const defaultBranches = [{ name: 'master' }, { name: 'develop' }];
-const deletedProjectIds: string[] = [];
+let deletedProjectIds: string[] = [];
 let cloudSyncApiEnabled = false;
 let remoteHasNewCommit = false;
 
@@ -307,6 +307,11 @@ export default function setup(app: Application) {
       return res.status(400).json({ error: 'enabled must be boolean value' });
     }
     cloudSyncApiEnabled = enabled;
+    if (!enabled) {
+      // clear the test data when cloud sync is disabled to avoid affecting other tests
+      deletedProjectIds = [];
+      remoteHasNewCommit = false;
+    }
     return res.status(200).send();
   });
 

--- a/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
@@ -147,7 +147,7 @@ test.describe('Cloud Sync', () => {
     // delete workspace locally
     await page.getByLabel('My Collection R1').getByTestId('DropdownButton').click();
     await page.getByRole('button', { name: 'Delete' }).click();
-    await page.getByText('Remove Local CopyThe project').click();
+    await page.getByText('Remove Local Copy').click();
     await page.getByRole('button', { name: 'Delete Workspace' }).click();
     // check workspace is deleted locally
     await expect.soft(page.getByLabel('Collection Project')).toBeVisible();

--- a/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
@@ -134,4 +134,37 @@ test.describe('Cloud Sync', () => {
       body: JSON.stringify({ enabled: false }),
     });
   });
+
+  test('Check delete workspace locally and remotely', async ({ page }) => {
+    //Sync collection project
+    await page.getByLabel('Collection Project').click();
+    // go back
+    await page
+      .locator('[data-icon="chevron-left"]')
+      .filter({ has: page.locator(':visible') })
+      .first()
+      .click();
+    // delete workspace locally
+    await page.getByLabel('My Collection R1').getByTestId('DropdownButton').click();
+    await page.getByRole('button', { name: 'Delete' }).click();
+    await page.getByText('Remove Local CopyThe project').click();
+    await page.getByRole('button', { name: 'Delete Workspace' }).click();
+    // check workspace is deleted locally
+    await expect.soft(page.getByLabel('Collection Project')).toBeVisible();
+    await expect.soft(page.getByLabel('My Collection R1')).toBeHidden();
+    // Sync collection project again
+    await page.getByLabel('Collection Project').click();
+    // go back
+    await page
+      .locator('[data-icon="chevron-left"]')
+      .filter({ has: page.locator(':visible') })
+      .first()
+      .click();
+    // delete workspace both locally and remotely
+    await page.getByLabel('My Collection R1').getByTestId('DropdownButton').click();
+    await page.getByRole('button', { name: 'Delete' }).click();
+    await page.getByRole('button', { name: 'Delete Workspace' }).click();
+    // check workspace is deleted remotely
+    await expect.soft(page.getByLabel('Collection Project')).toBeHidden();
+  });
 });

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.delete.tsx
@@ -67,7 +67,6 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
 
   const workspaceId = formData.get('workspaceId');
   const localOnly = formData.get('localOnly') === 'true';
-  console.log(`localOnly: ${localOnly}`);
   invariant(typeof workspaceId === 'string', 'Workspace ID is required');
 
   const workspace = await models.workspace.getById(workspaceId);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.delete.tsx
@@ -10,7 +10,7 @@ import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.delete';
 
-async function deleteWorkspaceFromCloud(workspace: Workspace, project: Project) {
+async function deleteCloudSyncWorkspaceCloud(workspace: Workspace, project: Project, localOnly: boolean) {
   const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(workspace._id);
   const isGitSync = !!workspaceMeta.gitRepositoryId;
 
@@ -18,7 +18,8 @@ async function deleteWorkspaceFromCloud(workspace: Workspace, project: Project) 
     try {
       const vcs = VCSInstance();
       await vcs.switchAndCreateBackendProjectIfNotExist(workspace._id, workspace.name);
-      await vcs.archiveProject();
+      // For cloud sync workspaces, delete only local file or also delete remote copy
+      await (localOnly ? vcs.removeBackendProjectsForRoot(workspace._id) : vcs.archiveProject());
     } catch (err) {
       return {
         error:
@@ -37,11 +38,11 @@ async function deleteWorkspaceFromLocal(workspace: Workspace) {
   await models.workspace.remove(workspace);
 }
 
-async function deleteWorkspace(workspace: Workspace | null, project: Project | null) {
+async function deleteWorkspace(workspace: Workspace | null, project: Project | null, localOnly: boolean) {
   invariant(workspace, 'Workspace not found');
   invariant(project, 'Project not found');
 
-  const ret = await deleteWorkspaceFromCloud(workspace, project);
+  const ret = await deleteCloudSyncWorkspaceCloud(workspace, project, localOnly);
   if (ret?.error) {
     return ret;
   }
@@ -65,12 +66,14 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
   const formData = await request.formData();
 
   const workspaceId = formData.get('workspaceId');
+  const localOnly = formData.get('localOnly') === 'true';
+  console.log(`localOnly: ${localOnly}`);
   invariant(typeof workspaceId === 'string', 'Workspace ID is required');
 
   const workspace = await models.workspace.getById(workspaceId);
   invariant(workspace, 'Workspace not found');
 
-  const msgObj = await deleteWorkspace(workspace, project);
+  const msgObj = await deleteWorkspace(workspace, project, localOnly);
 
   if (msgObj?.error) {
     return msgObj;
@@ -90,10 +93,13 @@ export const useWorkspaceDeleteActionFetcher = createFetcherSubmitHook(
       organizationId,
       projectId,
       workspaceId,
+      // for cloud sync workspaces, delete only local file or also delete remote copy
+      localOnly = 'true',
     }: {
       organizationId: string;
       projectId: string;
       workspaceId: string;
+      localOnly?: 'true' | 'false';
     }) => {
       const url = href('/organization/:organizationId/project/:projectId/workspace/delete', {
         organizationId,
@@ -102,6 +108,7 @@ export const useWorkspaceDeleteActionFetcher = createFetcherSubmitHook(
 
       const formData = new FormData();
       formData.append('workspaceId', workspaceId);
+      formData.append('localOnly', localOnly);
 
       return submit(formData, {
         action: url,

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.delete.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.delete.tsx
@@ -10,7 +10,7 @@ import { createFetcherSubmitHook } from '~/utils/router';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.delete';
 
-async function deleteCloudSyncWorkspaceCloud(workspace: Workspace, project: Project, localOnly: boolean) {
+async function deleteCloudSyncWorkspace(workspace: Workspace, project: Project, localOnly: boolean) {
   const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(workspace._id);
   const isGitSync = !!workspaceMeta.gitRepositoryId;
 
@@ -42,7 +42,7 @@ async function deleteWorkspace(workspace: Workspace | null, project: Project | n
   invariant(workspace, 'Workspace not found');
   invariant(project, 'Project not found');
 
-  const ret = await deleteCloudSyncWorkspaceCloud(workspace, project, localOnly);
+  const ret = await deleteCloudSyncWorkspace(workspace, project, localOnly);
   if (ret?.error) {
     return ret;
   }

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
@@ -312,24 +312,22 @@ export const WorkspaceCardDropdown: FC<Props> = props => {
                               aria-label="Remove Local Copy"
                               className="flex-1 rounded-sm border border-solid border-(--hl-md) p-4 transition-colors hover:bg-(--hl-xs) focus:bg-(--hl-sm) focus:outline-hidden data-disabled:opacity-25 data-selected:border-(--color-surprise) data-selected:ring-2 data-selected:ring-(--color-surprise)"
                             >
-                              <div className="flex items-center gap-2">
+                              <div>
                                 <Heading className="text-lg font-bold">Remove Local Copy</Heading>
+                                <p className="pt-2">The project will still exist on the Cloud.</p>
                               </div>
-                              <p className="pt-2">The project will still exist on the Cloud.</p>
                             </Radio>
                             <Radio
                               value="false"
                               aria-label="Delete Permanently"
                               className="flex-1 rounded-sm border border-solid border-(--hl-md) p-4 transition-colors hover:bg-(--hl-xs) focus:bg-(--hl-sm) focus:outline-hidden data-disabled:opacity-25 data-selected:border-(--color-surprise) data-selected:ring-2 data-selected:ring-(--color-surprise)"
                             >
-                              <div className="flex items-center gap-2">
-                                <Heading className="text-lg font-bold">
-                                  <span>Delete Permanently</span>
-                                </Heading>
+                              <div>
+                                <Heading className="text-lg font-bold">Delete Permanently</Heading>
+                                <p className="pt-2">
+                                  The project will be deleted everywhere. You cannot undo this action.
+                                </p>
                               </div>
-                              <p className="pt-2">
-                                The project will be deleted everywhere. You cannot undo this action.
-                              </p>
                             </Radio>
                           </div>
                         </RadioGroup>

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
@@ -299,7 +299,7 @@ export const WorkspaceCardDropdown: FC<Props> = props => {
                     className="flex flex-col gap-4"
                   >
                     <input type="hidden" name="workspaceId" value={workspace._id} />
-                    <p>
+                    <div>
                       This will permanently delete the{' '}
                       {<strong style={{ whiteSpace: 'pre-wrap' }}>{workspace?.name}</strong>}{' '}
                       {getWorkspaceLabel(workspace).singular}
@@ -332,7 +332,7 @@ export const WorkspaceCardDropdown: FC<Props> = props => {
                           </div>
                         </RadioGroup>
                       )}
-                    </p>
+                    </div>
                     {deleteWorkspaceFetcher.data && deleteWorkspaceFetcher.data.error && (
                       <p className="notice error margin-bottom-sm no-margin-top">{deleteWorkspaceFetcher.data.error}</p>
                     )}

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
@@ -4,7 +4,7 @@ import {
   exportMockServerToFile,
 } from 'insomnia/src/ui/components/settings/import-export';
 import React, { type FC, Fragment, useCallback, useState } from 'react';
-import { Button, Dialog, Heading, Modal, ModalOverlay } from 'react-aria-components';
+import { Button, Dialog, Heading, Label, Modal, ModalOverlay, Radio, RadioGroup } from 'react-aria-components';
 import { href, useParams } from 'react-router';
 
 import { useWorkspaceDeleteActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.delete';
@@ -302,7 +302,34 @@ export const WorkspaceCardDropdown: FC<Props> = props => {
                     <p>
                       This will permanently delete the{' '}
                       {<strong style={{ whiteSpace: 'pre-wrap' }}>{workspace?.name}</strong>}{' '}
-                      {getWorkspaceLabel(workspace).singular} {isRemoteProject(project) ? 'remotely' : ''}.
+                      {getWorkspaceLabel(workspace).singular}
+                      {isRemoteProject(project) && (
+                        <RadioGroup name="localOnly" defaultValue="false" className="mb-2 flex flex-col gap-2">
+                          <Label className="text-sm text-(--hl)">How do you want to delete it?</Label>
+                          <div className="flex gap-2">
+                            <Radio
+                              value="true"
+                              className="flex-1 rounded-sm border border-solid border-(--hl-md) p-4 transition-colors hover:bg-(--hl-xs) focus:bg-(--hl-sm) focus:outline-hidden data-disabled:opacity-25 data-selected:border-(--color-surprise) data-selected:ring-2 data-selected:ring-(--color-surprise)"
+                            >
+                              <div className="flex items-center gap-2">
+                                <Heading className="text-lg font-bold">Delete Local File</Heading>
+                              </div>
+                              <p className="pt-2">Delete only the local file.</p>
+                            </Radio>
+                            <Radio
+                              value="false"
+                              className="flex-1 rounded-sm border border-solid border-(--hl-md) p-4 transition-colors hover:bg-(--hl-xs) focus:bg-(--hl-sm) focus:outline-hidden data-disabled:opacity-25 data-selected:border-(--color-surprise) data-selected:ring-2 data-selected:ring-(--color-surprise)"
+                            >
+                              <div className="flex items-center gap-2">
+                                <Heading className="text-lg font-bold">
+                                  <span>Delete Local & Remote File</span>
+                                </Heading>
+                              </div>
+                              <p className="pt-2">Permanently removes from everywhere - local file and the cloud.</p>
+                            </Radio>
+                          </div>
+                        </RadioGroup>
+                      )}
                     </p>
                     {deleteWorkspaceFetcher.data && deleteWorkspaceFetcher.data.error && (
                       <p className="notice error margin-bottom-sm no-margin-top">{deleteWorkspaceFetcher.data.error}</p>

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
@@ -309,6 +309,7 @@ export const WorkspaceCardDropdown: FC<Props> = props => {
                           <div className="flex gap-2">
                             <Radio
                               value="true"
+                              aria-label="Remove Local Copy"
                               className="flex-1 rounded-sm border border-solid border-(--hl-md) p-4 transition-colors hover:bg-(--hl-xs) focus:bg-(--hl-sm) focus:outline-hidden data-disabled:opacity-25 data-selected:border-(--color-surprise) data-selected:ring-2 data-selected:ring-(--color-surprise)"
                             >
                               <div className="flex items-center gap-2">
@@ -318,6 +319,7 @@ export const WorkspaceCardDropdown: FC<Props> = props => {
                             </Radio>
                             <Radio
                               value="false"
+                              aria-label="Delete Permanently"
                               className="flex-1 rounded-sm border border-solid border-(--hl-md) p-4 transition-colors hover:bg-(--hl-xs) focus:bg-(--hl-sm) focus:outline-hidden data-disabled:opacity-25 data-selected:border-(--color-surprise) data-selected:ring-2 data-selected:ring-(--color-surprise)"
                             >
                               <div className="flex items-center gap-2">
@@ -339,6 +341,7 @@ export const WorkspaceCardDropdown: FC<Props> = props => {
                     <div className="flex justify-end">
                       <Button
                         type="submit"
+                        aria-label="Delete Workspace"
                         className="rounded-xs border border-solid border-(--hl-md) bg-(--color-danger) px-3 py-2 text-(--color-font-danger) transition-colors hover:bg-(--color-danger)/90 hover:no-underline"
                       >
                         Delete

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
@@ -312,9 +312,9 @@ export const WorkspaceCardDropdown: FC<Props> = props => {
                               className="flex-1 rounded-sm border border-solid border-(--hl-md) p-4 transition-colors hover:bg-(--hl-xs) focus:bg-(--hl-sm) focus:outline-hidden data-disabled:opacity-25 data-selected:border-(--color-surprise) data-selected:ring-2 data-selected:ring-(--color-surprise)"
                             >
                               <div className="flex items-center gap-2">
-                                <Heading className="text-lg font-bold">Delete Local File</Heading>
+                                <Heading className="text-lg font-bold">Remove Local Copy</Heading>
                               </div>
-                              <p className="pt-2">Delete only the local file.</p>
+                              <p className="pt-2">The project will still exist on the Cloud.</p>
                             </Radio>
                             <Radio
                               value="false"
@@ -322,10 +322,12 @@ export const WorkspaceCardDropdown: FC<Props> = props => {
                             >
                               <div className="flex items-center gap-2">
                                 <Heading className="text-lg font-bold">
-                                  <span>Delete Local & Remote File</span>
+                                  <span>Delete Permanently</span>
                                 </Heading>
                               </div>
-                              <p className="pt-2">Permanently removes from everywhere - local file and the cloud.</p>
+                              <p className="pt-2">
+                                The project will be deleted everywhere. You cannot undo this action.
+                              </p>
                             </Radio>
                           </div>
                         </RadioGroup>


### PR DESCRIPTION
Allow user to choose whether to delete local project or delete both local & remote project (default) when delete workspace in cloud sync projects.
<img width="595" height="341" alt="Screenshot 2026-02-05 at 11 04 28" src="https://github.com/user-attachments/assets/95d8bf9e-7cb4-46f8-b683-bc0457bd5186" />


[INS-1981](https://konghq.atlassian.net/browse/INS-1981)

[INS-1981]: https://konghq.atlassian.net/browse/INS-1981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ