### PR TITLE
fix: filter legacy credential

### DIFF
--- a/packages/insomnia/src/routes/git-credentials.tsx
+++ b/packages/insomnia/src/routes/git-credentials.tsx
@@ -1,13 +1,16 @@
 import { href, type LoaderFunctionArgs } from 'react-router';
 
 import { gitCredentials } from '~/models';
+import { isGitCredentialsV2 } from '~/models/git-credentials';
 import { createFetcherLoadHook } from '~/utils/router';
 
 export async function clientLoader(_args: LoaderFunctionArgs) {
   const credentials = await gitCredentials.all();
   const providers = await window.main.git.listGitProviders();
+  // Filter out only GitCredentialsV2 in case there are some legacy credentials in some edge cases (migration failed or user downgraded then upgraded again)
+  const gitCredentialsV2 = credentials.filter(credential => isGitCredentialsV2(credential));
 
-  return { credentials, providers };
+  return { credentials: gitCredentialsV2, providers };
 }
 
 export const useGitCredentialsLoaderFetcher = createFetcherLoadHook(

--- a/packages/insomnia/src/ui/components/project/git-repo-form.tsx
+++ b/packages/insomnia/src/ui/components/project/git-repo-form.tsx
@@ -22,7 +22,7 @@ import { GitRemoteBranchSelect } from '~/ui/components/git-credentials/git-remot
 import { GitRepositorySelect } from '~/ui/components/git-credentials/git-repository-select';
 import { showSettingsModal } from '~/ui/components/modals/settings-modal';
 
-import { type GitCredentials, isGitCredentialsV2, isOAuthCredential } from '../../../models/git-credentials';
+import { type GitCredentialsV2, isGitCredentialsV2, isOAuthCredential } from '../../../models/git-credentials';
 import { ErrorBoundary } from '../error-boundary';
 import type { ActiveView, ProjectData } from './utils';
 
@@ -34,7 +34,7 @@ const getDisplayValue = (fullUri: string | undefined, prefix: string | undefined
   return fullUri;
 };
 
-const getCredentialEmails = (credential: GitCredentials | undefined) => {
+const getCredentialEmails = (credential: GitCredentialsV2 | undefined) => {
   if (credential && isGitCredentialsV2(credential) && isOAuthCredential(credential)) {
     return credential.credentials?.emails || [];
   }
@@ -47,7 +47,7 @@ interface Props {
   initCloneGitRepositoryFetcher: ReturnType<typeof useGitProjectInitCloneActionFetcher>;
   organizationId: string;
   setActiveView: React.Dispatch<React.SetStateAction<ActiveView>>;
-  credentials: GitCredentials[];
+  credentials: GitCredentialsV2[];
   providers: GitProviderOption[];
   formId: string;
 }
@@ -144,7 +144,7 @@ export const GitRepoForm: FC<Props> = ({
           >
             <Label className="mb-2 px-0.5 pt-0 text-sm">Authorized as</Label>
             <Button className="flex w-full flex-1 items-center justify-between gap-2 rounded-xs border border-solid border-(--hl-sm) bg-(--color-bg) px-2 py-1 text-(--color-font) ring-1 ring-transparent transition-colors placeholder:italic hover:bg-(--hl-xs) focus:ring-1 focus:ring-(--hl-md) focus:outline-hidden focus:ring-inset aria-pressed:bg-(--hl-sm)">
-              <SelectValue<GitCredentials> className="flex items-center justify-center gap-2 truncate">
+              <SelectValue<GitCredentialsV2> className="flex items-center justify-center gap-2 truncate">
                 {({ selectedItem }) => {
                   if (selectedItem) {
                     const provider = providers.find(p => p.type === selectedItem.provider);

--- a/packages/insomnia/src/ui/components/project/project-create-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-create-form.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { Button, Input, Label, TextField } from 'react-aria-components';
 import { useParams } from 'react-router';
 
-import type { GitCredentials } from '~/models/git-credentials';
+import type { GitCredentialsV2 } from '~/models/git-credentials';
 import { type StorageRules } from '~/models/organization';
 import { useGitProjectInitCloneActionFetcher } from '~/routes/git.init-clone';
 import { useProjectNewActionFetcher } from '~/routes/organization.$organizationId.project.new';
@@ -24,7 +24,7 @@ interface Props {
   defaultProjectName?: string;
   onCancel?(): void;
   activeViewObj?: ReturnType<typeof useActiveView>;
-  credentials: GitCredentials[];
+  credentials: GitCredentialsV2[];
   providers: GitProviderOption[];
 }
 

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -17,7 +17,7 @@ import { Banner } from '~/basic-components/banner';
 import { Divider } from '~/basic-components/divider';
 import { LearnMoreLink } from '~/basic-components/link';
 import {
-  type GitCredentials,
+  type GitCredentialsV2,
   isGitCredentialsV2,
   isOAuthCredential,
   type ProviderEmail,
@@ -71,7 +71,7 @@ interface Props {
   defaultProjectName?: string;
   onCancel?(): void;
   onSuccessUpdate?(): void;
-  credentials: GitCredentials[];
+  credentials: GitCredentialsV2[];
   providers: GitProviderOption[];
 }
 


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

> In some edge cases (migration failed or user downgrade then upgrade again), there will be some legacy format git credentials.

Filter legacy Git credentials in credentials list