### PR TITLE
fix: git project repo clear handling

### DIFF
--- a/packages/insomnia/src/ui/components/git-credentials/git-repository-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-repository-select.tsx
@@ -49,6 +49,10 @@ export const GitRepositorySelect = ({
         isRequired
         isDisabled={loading}
         onSelectionChange={key => {
+          if (!key) {
+            onSelect('');
+            return;
+          }
           const selectedRepository = repositories.find(r => r.cloneUrl === key);
           if (selectedRepository) {
             setCannotFindRepository(false);


### PR DESCRIPTION
Now correctly skips refetching (and clears) the branches if the repo select is cleared