### PR TITLE
fix: nowrap input prefixes [INS-2039]

### DIFF
--- a/packages/insomnia/src/ui/components/base/input.tsx
+++ b/packages/insomnia/src/ui/components/base/input.tsx
@@ -50,7 +50,7 @@ export const Input = ({
             )}
           >
             {prefix && (
-              <span className="flex h-full items-center border-r border-(--hl-sm) bg-(--hl-xs) px-2 text-sm text-(--hl)">
+              <span className="flex h-full shrink-0 items-center whitespace-nowrap border-r border-(--hl-sm) bg-(--hl-xs) px-2 text-sm text-(--hl)">
                 {prefix}
               </span>
             )}


### PR DESCRIPTION
<img width="667" height="167" alt="Screenshot 2026-01-30 at 13 23 44" src="https://github.com/user-attachments/assets/e31a8c08-9566-4404-a9ea-677c2d16be37" />
