### PR TITLE
fix: show static author email for all git auth types

### DIFF
--- a/packages/insomnia/src/ui/components/git/connection-info.tsx
+++ b/packages/insomnia/src/ui/components/git/connection-info.tsx
@@ -8,6 +8,7 @@ export const GitConnectionInfo = ({
   gitRepository,
   providerInfo,
   projectId,
+  authorEmail,
 }: {
   projectId?: string;
   gitRepository?: GitRepository;
@@ -15,6 +16,7 @@ export const GitConnectionInfo = ({
     iconName?: IconProp;
     displayName: string;
   };
+  authorEmail?: string;
 }) => {
   const [branch, setBranch] = useState('');
   useEffect(() => {
@@ -55,6 +57,12 @@ export const GitConnectionInfo = ({
           <div className="flex">
             <div className="w-[110px] font-semibold">Base Branch</div>
             <div>{branch}</div>
+          </div>
+        )}
+        {authorEmail && (
+          <div className="flex">
+            <div className="w-[110px] font-semibold">Author Email</div>
+            <div>{authorEmail}</div>
           </div>
         )}
       </div>

--- a/packages/insomnia/src/ui/components/git/connection-info.tsx
+++ b/packages/insomnia/src/ui/components/git/connection-info.tsx
@@ -8,7 +8,6 @@ export const GitConnectionInfo = ({
   gitRepository,
   providerInfo,
   projectId,
-  authorEmail,
 }: {
   projectId?: string;
   gitRepository?: GitRepository;
@@ -16,7 +15,6 @@ export const GitConnectionInfo = ({
     iconName?: IconProp;
     displayName: string;
   };
-  authorEmail?: string;
 }) => {
   const [branch, setBranch] = useState('');
   useEffect(() => {
@@ -57,12 +55,6 @@ export const GitConnectionInfo = ({
           <div className="flex">
             <div className="w-[110px] font-semibold">Base Branch</div>
             <div>{branch}</div>
-          </div>
-        )}
-        {authorEmail && (
-          <div className="flex">
-            <div className="w-[110px] font-semibold">Author Email</div>
-            <div>{authorEmail}</div>
           </div>
         )}
       </div>

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -290,6 +290,7 @@ export const ProjectSettingsForm: FC<Props> = ({
                 gitRepository={gitRepository}
                 providerInfo={selectedProvider}
                 projectId={project!._id}
+                authorEmail={showEmailSelector ? undefined : selectedCredential?.author.email}
               />
               {showEmailSelector && (
                 <div className="flex flex-col gap-2">

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -290,9 +290,8 @@ export const ProjectSettingsForm: FC<Props> = ({
                 gitRepository={gitRepository}
                 providerInfo={selectedProvider}
                 projectId={project!._id}
-                authorEmail={showEmailSelector ? undefined : selectedCredential?.author.email}
               />
-              {showEmailSelector && (
+              {showEmailSelector ? (
                 <div className="flex flex-col gap-2">
                   {isLoadingEmails ? (
                     <div className="flex items-center gap-2 text-sm">
@@ -370,7 +369,14 @@ export const ProjectSettingsForm: FC<Props> = ({
                     </div>
                   )}
                 </div>
-              )}
+              ) : selectedCredential?.author.email ? (
+                <div className="text-[12px]">
+                  <div className="flex">
+                    <div className="w-[110px] font-semibold">Author Email</div>
+                    <div>{selectedCredential?.author.email}</div>
+                  </div>
+                </div>
+              ) : null}
             </>
           )}
           {showGitRepoForm && (


### PR DESCRIPTION

<img width="672" height="478" alt="Screenshot 2026-02-03 at 09 33 24" src="https://github.com/user-attachments/assets/a7b3a0ba-4f1c-4d7d-a00a-38ac8eed6812" />
