### PR TITLE
feat: lower Import UX friction

### DIFF
--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -618,7 +618,7 @@ export const importResourcesToNewWorkspace = async ({
     });
   } else {
     newWorkspace = await models.workspace.create({
-      name: workspaceToImport?.name || 'Imported Workspace',
+      name: workspaceToImport?.name || 'Imported Collection',
       scope: workspaceToImport?.scope || 'collection',
       parentId: projectId,
     });

--- a/packages/insomnia/src/main/importers/entities.ts
+++ b/packages/insomnia/src/main/importers/entities.ts
@@ -1,23 +1,12 @@
 import type * as Har from 'har-format';
 
+import type { RequestAuthentication } from '~/models/request';
+
 export interface Comment {
   comment?: string;
 }
 
 export type Variable = `{{ ${string} }}`;
-
-export interface Authentication extends Comment {
-  authorizationUrl?: string;
-  accessTokenUrl?: string;
-  clientId?: string;
-  clientSecret?: Variable;
-  scope?: string;
-  type?: 'basic' | 'oauth2';
-  grantType?: 'authorization_code' | 'password' | 'client_credentials';
-  disabled?: boolean;
-  username?: string;
-  password?: string;
-}
 
 export interface Parameter extends Comment {
   name: string;
@@ -62,7 +51,7 @@ export interface ImportRequest extends Comment {
   _id?: string;
   // @TODO Fix me
   _type?: string;
-  authentication?: Authentication;
+  authentication?: RequestAuthentication | {};
   body?: Body;
   cookies?: Cookie[];
   environment?: {};

--- a/packages/insomnia/src/main/importers/importers/__snapshots__/index.test.ts.snap
+++ b/packages/insomnia/src/main/importers/importers/__snapshots__/index.test.ts.snap
@@ -12,6 +12,7 @@ exports[`Fixtures > Import curl > complex-input.sh 1`] = `
       "_type": "request",
       "authentication": {
         "password": "My:Secret:Password",
+        "type": "basic",
         "username": "My User",
       },
       "body": {

--- a/packages/insomnia/src/main/importers/importers/curl.test.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { convert } from './curl';
+import { convert, name } from './curl';
 
 describe('curl', () => {
   const testCases = [
@@ -209,6 +209,7 @@ describe('curl', () => {
       curl: "curl https://example.com    -H 'Content-Type:application/x-www-form-urlencoded'",
       expected: { headers: [{ name: 'Content-Type', value: 'application/x-www-form-urlencoded' }] },
     },
+    // auth
     {
       name: 'should handle -u for basic auth',
       curl: 'curl https://example.com -u username:password',
@@ -218,6 +219,14 @@ describe('curl', () => {
       name: 'should handle --user for basic auth',
       curl: 'curl https://example.com --user username:password',
       expected: { authentication: { username: 'username', password: 'password' } },
+    },
+    {
+      name: 'should handle bearer',
+      curl: `curl http://httpbin.org/get -H 'Authorization: Bearer mytoken123'`,
+      expected: {
+        authentication: { type: 'bearer', token: 'mytoken123' },
+        headers: [],
+      },
     },
   ];
 

--- a/packages/insomnia/src/main/importers/importers/curl.test.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.test.ts
@@ -1,263 +1,223 @@
-import { quote } from 'shell-quote';
 import { describe, expect, it } from 'vitest';
 
-import type { Parameter } from '../entities';
 import { convert } from './curl';
 
 describe('curl', () => {
-  describe("cURL --data flags -H 'Content-Type: application/x-www-form-urlencoded'", () => {
-    it.each([
-      // -d
-      { flag: '-d', inputs: ['key=value'], expected: [{ name: 'key', value: 'value' }] },
-      { flag: '-d', inputs: ['value'], expected: [{ name: '', value: 'value' }] },
-      { flag: '-d', inputs: ['@filename'], expected: [{ name: '', fileName: 'filename', type: 'file' }] },
-      {
-        flag: '-d',
-        inputs: ['first=1', 'second=2', 'third'],
-        expected: [
-          { name: 'first', value: '1' },
-          {
-            name: 'second',
-            value: '2',
-          },
-          { name: '', value: 'third' },
-        ],
+  const testCases = [
+    // --data flags with urlencoded content type
+    {
+      name: 'should handle -d with key=value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' -d 'key=value'",
+      expected: { body: { params: [{ name: 'key', value: 'value' }] } },
+    },
+    {
+      name: 'should handle -d with only a value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' -d 'value'",
+      expected: { body: { params: [{ name: '', value: 'value' }] } },
+    },
+    {
+      name: 'should handle -d with @filename',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' -d '@filename'",
+      expected: { body: { params: [{ name: '', fileName: 'filename', type: 'file' }] } },
+    },
+    {
+      name: 'should handle multiple -d flags',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' -d 'first=1' -d 'second=2' -d 'third'",
+      expected: {
+        body: {
+          params: [
+            { name: 'first', value: '1' },
+            { name: 'second', value: '2' },
+            { name: '', value: 'third' },
+          ],
+        },
       },
-      {
-        flag: '-d',
-        inputs: ['first=1&second=2'],
-        expected: [
-          { name: 'first', value: '1' },
-          { name: 'second', value: '2' },
-        ],
+    },
+    {
+      name: 'should handle -d with url-encoded ampersand',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' -d 'first=1&second=2'",
+      expected: {
+        body: {
+          params: [
+            { name: 'first', value: '1' },
+            { name: 'second', value: '2' },
+          ],
+        },
       },
-      { flag: '-d', inputs: ['%3D'], expected: [{ name: '', value: '=' }] },
-      { flag: '--d', inputs: ['%3D=%3D'], expected: [{ name: '=', value: '=' }] },
+    },
+    {
+      name: 'should handle -d with encoded equals sign',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' -d '%3D'",
+      expected: { body: { params: [{ name: '', value: '=' }] } },
+    },
+    {
+      name: 'should handle --d with encoded equals signs in key and value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --d '%3D=%3D'",
+      expected: { body: { params: [{ name: '=', value: '=' }] } },
+    },
+    // --data
+    {
+      name: 'should handle --data with key=value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data 'key=value'",
+      expected: { body: { params: [{ name: 'key', value: 'value' }] } },
+    },
+    {
+      name: 'should handle --data with only a value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data 'value'",
+      expected: { body: { params: [{ name: '', value: 'value' }] } },
+    },
+    {
+      name: 'should handle --data with @filename',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data '@filename'",
+      expected: { body: { params: [{ name: '', fileName: 'filename' }] } },
+    },
+    {
+      name: 'should handle multiple --data flags',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data 'first=1' --data 'second=2' --data 'third'",
+      expected: {
+        body: {
+          params: [
+            { name: 'first', value: '1' },
+            { name: 'second', value: '2' },
+            { name: '', value: 'third' },
+          ],
+        },
+      },
+    },
+    {
+      name: 'should handle --data with url-encoded ampersand',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data 'first=1&second=2'",
+      expected: {
+        body: {
+          params: [
+            { name: 'first', value: '1' },
+            { name: 'second', value: '2' },
+          ],
+        },
+      },
+    },
+    {
+      name: 'should handle --data with base64 value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data 'base64=SGVsbG8='",
+      expected: { body: { params: [{ name: 'base64', value: 'SGVsbG8=' }] } },
+    },
+    // --data-ascii
+    {
+      name: 'should handle --data-ascii with key=value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data-ascii 'key=value'",
+      expected: { body: { params: [{ name: 'key', value: 'value' }] } },
+    },
+    {
+      name: 'should handle --data-ascii with @filename',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data-ascii '@filename'",
+      expected: { body: { params: [{ name: '', fileName: 'filename', type: 'file' }] } },
+    },
+    // --data-binary
+    {
+      name: 'should handle --data-binary with key=value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data-binary 'key=value'",
+      expected: { body: { params: [{ name: 'key', value: 'value' }] } },
+    },
+    {
+      name: 'should handle --data-binary with @filename',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data-binary '@filename'",
+      expected: { body: { params: [{ name: '', fileName: 'filename', type: 'file' }] } },
+    },
+    {
+      name: 'should handle --data-binary with JSON string',
+      curl: 'curl -X POST https://example.com -H \'Content-Type: application/x-www-form-urlencoded\' --data-binary \'{"foo":"sGrG5sXDP5vX=p41h9tBcaQ==","bar":"123"}\'',
+      expected: { body: { params: [{ name: '{"foo":"sGrG5sXDP5vX', value: 'p41h9tBcaQ==","bar":"123"}' }] } },
+    },
+    {
+      name: 'should handle --data-binary with multiple equals signs',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data-binary 'key=value=with=equals'",
+      expected: { body: { params: [{ name: 'key', value: 'value=with=equals' }] } },
+    },
+    // --data-raw
+    {
+      name: 'should handle --data-raw with @filename literally',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data-raw '@filename'",
+      expected: { body: { params: [{ name: '', value: '@filename' }] } },
+    },
+    {
+      name: 'should handle --data-raw with key=value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data-raw 'key=value'",
+      expected: { body: { params: [{ name: 'key', value: 'value' }] } },
+    },
+    // --data-urlencode
+    {
+      name: 'should handle --data-urlencode with key=value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode 'key=value'",
+      expected: { body: { params: [{ name: 'key', value: 'value' }] } },
+    },
+    {
+      name: 'should handle --data-urlencode with key@filename',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode 'key@filename'",
+      expected: { body: { params: [{ name: 'key', fileName: 'filename', type: 'file' }] } },
+    },
+    {
+      name: 'should handle --data-urlencode with =value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode '=value'",
+      expected: { body: { params: [{ name: '', value: 'value' }] } },
+    },
+    {
+      name: 'should handle --data-urlencode with special characters',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode ' '",
+      expected: { body: { params: [{ name: '', value: ' ' }] } },
+    },
+    {
+      name: 'should handle --data-urlencode with only equals',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode '='",
+      expected: { body: { params: [{ name: '', value: '' }] } },
+    },
+    {
+      name: 'should handle --data-urlencode with encoded equals',
+      curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data-urlencode '%3D'",
+      expected: { body: { params: [{ name: '', value: '%3D' }] } },
+    },
 
-      // --data
-      { flag: '--data', inputs: ['key=value'], expected: [{ name: 'key', value: 'value' }] },
-      { flag: '--data', inputs: ['value'], expected: [{ name: '', value: 'value' }] },
-      { flag: '--data', inputs: ['@filename'], expected: [{ name: '', fileName: 'filename' }] },
-      {
-        flag: '--data',
-        inputs: ['first=1', 'second=2', 'third'],
-        expected: [
-          { name: 'first', value: '1' },
-          {
-            name: 'second',
-            value: '2',
-          },
-          { name: '', value: 'third' },
-        ],
-      },
-      {
-        flag: '--data',
-        inputs: ['first=1&second=2'],
-        expected: [
-          { name: 'first', value: '1' },
-          { name: 'second', value: '2' },
-        ],
-      },
-      { flag: '--data', inputs: ['%3D'], expected: [{ name: '', value: '=' }] },
-      { flag: '--data', inputs: ['%3D=%3D'], expected: [{ name: '=', value: '=' }] },
-      { flag: '--data', inputs: ['base64=SGVsbG8='], expected: [{ name: 'base64', value: 'SGVsbG8=' }] },
+    // --data flags without urlencoded content type
+    {
+      name: 'should handle -d as raw text body',
+      curl: "curl -X POST https://example.com -d 'key=value'",
+      expected: { body: { text: 'key=value' } },
+    },
 
-      // --data-ascii
-      { flag: '--data-ascii', inputs: ['key=value'], expected: [{ name: 'key', value: 'value' }] },
-      { flag: '--data-ascii', inputs: ['value'], expected: [{ name: '', value: 'value' }] },
-      { flag: '--data-ascii', inputs: ['@filename'], expected: [{ name: '', fileName: 'filename', type: 'file' }] },
-      {
-        flag: '--data-ascii',
-        inputs: ['first=1', 'second=2', 'third'],
-        expected: [
-          { name: 'first', value: '1' },
-          {
-            name: 'second',
-            value: '2',
-          },
-          { name: '', value: 'third' },
-        ],
-      },
-      {
-        flag: '--data-ascii',
-        inputs: ['first=1&second=2'],
-        expected: [
-          { name: 'first', value: '1' },
-          { name: 'second', value: '2' },
-        ],
-      },
+    // -H flags
+    {
+      name: 'should handle -H with space after colon',
+      curl: "curl https://example.com -H 'X-Host: example.com'",
+      expected: { headers: [{ name: 'X-Host', value: 'example.com' }] },
+    },
+    {
+      name: 'should handle -H with no space after colon',
+      curl: "curl https://example.com -H 'X-Host:example.com'",
+      expected: { headers: [{ name: 'X-Host', value: 'example.com' }] },
+    },
+    {
+      name: 'should handle -H for Content-Type',
+      curl: "curl https://example.com -H 'Content-Type:application/x-www-form-urlencoded'",
+      expected: { headers: [{ name: 'Content-Type', value: 'application/x-www-form-urlencoded' }] },
+    },
+    {
+      name: 'should handle -H with leading spaces before flag',
+      curl: "curl https://example.com    -H 'Content-Type:application/x-www-form-urlencoded'",
+      expected: { headers: [{ name: 'Content-Type', value: 'application/x-www-form-urlencoded' }] },
+    },
+    {
+      name: 'should handle -u for basic auth',
+      curl: 'curl https://example.com -u username:password',
+      expected: { authentication: { username: 'username', password: 'password' } },
+    },
+    {
+      name: 'should handle --user for basic auth',
+      curl: 'curl https://example.com --user username:password',
+      expected: { authentication: { username: 'username', password: 'password' } },
+    },
+  ];
 
-      // --data-binary
-      { flag: '--data-binary', inputs: ['key=value'], expected: [{ name: 'key', value: 'value' }] },
-      { flag: '--data-binary', inputs: ['value'], expected: [{ name: '', value: 'value' }] },
-      { flag: '--data-binary', inputs: ['@filename'], expected: [{ name: '', fileName: 'filename', type: 'file' }] },
-      {
-        flag: '--data-binary',
-        inputs: ['first=1', 'second=2', 'third'],
-        expected: [
-          { name: 'first', value: '1' },
-          {
-            name: 'second',
-            value: '2',
-          },
-          { name: '', value: 'third' },
-        ],
-      },
-      {
-        flag: '--data-binary',
-        inputs: ['first=1&second=2'],
-        expected: [
-          { name: 'first', value: '1' },
-          { name: 'second', value: '2' },
-        ],
-      },
-      {
-        flag: '--data-binary',
-        inputs: ['{"foo":"sGrG5sXDP5vX=p41h9tBcaQ==","bar":"123"}'],
-        expected: [{ name: '{"foo":"sGrG5sXDP5vX', value: 'p41h9tBcaQ==","bar":"123"}' }],
-      },
-      {
-        flag: '--data-binary',
-        inputs: ['key=value=with=equals'],
-        expected: [{ name: 'key', value: 'value=with=equals' }],
-      },
-
-      // --data-raw
-      { flag: '--data-raw', inputs: ['@filename'], expected: [{ name: '', value: '@filename' }] },
-      { flag: '--data-raw', inputs: ['key=value'], expected: [{ name: 'key', value: 'value' }] },
-      {
-        flag: '--data-raw',
-        inputs: ['first=1', 'second=2', 'third'],
-        expected: [
-          { name: 'first', value: '1' },
-          {
-            name: 'second',
-            value: '2',
-          },
-          { name: '', value: 'third' },
-        ],
-      },
-      {
-        flag: '--data-raw',
-        inputs: ['first=1&second=2'],
-        expected: [
-          { name: 'first', value: '1' },
-          { name: 'second', value: '2' },
-        ],
-      },
-
-      // --data-urlencode
-      { flag: '--data-urlencode', inputs: ['key=value'], expected: [{ name: 'key', value: 'value' }] },
-      {
-        flag: '--data-urlencode',
-        inputs: ['key@filename'],
-        expected: [{ name: 'key', fileName: 'filename', type: 'file' }],
-      },
-      {
-        flag: '--data-urlencode',
-        inputs: ['first=1', 'second=2', 'third'],
-        expected: [
-          { name: 'first', value: '1' },
-          {
-            name: 'second',
-            value: '2',
-          },
-          { name: '', value: 'third' },
-        ],
-      },
-      {
-        flag: '--data-urlencode',
-        inputs: ['first=1&second=2'],
-        expected: [
-          { name: 'first', value: '1' },
-          { name: 'second', value: '2' },
-        ],
-      },
-      { flag: '--data-urlencode', inputs: ['=value'], expected: [{ name: '', value: 'value' }] },
-
-      // --data-urlencode URI encoding
-      { flag: '--data-urlencode', inputs: ['a='], expected: [{ name: 'a', value: '' }] },
-      { flag: '--data-urlencode', inputs: [' '], expected: [{ name: '', value: ' ' }] },
-      { flag: '--data-urlencode', inputs: ['<'], expected: [{ name: '', value: '<' }] },
-      { flag: '--data-urlencode', inputs: ['>'], expected: [{ name: '', value: '>' }] },
-      { flag: '--data-urlencode', inputs: ['?'], expected: [{ name: '', value: '?' }] },
-      { flag: '--data-urlencode', inputs: ['['], expected: [{ name: '', value: '[' }] },
-      { flag: '--data-urlencode', inputs: [']'], expected: [{ name: '', value: ']' }] },
-      { flag: '--data-urlencode', inputs: ['|'], expected: [{ name: '', value: '|' }] },
-      { flag: '--data-urlencode', inputs: ['^'], expected: [{ name: '', value: '^' }] },
-      { flag: '--data-urlencode', inputs: ['"'], expected: [{ name: '', value: '"' }] },
-      { flag: '--data-urlencode', inputs: ['='], expected: [{ name: '', value: '' }] },
-      { flag: '--data-urlencode', inputs: ['%3D'], expected: [{ name: '', value: '%3D' }] },
-    ])(
-      'handles %p correctly',
-      async ({ flag, inputs, expected }: { flag: string; inputs: string[]; expected: Parameter[] }) => {
-        const flaggedInputs = inputs.map(input => `${flag} ${quote([input])}`).join(' ');
-        const rawData = `curl -X POST https://example.com 
-      -H 'Content-Type: application/x-www-form-urlencoded'
-      ${flaggedInputs}
-      `;
-
-        expect(convert(rawData)).toMatchObject([
-          {
-            body: {
-              params: expected,
-            },
-          },
-        ]);
-      },
-    );
-  });
-
-  describe('cURL --data flags', () => {
-    it.each([{ flag: '-d', inputs: ['key=value'], expected: 'key=value' }])(
-      'handles %p correctly',
-      async ({ flag, inputs, expected }: { flag: string; inputs: string[]; expected: string }) => {
-        const flaggedInputs = inputs.map(input => `${flag} ${quote([input])}`).join(' ');
-        const rawData = `curl -X POST https://example.com 
-      ${flaggedInputs}
-      `;
-
-        expect(convert(rawData)).toMatchObject([
-          {
-            body: {
-              text: expected,
-            },
-          },
-        ]);
-      },
-    );
-  });
-
-  describe('cURL -H flags', () => {
-    it.each([
-      { flag: '-H', inputs: ['X-Host: example.com'], expected: [{ name: 'X-Host', value: 'example.com' }] },
-      { flag: '-H', inputs: ['X-Host:example.com'], expected: [{ name: 'X-Host', value: 'example.com' }] },
-      {
-        flag: '-H',
-        inputs: ['Content-Type:application/x-www-form-urlencoded'],
-        expected: [{ name: 'Content-Type', value: 'application/x-www-form-urlencoded' }],
-      },
-      {
-        flag: '   -H',
-        inputs: ['Content-Type:application/x-www-form-urlencoded'],
-        expected: [{ name: 'Content-Type', value: 'application/x-www-form-urlencoded' }],
-      },
-      {
-        flag: ' -H',
-        inputs: ['Content-Type:application/x-www-form-urlencoded'],
-        expected: [{ name: 'Content-Type', value: 'application/x-www-form-urlencoded' }],
-      },
-    ])(
-      'handles %p correctly',
-      async ({ flag, inputs, expected }: { flag: string; inputs: string[]; expected: Parameter[] }) => {
-        const flaggedInputs = inputs.map(input => `${flag} ${quote([input])}`).join(' ');
-        const rawData = `curl https://example.com ${flaggedInputs}`;
-        expect(convert(rawData)).toMatchObject([
-          {
-            headers: expected,
-          },
-        ]);
-      },
-    );
+  it.each(testCases)('$name', ({ curl, expected }) => {
+    const result = convert(curl);
+    expect(result).toMatchObject([expected]);
   });
 });

--- a/packages/insomnia/src/main/importers/importers/curl.test.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { convert, name } from './curl';
+import { convert } from './curl';
 
 describe('curl', () => {
   const testCases = [

--- a/packages/insomnia/src/main/importers/importers/curl.test.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.test.ts
@@ -57,6 +57,11 @@ describe('curl', () => {
     },
     // --data
     {
+      name: 'should handle --data with json string',
+      curl: `curl -X POST http://httpbin.org/post -H 'Content-Type: application/json' -H 'Accept: application/json' -H 'X-Request-ID: abc123' -d '{"user":{"name":"John","email":"john@example.com"}}'`,
+      expected: { body: { text: '{"user":{"name":"John","email":"john@example.com"}}' } },
+    },
+    {
       name: 'should handle --data with key=value',
       curl: "curl -X POST https://example.com -H 'Content-Type: application/x-www-form-urlencoded' --data 'key=value'",
       expected: { body: { params: [{ name: 'key', value: 'value' }] } },
@@ -125,8 +130,8 @@ describe('curl', () => {
     },
     {
       name: 'should handle --data-binary with JSON string',
-      curl: 'curl -X POST https://example.com -H \'Content-Type: application/x-www-form-urlencoded\' --data-binary \'{"foo":"sGrG5sXDP5vX=p41h9tBcaQ==","bar":"123"}\'',
-      expected: { body: { params: [{ name: '{"foo":"sGrG5sXDP5vX', value: 'p41h9tBcaQ==","bar":"123"}' }] } },
+      curl: `curl -X POST https://example.com -H 'Content-Type: application/json' --data-binary '{"foo":"sGrG5sXDP5vX=p41h9tBcaQ==","bar":"123"}'`,
+      expected: { body: { text: '{"foo":"sGrG5sXDP5vX=p41h9tBcaQ==","bar":"123"}' } },
     },
     {
       name: 'should handle --data-binary with multiple equals signs',

--- a/packages/insomnia/src/main/importers/importers/curl.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.ts
@@ -32,11 +32,9 @@ const SUPPORTED_ARGS = [
   'X',
 ];
 
-type Pair = string | boolean;
+type PairsByName = Record<string, (string | boolean)[]>;
 
-type PairsByName = Record<string, Pair[]>;
-
-const importCommand = (parseEntries: ParseEntry[]): ImportRequest => {
+const importCommand = (parseEntries: ParseEntry[]) => {
   // ~~~~~~~~~~~~~~~~~~~~~ //
   // Collect all the flags //
   // ~~~~~~~~~~~~~~~~~~~~~ //
@@ -83,39 +81,34 @@ const importCommand = (parseEntries: ParseEntry[]): ImportRequest => {
       singletons.push(parseEntry);
     }
   }
-
-  // ~~~~~~~~~~~~~~~~~ //
-  // Build the request //
-  // ~~~~~~~~~~~~~~~~~ //
-
-  /// /////// Url & parameters //////////
-  let parameters: Parameter[] = [];
-  let url = '';
-
+  return { pairsByName, singletons };
+};
+const extractUrlAndParameters = (urlValue: string): { url: string; parameters: Parameter[] } => {
   try {
-    const urlValue = getPairValue(pairsByName, (singletons[0] as string) || '', ['url']);
     const { searchParams, href, search } = new URL(urlValue);
-    parameters = Array.from(searchParams.entries()).map(([name, value]) => ({
+    const parameters = Array.from(searchParams.entries()).map(([name, value]) => ({
       name,
       value,
       disabled: false,
     }));
-
-    url = href.replace(search, '').replace(/\/$/, '');
-  } catch {}
-
-  /// /////// Authentication //////////
+    const url = href.replace(search, '').replace(/\/$/, '');
+    return { url, parameters };
+  } catch {
+    return { url: '', parameters: [] };
+  }
+};
+const extractAuth = (pairsByName: PairsByName) => {
   const [username, password] = getPairValue(pairsByName, '', ['u', 'user']).split(/:(.*)$/);
 
-  const authentication = username
+  return username
     ? {
         username: username.trim(),
         password: password.trim(),
       }
     : {};
-
-  /// /////// Headers //////////
-  const headers = [
+};
+const extractHeaders = (pairsByName: PairsByName) => {
+  return [
     ...((pairsByName.header as string[] | undefined) || []),
     ...((pairsByName.H as string[] | undefined) || []),
   ].map(header => {
@@ -132,35 +125,21 @@ const importCommand = (parseEntries: ParseEntry[]): ImportRequest => {
       value: value.trim(),
     };
   });
-
-  /// /////// Cookies //////////
-  const cookieHeaderValue = [
-    ...((pairsByName.cookie as string[] | undefined) || []),
-    ...((pairsByName.b as string[] | undefined) || []),
-  ]
+};
+const extractCookieHeaderValue = (pairsByName: PairsByName) => {
+  return [...((pairsByName.cookie as string[] | undefined) || []), ...((pairsByName.b as string[] | undefined) || [])]
     .map(str => {
       const name = str.split('=', 1)[0];
       const value = str.replace(`${name}=`, '');
       return `${name}=${value}`;
     })
     .join('; ');
-
-  // Convert cookie value to header
-  const existingCookieHeader = headers.find(header => header.name.toLowerCase() === 'cookie');
-
-  if (cookieHeaderValue && existingCookieHeader) {
-    // Has existing cookie header, so let's update it
-    existingCookieHeader.value += `; ${cookieHeaderValue}`;
-  } else if (cookieHeaderValue) {
-    // No existing cookie header, so let's make a new one
-    headers.push({
-      name: 'Cookie',
-      value: cookieHeaderValue,
-    });
-  }
-
-  /// /////// Body (Text or Blob) //////////
-  const dataParameters = pairsToDataParameters(pairsByName);
+};
+const extractBody = (
+  dataParameters: Parameter[],
+  pairsByName: PairsByName,
+  headers: { name: string; value: string }[],
+) => {
   const contentTypeHeader = headers.find(header => header.name.toLowerCase() === 'content-type');
   const mimeType = contentTypeHeader ? contentTypeHeader.value.split(';')[0] : null;
 
@@ -185,14 +164,8 @@ const importCommand = (parseEntries: ParseEntry[]): ImportRequest => {
     return item;
   });
 
-  /// /////// Body //////////
-  let body = {};
-  const bodyAsGET = getPairValue(pairsByName, false, ['G', 'get']);
-
-  if (dataParameters.length !== 0 && bodyAsGET) {
-    parameters.push(...dataParameters);
-  } else if (dataParameters.length !== 0 && mimeType === 'application/x-www-form-urlencoded') {
-    body = {
+  if (dataParameters.length !== 0 && mimeType === 'application/x-www-form-urlencoded') {
+    return {
       mimeType,
       params: dataParameters.map(parameter => ({
         ...parameter,
@@ -201,26 +174,62 @@ const importCommand = (parseEntries: ParseEntry[]): ImportRequest => {
       })),
     };
   } else if (dataParameters.length !== 0) {
-    body = {
+    return {
       text: dataParameters
         .map(parameter => (parameter.name ? `${parameter.name}=${parameter.value}` : parameter.value))
         .join('&'),
       mimeType: mimeType || '',
     };
   } else if (formDataParams.length) {
-    body = {
+    return {
       params: formDataParams,
       mimeType: mimeType || 'multipart/form-data',
     };
   }
-
-  /// /////// Method //////////
+  return {};
+};
+const extractMethod = (pairsByName: PairsByName, body: any) => {
   let method = getPairValue(pairsByName, '__UNSET__', ['X', 'request']).toUpperCase();
 
   if (method === '__UNSET__' && body) {
     method = 'text' in body || 'params' in body ? 'POST' : 'GET';
   }
+  return method;
+};
 
+const buildRequestObject = ({
+  pairsByName,
+  singletons,
+}: {
+  pairsByName: PairsByName;
+  singletons: ParseEntry[];
+}): ImportRequest => {
+  const urlValue = getPairValue(pairsByName, (singletons[0] as string) || '', ['url']);
+  const { url, parameters } = extractUrlAndParameters(urlValue);
+
+  const authentication = extractAuth(pairsByName);
+  const headers = extractHeaders(pairsByName);
+  const cookieHeaderValue = extractCookieHeaderValue(pairsByName);
+  // Convert cookie value to header
+  const existingCookieHeader = headers.find(header => header.name.toLowerCase() === 'cookie');
+  if (cookieHeaderValue && existingCookieHeader) {
+    // Has existing cookie header, so let's update it
+    existingCookieHeader.value += `; ${cookieHeaderValue}`;
+  } else if (cookieHeaderValue) {
+    // No existing cookie header, so let's make a new one
+    headers.push({
+      name: 'Cookie',
+      value: cookieHeaderValue,
+    });
+  }
+  const dataParameters = pairsToDataParameters(pairsByName);
+  let body = {};
+  if (dataParameters.length !== 0 && getPairValue(pairsByName, false, ['G', 'get'])) {
+    parameters.push(...dataParameters);
+  } else {
+    body = extractBody(dataParameters, pairsByName, headers);
+  }
+  const method = extractMethod(pairsByName, body);
   const count = requestCount++;
   return {
     _id: `__REQ_${count}__`,
@@ -327,7 +336,7 @@ const pairsToDataParameters = (keyedPairs: PairsByName): Parameter[] => {
  * @param pair command line value
  * @param allowFiles whether to allow the `@` to support include files
  */
-const pairToParameters = (pair: Pair, allowFiles = false): Parameter[] => {
+const pairToParameters = (pair: string | boolean, allowFiles = false): Parameter[] => {
   if (typeof pair === 'boolean') {
     return [{ name: '', value: pair.toString() }];
   }
@@ -419,7 +428,10 @@ export const convert: Converter = rawData => {
   // Push the last unfinished command
   commands.push(currentCommand);
 
-  const requests: ImportRequest[] = commands.filter(command => command[0] === 'curl').map(importCommand);
+  const requests: ImportRequest[] = commands
+    .filter(command => command[0] === 'curl')
+    .map(importCommand)
+    .map(buildRequestObject);
 
   return requests;
 };

--- a/packages/insomnia/src/main/importers/importers/curl.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.ts
@@ -117,6 +117,7 @@ const extractAuth = (pairsByName: PairsByName): RequestAuthentication | {} => {
 };
 const extractHeaders = (pairsByName: PairsByName) => {
   return [...((pairsByName.header as string[] | undefined) || []), ...((pairsByName.H as string[] | undefined) || [])]
+    .filter(header => header.includes(':'))
     .filter(header => {
       const [name, value] = header.split(/:(.*)$/);
       return isBearerAuth(name, value) === false;

--- a/packages/insomnia/src/main/importers/importers/curl.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.ts
@@ -99,8 +99,8 @@ const extractUrlAndParameters = (urlValue: string): { url: string; parameters: P
     return { url: '', parameters: [] };
   }
 };
-const isBearerAuth = (header: string, value: string) =>
-  header.toLowerCase() === 'authorization' && value.trim().toLowerCase().startsWith('bearer');
+const isBearerAuth = (header?: string, value?: string) =>
+  header?.toLowerCase() === 'authorization' && value?.trim().toLowerCase().startsWith('bearer');
 const extractAuth = (pairsByName: PairsByName): RequestAuthentication | {} => {
   const [username, password] = getPairValue(pairsByName, '', ['u', 'user']).split(/:(.*)$/);
   const [header, value] = getPairValue(pairsByName, '', ['H', 'header']).split(/:(.*)$/);

--- a/packages/insomnia/src/main/importers/importers/curl.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.ts
@@ -2,6 +2,8 @@ import { URL } from 'node:url';
 
 import { type ControlOperator, parse, type ParseEntry } from 'shell-quote';
 
+import type { RequestAuthentication } from '~/models/request';
+
 import { type Converter, type ImportRequest, type Parameter } from '../entities';
 
 export const id = 'curl';
@@ -99,7 +101,7 @@ const extractUrlAndParameters = (urlValue: string): { url: string; parameters: P
 };
 const isBearerAuth = (header: string, value: string) =>
   header.toLowerCase() === 'authorization' && value.trim().toLowerCase().startsWith('bearer');
-const extractAuth = (pairsByName: PairsByName) => {
+const extractAuth = (pairsByName: PairsByName): RequestAuthentication | {} => {
   const [username, password] = getPairValue(pairsByName, '', ['u', 'user']).split(/:(.*)$/);
   const [header, value] = getPairValue(pairsByName, '', ['H', 'header']).split(/:(.*)$/);
   if (isBearerAuth(header, value)) {
@@ -107,6 +109,7 @@ const extractAuth = (pairsByName: PairsByName) => {
   }
   return username
     ? {
+        type: 'basic',
         username: username.trim(),
         password: password.trim(),
       }

--- a/packages/insomnia/src/main/importers/importers/curl.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.ts
@@ -340,6 +340,10 @@ const pairToParameters = (pair: string | boolean, allowFiles = false): Parameter
   if (typeof pair === 'boolean') {
     return [{ name: '', value: pair.toString() }];
   }
+  try {
+    JSON.parse(pair);
+    return [{ name: '', value: pair }];
+  } catch {}
 
   return pair.split('&').map(pair => {
     if (pair.includes('@') && allowFiles) {

--- a/packages/insomnia/src/main/importers/importers/curl.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.ts
@@ -97,9 +97,14 @@ const extractUrlAndParameters = (urlValue: string): { url: string; parameters: P
     return { url: '', parameters: [] };
   }
 };
+const isBearerAuth = (header: string, value: string) =>
+  header.toLowerCase() === 'authorization' && value.trim().toLowerCase().startsWith('bearer');
 const extractAuth = (pairsByName: PairsByName) => {
   const [username, password] = getPairValue(pairsByName, '', ['u', 'user']).split(/:(.*)$/);
-
+  const [header, value] = getPairValue(pairsByName, '', ['H', 'header']).split(/:(.*)$/);
+  if (isBearerAuth(header, value)) {
+    return { type: 'bearer', token: value.trim().slice(7) };
+  }
   return username
     ? {
         username: username.trim(),
@@ -108,23 +113,25 @@ const extractAuth = (pairsByName: PairsByName) => {
     : {};
 };
 const extractHeaders = (pairsByName: PairsByName) => {
-  return [
-    ...((pairsByName.header as string[] | undefined) || []),
-    ...((pairsByName.H as string[] | undefined) || []),
-  ].map(header => {
-    const [name, value] = header.split(/:(.*)$/);
-    // remove final colon from header name if present
-    if (!value) {
+  return [...((pairsByName.header as string[] | undefined) || []), ...((pairsByName.H as string[] | undefined) || [])]
+    .filter(header => {
+      const [name, value] = header.split(/:(.*)$/);
+      return isBearerAuth(name, value) === false;
+    })
+    .map(header => {
+      const [name, value] = header.split(/:(.*)$/);
+      // remove final colon from header name if present
+      if (!value) {
+        return {
+          name: name.trim().replace(/;$/, ''),
+          value: '',
+        };
+      }
       return {
-        name: name.trim().replace(/;$/, ''),
-        value: '',
+        name: name.trim(),
+        value: value.trim(),
       };
-    }
-    return {
-      name: name.trim(),
-      value: value.trim(),
-    };
-  });
+    });
 };
 const extractCookieHeaderValue = (pairsByName: PairsByName) => {
   return [...((pairsByName.cookie as string[] | undefined) || []), ...((pairsByName.b as string[] | undefined) || [])]

--- a/packages/insomnia/src/main/importers/importers/openapi-3.ts
+++ b/packages/insomnia/src/main/importers/importers/openapi-3.ts
@@ -5,7 +5,7 @@ import SwaggerParser from '@apidevtools/swagger-parser';
 import type { OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 import YAML from 'yaml';
 
-import type { Authentication, Converter, ImportRequest } from '../entities';
+import type { Converter, ImportRequest } from '../entities';
 import { unthrowableParseJson } from '../utils';
 
 export const id = 'openapi3';
@@ -283,7 +283,7 @@ const importRequest = (
     body: body,
     description: endpointSchema.description || '',
     headers: [...paramHeaders, ...securityHeaders],
-    authentication: authentication as Authentication,
+    authentication: authentication,
     parameters: [...prepareQueryParams(endpointSchema), ...securityParams],
   };
 };

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -306,6 +306,7 @@ const Root = () => {
   const [importObject, setImportObject] = useState({ type: 'clipboard', defaultValue: '' } as {
     type: SourceType;
     defaultValue: string;
+    origin?: string;
   });
   const { submit: createCloudCredentials } = useCreateCloudCredentialActionFetcher();
   const { submit: authorizeSubmit } = useAuthorizeActionFetcher();
@@ -351,10 +352,10 @@ const Root = () => {
           },
         });
         if (params.uri) {
-          return setImportObject({ type: 'uri', defaultValue: params.uri });
+          return setImportObject({ type: 'uri', defaultValue: params.uri, origin: params.origin });
         }
         if (params.curl) {
-          return setImportObject({ type: 'curl', defaultValue: params.curl });
+          return setImportObject({ type: 'curl', defaultValue: params.curl, origin: params.origin });
         }
       }
       if (urlWithoutParams === 'insomnia://plugins/install') {

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.new.tsx
@@ -134,8 +134,8 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
       has_prescript: !!req?.preRequestScript,
       has_postscript: !!req?.afterResponseScript,
       request_header_names: req?.headers?.map(h => h.name) || [],
-      count_cookies: req?.headers.find(h => h.name.toLowerCase() === 'cookie')
-        ? req.headers.find(h => h.name.toLowerCase() === 'cookie')?.value.split(';').length
+      count_cookies: req?.headers?.find(h => h.name.toLowerCase() === 'cookie')
+        ? req.headers?.find(h => h.name.toLowerCase() === 'cookie')?.value.split(';').length
         : 0,
       count_certificates: certificates.length,
       count_headers: req?.headers?.length || 0,

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -386,6 +386,7 @@ const ScanResourcesForm = ({
       isMounted = false;
     };
   }, [from]);
+  const isValidCurl = (importFrom === 'curl' && message && message.startsWith('Detected')) || importFrom !== 'curl';
   return (
     <Fragment>
       <div className="flex flex-col">
@@ -477,7 +478,14 @@ const ScanResourcesForm = ({
 
       <div className="flex items-end justify-between gap-(--padding-sm)">
         <SupportedFormats />
-        <Button variant="contained" bg="surprise" type="submit" form={id} className="btn h-10 gap-(--padding-sm)">
+        <Button
+          isDisabled={!isValidCurl}
+          variant="contained"
+          bg="surprise"
+          type="submit"
+          form={id}
+          className="btn h-10 gap-(--padding-sm)"
+        >
           <i className="fa fa-file-import" /> Scan
           {loading && <Icon icon="spinner" className="ml-[4px] animate-spin" />}
         </Button>

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -283,7 +283,7 @@ export const ImportModal: FC<ImportModalProps> = ({
 
   return (
     <OverlayContainer onClick={e => e.stopPropagation()}>
-      <Modal ref={modalRef} onHide={onHide}>
+      <Modal ref={modalRef} onHide={onHide} className="max-h-none">
         <ModalHeader>{header}</ModalHeader>
         {hasAnyDataToImport ? (
           <ImportResourcesForm

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -283,7 +283,7 @@ export const ImportModal: FC<ImportModalProps> = ({
 
   return (
     <OverlayContainer onClick={e => e.stopPropagation()}>
-      <Modal ref={modalRef} onHide={onHide} className="max-h-none">
+      <Modal ref={modalRef} onHide={onHide}>
         <ModalHeader>{header}</ModalHeader>
         {hasAnyDataToImport ? (
           <ImportResourcesForm
@@ -389,7 +389,7 @@ const ScanResourcesForm = ({
   const isValidCurl = (importFrom === 'curl' && message && message.startsWith('Detected')) || importFrom !== 'curl';
   return (
     <Fragment>
-      <div className="flex flex-col">
+      <div className="flex flex-col overflow-y-auto">
         <div className="mb-4 w-full items-center gap-4 rounded-lg border border-solid border-[rgba(var(--color-warning-rgb),1)] bg-(--color-bg) px-3 py-2 text-sm text-wrap text-[rgba(var(--color-warning-rgb),1)] shadow-lg outline-hidden">
           ⚠️ Make sure that you trust the import source before continuing.
         </div>

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -455,9 +455,9 @@ const ScanResourcesForm = ({
             <ScanResultsTable scanResults={scanResults} />
           </div>
         )}
-        {message && <div className="margin-left txt-sm truncate italic">{message}</div>}
+        {message && <div className="truncate">{message}</div>}
         {from?.type === 'curl' && from.origin && (
-          <div className="notice my-1 flex w-full justify-start py-1">
+          <div className="flex w-full justify-start py-1">
             <CurlIcon />
             cURL from{' '}
             <Link className="px-2 font-bold underline" href={from.origin}>

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import { formatDistanceToNowStrict } from 'date-fns';
 import React, { type FC, Fragment, type ReactNode, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { type DirectoryDropItem, type FileDropItem, OverlayContainer, useDrop } from 'react-aria';
-import { Heading } from 'react-aria-components';
+import { Heading, Link } from 'react-aria-components';
 import { useNavigate, useParams } from 'react-router';
 
 import { isNotNullOrUndefined } from '~/common/misc';
@@ -178,17 +178,21 @@ interface ImportModalProps extends ModalProps {
   from:
     | {
         type: 'file';
+        origin?: string;
       }
     | {
         type: 'uri';
         defaultValue?: string;
+        origin?: string;
       }
     | {
         type: 'curl';
         defaultValue?: string;
+        origin?: string;
       }
     | {
         type: 'clipboard';
+        origin?: string;
       };
 }
 
@@ -344,6 +348,9 @@ const ScanResourcesForm = ({
   return (
     <Fragment>
       <div className="flex flex-col">
+        <div className="mb-4 w-full items-center gap-4 rounded-lg border border-solid border-[rgba(var(--color-warning-rgb),1)] bg-(--color-bg) px-3 py-2 text-sm text-wrap text-[rgba(var(--color-warning-rgb),1)] shadow-lg outline-hidden">
+          ⚠️ Make sure that you trust the import source before continuing.
+        </div>
         <form
           aria-label="Import from"
           id={id}
@@ -407,6 +414,19 @@ const ScanResourcesForm = ({
         {scanResults && (
           <div className="margin-top-sm max-h-[20vh] overflow-y-auto">
             <ScanResultsTable scanResults={scanResults} />
+          </div>
+        )}
+      </div>
+      <div>
+        {from?.type === 'curl' && from.origin && (
+          <div className="notice my-1 flex w-full justify-start py-1">
+            <CurlIcon />
+            cURL from{' '}
+            <Link className="px-2 font-bold underline" href={from.origin}>
+              {' '}
+              {from.origin}{' '}
+            </Link>{' '}
+            ⚠️
           </div>
         )}
       </div>

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -394,8 +394,8 @@ const ScanResourcesForm = ({
             <div className="form-control form-control--outlined">
               <label>
                 cURL:
-                <input
-                  type="text"
+                <textarea
+                  className="h-[200px] resize-none font-mono"
                   name="curl"
                   defaultValue={from?.type === 'curl' ? from.defaultValue : undefined}
                   placeholder="curl --request GET --url http://insomnia.rest/"

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -345,9 +345,9 @@ const ScanResourcesForm = ({
   const id = useId();
   const [importFrom, setImportFrom] = useState(from?.type || 'uri');
   const [message, setMessage] = useState('');
-  const validateCurl = async (value: string) => {
+  const validateCurl = async (isMounted: boolean, value: string) => {
     if (!value) {
-      setMessage('Invalid cURL request');
+      isMounted && setMessage('Invalid cURL request');
       return;
     }
     try {
@@ -361,24 +361,30 @@ const ScanResourcesForm = ({
       );
       const { resources } = data;
       const importedRequest = resources[0];
-      setMessage(
-        importedRequest.url
-          ? `Detected ${importedRequest.method} request to ${importedRequest.url}`
-          : 'Invalid cURL request',
-      );
+      isMounted &&
+        setMessage(
+          importedRequest.url
+            ? `Detected ${importedRequest.method} request to ${importedRequest.url}`
+            : 'Invalid cURL request',
+        );
     } catch (error) {
       console.log('[importer] error', error);
 
-      setMessage(
-        error.message.includes('No importers found for file')
-          ? 'Invalid cURL request'
-          : error.message.replace("Error invoking remote method 'parseImport': Error: ", ''),
-      );
+      isMounted &&
+        setMessage(
+          error.message.includes('No importers found for file')
+            ? 'Invalid cURL request'
+            : error.message.replace("Error invoking remote method 'parseImport': Error: ", ''),
+        );
     }
   };
   useEffect(() => {
-    validateCurl(from?.type === 'curl' && from.defaultValue ? from.defaultValue : '');
-    return () => {};
+    let isMounted = true;
+
+    validateCurl(isMounted, from?.type === 'curl' && from.defaultValue ? from.defaultValue : '');
+    return () => {
+      isMounted = false;
+    };
   }, [from]);
   return (
     <Fragment>
@@ -443,7 +449,7 @@ const ScanResourcesForm = ({
                   placeholder="curl --request GET --url http://insomnia.rest/"
                   onChange={async event => {
                     const { value } = event.target;
-                    validateCurl(value);
+                    validateCurl(true, value);
                   }}
                 />
               </label>
@@ -455,7 +461,7 @@ const ScanResourcesForm = ({
             <ScanResultsTable scanResults={scanResults} />
           </div>
         )}
-        {message && <div className="truncate">{message}</div>}
+        {importFrom === 'curl' && message && <div className="truncate">{message}</div>}
         {from?.type === 'curl' && from.origin && (
           <div className="flex w-full justify-start py-1">
             <CurlIcon />

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -4,7 +4,6 @@ import React, { type FC, Fragment, type ReactNode, useEffect, useId, useMemo, us
 import { type DirectoryDropItem, type FileDropItem, OverlayContainer, useDrop } from 'react-aria';
 import { Heading, Link } from 'react-aria-components';
 import { useNavigate, useParams } from 'react-router';
-import { useMount } from 'react-use';
 
 import { isNotNullOrUndefined } from '~/common/misc';
 import { scopeToActivity } from '~/models/workspace';
@@ -377,9 +376,10 @@ const ScanResourcesForm = ({
       );
     }
   };
-  useMount(() => {
+  useEffect(() => {
     validateCurl(from?.type === 'curl' && from.defaultValue ? from.defaultValue : '');
-  });
+    return () => {};
+  }, [from]);
   return (
     <Fragment>
       <div className="flex flex-col">

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -423,14 +423,19 @@ const ScanResourcesForm = ({
                       );
                       const { resources } = data;
                       const importedRequest = resources[0];
-                      if (importedRequest) {
-                        setMessage(`Detected ${importedRequest.method} request to ${importedRequest.url}`);
-                      } else {
-                        setMessage('Invalid cURL request');
-                      }
+                      setMessage(
+                        importedRequest.url
+                          ? `Detected ${importedRequest.method} request to ${importedRequest.url}`
+                          : 'Invalid cURL request',
+                      );
                     } catch (error) {
                       console.log('[importer] error', error);
-                      setMessage(error.message.replace("Error invoking remote method 'parseImport': Error: ", ''));
+
+                      setMessage(
+                        error.message.includes('No importers found for file')
+                          ? 'Invalid cURL request'
+                          : error.message.replace("Error invoking remote method 'parseImport': Error: ", ''),
+                      );
                     }
                   }}
                 />

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -496,7 +496,7 @@ const ImportResourcesForm = ({
 }: {
   scanResults: ScanResult[];
   errors?: string[];
-  onImport: (overrideBaseEnvironmentData: boolean, selectedWorkspaceId?: string) => void;
+  onImport: (overrideBaseEnvironmentData: boolean, selectedProjectId?: string, selectedWorkspaceId?: string) => void;
   disabled: boolean;
   loading: boolean;
   isImportingBaseEnvironmentToWorkspace: boolean;
@@ -510,15 +510,19 @@ const ImportResourcesForm = ({
   const isSingleRequest = scanResults.length === 1 && (scanResults[0].requests?.length || 0) === 1;
   const workspacesFetcher = useProjectListWorkspacesLoaderFetcher();
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(workspaceId || '');
+  const [selectedProjectId, setSelectedProjectId] = useState(projectId || '');
   useEffect(() => {
-    const isIdleAndUninitialized = workspacesFetcher.state === 'idle' && !workspacesFetcher.data;
-    if (isIdleAndUninitialized) {
+    const isIdle = workspacesFetcher.state === 'idle';
+    const hasFetchedSelectedProject = selectedProjectId === workspacesFetcher?.data?.activeProject._id;
+    const hasDataAndFetchedSelectedProject = workspacesFetcher?.data && hasFetchedSelectedProject;
+    const needsFetch = isIdle && !hasDataAndFetchedSelectedProject;
+    if (needsFetch) {
       workspacesFetcher.load({
         organizationId,
-        projectId,
+        projectId: selectedProjectId,
       });
     }
-  }, [organizationId, projectId, workspacesFetcher]);
+  }, [organizationId, projectId, selectedProjectId, workspacesFetcher]);
   // List collections for active project, sorted by last modified timestamp descending
   // Should we list design or mcp?
   const workspacesForActiveProject =
@@ -528,11 +532,34 @@ const ImportResourcesForm = ({
       .filter(isNotNullOrUndefined)
       .filter(w => w.scope === 'collection' || w.scope === 'design') || [];
   const shouldShowWorkspaceSelect = !workspaceId && isSingleRequest && workspacesForActiveProject.length > 0;
+  const shouldShowProjectSelect = true;
   return (
     <Fragment>
       <div className="flex max-h-[50vh] flex-col gap-(--padding-md) overflow-auto">
         <div className="overflow-y-auto">
           <ScanResultsTable scanResults={scanResults} />
+          {shouldShowProjectSelect && (
+            <div className="form-row mt-2">
+              <div className="form-control form-control--outlined">
+                <label>
+                  Select Project:
+                  <select
+                    aria-label="Select Project"
+                    name="projectId"
+                    value={selectedProjectId}
+                    onChange={e => setSelectedProjectId(e.target.value)}
+                  >
+                    <option value="">-- New Project --</option>
+                    {workspacesFetcher?.data?.projects.map(w => (
+                      <option key={w._id} value={w._id}>
+                        {w.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+            </div>
+          )}
           {shouldShowWorkspaceSelect && (
             <div className="form-row mt-2">
               <div className="form-control form-control--outlined">

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -4,6 +4,7 @@ import React, { type FC, Fragment, type ReactNode, useEffect, useId, useMemo, us
 import { type DirectoryDropItem, type FileDropItem, OverlayContainer, useDrop } from 'react-aria';
 import { Heading, Link } from 'react-aria-components';
 import { useNavigate, useParams } from 'react-router';
+import { useMount } from 'react-use';
 
 import { isNotNullOrUndefined } from '~/common/misc';
 import { scopeToActivity } from '~/models/workspace';
@@ -345,6 +346,40 @@ const ScanResourcesForm = ({
   const id = useId();
   const [importFrom, setImportFrom] = useState(from?.type || 'uri');
   const [message, setMessage] = useState('');
+  const validateCurl = async (value: string) => {
+    if (!value) {
+      setMessage('Invalid cURL request');
+      return;
+    }
+    try {
+      const { data } = await window.main.parseImport(
+        {
+          contentStr: value,
+        },
+        {
+          importerId: 'curl',
+        },
+      );
+      const { resources } = data;
+      const importedRequest = resources[0];
+      setMessage(
+        importedRequest.url
+          ? `Detected ${importedRequest.method} request to ${importedRequest.url}`
+          : 'Invalid cURL request',
+      );
+    } catch (error) {
+      console.log('[importer] error', error);
+
+      setMessage(
+        error.message.includes('No importers found for file')
+          ? 'Invalid cURL request'
+          : error.message.replace("Error invoking remote method 'parseImport': Error: ", ''),
+      );
+    }
+  };
+  useMount(() => {
+    validateCurl(from?.type === 'curl' && from.defaultValue ? from.defaultValue : '');
+  });
   return (
     <Fragment>
       <div className="flex flex-col">
@@ -408,35 +443,7 @@ const ScanResourcesForm = ({
                   placeholder="curl --request GET --url http://insomnia.rest/"
                   onChange={async event => {
                     const { value } = event.target;
-                    if (!value) {
-                      setMessage('Invalid cURL request');
-                      return;
-                    }
-                    try {
-                      const { data } = await window.main.parseImport(
-                        {
-                          contentStr: value,
-                        },
-                        {
-                          importerId: 'curl',
-                        },
-                      );
-                      const { resources } = data;
-                      const importedRequest = resources[0];
-                      setMessage(
-                        importedRequest.url
-                          ? `Detected ${importedRequest.method} request to ${importedRequest.url}`
-                          : 'Invalid cURL request',
-                      );
-                    } catch (error) {
-                      console.log('[importer] error', error);
-
-                      setMessage(
-                        error.message.includes('No importers found for file')
-                          ? 'Invalid cURL request'
-                          : error.message.replace("Error invoking remote method 'parseImport': Error: ", ''),
-                      );
-                    }
+                    validateCurl(value);
                   }}
                 />
               </label>

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -292,12 +292,16 @@ export const ImportModal: FC<ImportModalProps> = ({
             loading={importFetcher.state !== 'idle'}
             disabled={importErrors.length > 0}
             isImportingBaseEnvironmentToWorkspace={!!isImportingBaseEnvironmentToWorkspace}
-            onImport={(overrideBaseEnvironmentData: boolean, selectedWorkspaceId?: string) => {
+            onImport={(
+              overrideBaseEnvironmentData: boolean,
+              selectedProjectId?: string,
+              selectedWorkspaceId?: string,
+            ) => {
               invariant(Array.isArray(scanResourcesFetcherData));
 
               importFetcher.submit({
                 organizationId,
-                projectId: defaultProjectId || '',
+                projectId: selectedProjectId || defaultProjectId || '',
                 workspaceId: selectedWorkspaceId || (shouldImportToWorkspace ? defaultWorkspaceId : undefined),
                 options: {
                   overrideBaseEnvironmentData,
@@ -330,7 +334,23 @@ export const ImportModal: FC<ImportModalProps> = ({
     </OverlayContainer>
   );
 };
-
+const validateCurl = async (value: string) => {
+  if (!value) {
+    return 'Invalid cURL request';
+  }
+  try {
+    const { data } = await window.main.parseImport({ contentStr: value }, { importerId: 'curl' });
+    const importedRequest = data?.resources?.[0];
+    return importedRequest.url
+      ? `Detected ${importedRequest.method} request to ${importedRequest.url}`
+      : 'Invalid cURL request';
+  } catch (error) {
+    console.log('[importer] error', error);
+    return error.message.includes('No importers found for file')
+      ? 'Invalid cURL request'
+      : error.message.replace("Error invoking remote method 'parseImport': Error: ", '');
+  }
+};
 const ScanResourcesForm = ({
   onSubmit,
   from,
@@ -345,43 +365,14 @@ const ScanResourcesForm = ({
   const id = useId();
   const [importFrom, setImportFrom] = useState(from?.type || 'uri');
   const [message, setMessage] = useState('');
-  const validateCurl = async (isMounted: boolean, value: string) => {
-    if (!value) {
-      isMounted && setMessage('Invalid cURL request');
-      return;
-    }
-    try {
-      const { data } = await window.main.parseImport(
-        {
-          contentStr: value,
-        },
-        {
-          importerId: 'curl',
-        },
-      );
-      const { resources } = data;
-      const importedRequest = resources[0];
-      isMounted &&
-        setMessage(
-          importedRequest.url
-            ? `Detected ${importedRequest.method} request to ${importedRequest.url}`
-            : 'Invalid cURL request',
-        );
-    } catch (error) {
-      console.log('[importer] error', error);
 
-      isMounted &&
-        setMessage(
-          error.message.includes('No importers found for file')
-            ? 'Invalid cURL request'
-            : error.message.replace("Error invoking remote method 'parseImport': Error: ", ''),
-        );
-    }
-  };
   useEffect(() => {
     let isMounted = true;
-
-    validateCurl(isMounted, from?.type === 'curl' && from.defaultValue ? from.defaultValue : '');
+    const fn = async () => {
+      const msg = await validateCurl(from?.type === 'curl' && from.defaultValue ? from.defaultValue : '');
+      isMounted && setMessage(msg);
+    };
+    fn();
     return () => {
       isMounted = false;
     };
@@ -450,7 +441,8 @@ const ScanResourcesForm = ({
                   placeholder="curl --request GET --url http://insomnia.rest/"
                   onChange={async event => {
                     const { value } = event.target;
-                    validateCurl(true, value);
+                    const msg = await validateCurl(value);
+                    setMessage(msg);
                   }}
                 />
               </label>

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -344,7 +344,7 @@ const ScanResourcesForm = ({
 }) => {
   const id = useId();
   const [importFrom, setImportFrom] = useState(from?.type || 'uri');
-
+  const [message, setMessage] = useState('');
   return (
     <Fragment>
       <div className="flex flex-col">
@@ -406,6 +406,33 @@ const ScanResourcesForm = ({
                   name="curl"
                   defaultValue={from?.type === 'curl' ? from.defaultValue : undefined}
                   placeholder="curl --request GET --url http://insomnia.rest/"
+                  onChange={async event => {
+                    const { value } = event.target;
+                    if (!value) {
+                      setMessage('Invalid cURL request');
+                      return;
+                    }
+                    try {
+                      const { data } = await window.main.parseImport(
+                        {
+                          contentStr: value,
+                        },
+                        {
+                          importerId: 'curl',
+                        },
+                      );
+                      const { resources } = data;
+                      const importedRequest = resources[0];
+                      if (importedRequest) {
+                        setMessage(`Detected ${importedRequest.method} request to ${importedRequest.url}`);
+                      } else {
+                        setMessage('Invalid cURL request');
+                      }
+                    } catch (error) {
+                      console.log('[importer] error', error);
+                      setMessage(error.message.replace("Error invoking remote method 'parseImport': Error: ", ''));
+                    }
+                  }}
                 />
               </label>
             </div>
@@ -416,8 +443,7 @@ const ScanResourcesForm = ({
             <ScanResultsTable scanResults={scanResults} />
           </div>
         )}
-      </div>
-      <div>
+        {message && <div className="margin-left txt-sm truncate italic">{message}</div>}
         {from?.type === 'curl' && from.origin && (
           <div className="notice my-1 flex w-full justify-start py-1">
             <CurlIcon />
@@ -430,6 +456,7 @@ const ScanResourcesForm = ({
           </div>
         )}
       </div>
+
       <div className="flex items-end justify-between gap-(--padding-sm)">
         <SupportedFormats />
         <Button variant="contained" bg="surprise" type="submit" form={id} className="btn h-10 gap-(--padding-sm)">

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -515,7 +515,7 @@ const ImportResourcesForm = ({
     const isIdle = workspacesFetcher.state === 'idle';
     const hasFetchedSelectedProject = selectedProjectId === workspacesFetcher?.data?.activeProject._id;
     const hasDataAndFetchedSelectedProject = workspacesFetcher?.data && hasFetchedSelectedProject;
-    const needsFetch = isIdle && !hasDataAndFetchedSelectedProject;
+    const needsFetch = isIdle && !hasDataAndFetchedSelectedProject && selectedProjectId;
     if (needsFetch) {
       workspacesFetcher.load({
         organizationId,
@@ -525,41 +525,40 @@ const ImportResourcesForm = ({
   }, [organizationId, projectId, selectedProjectId, workspacesFetcher]);
   // List collections for active project, sorted by last modified timestamp descending
   // Should we list design or mcp?
-  const workspacesForActiveProject =
-    workspacesFetcher?.data?.files
-      .toSorted((a, b) => b.lastModifiedTimestamp - a.lastModifiedTimestamp)
-      .map(w => ({ ...w.workspace, lastModifiedTimestamp: w.lastModifiedTimestamp }))
-      .filter(isNotNullOrUndefined)
-      .filter(w => w.scope === 'collection' || w.scope === 'design') || [];
-  const shouldShowWorkspaceSelect = !workspaceId && isSingleRequest && workspacesForActiveProject.length > 0;
-  const shouldShowProjectSelect = true;
+  const selectedNewProject = !selectedProjectId;
+  const workspacesForActiveProject = selectedNewProject
+    ? []
+    : workspacesFetcher?.data?.files
+        .toSorted((a, b) => b.lastModifiedTimestamp - a.lastModifiedTimestamp)
+        .map(w => ({ ...w.workspace, lastModifiedTimestamp: w.lastModifiedTimestamp }))
+        .filter(isNotNullOrUndefined)
+        .filter(w => w.scope === 'collection' || w.scope === 'design') || [];
+  const shouldShowWorkspaceSelect = isSingleRequest && workspacesForActiveProject.length > 0;
   return (
     <Fragment>
       <div className="flex max-h-[50vh] flex-col gap-(--padding-md) overflow-auto">
         <div className="overflow-y-auto">
           <ScanResultsTable scanResults={scanResults} />
-          {shouldShowProjectSelect && (
-            <div className="form-row mt-2">
-              <div className="form-control form-control--outlined">
-                <label>
-                  Select Project:
-                  <select
-                    aria-label="Select Project"
-                    name="projectId"
-                    value={selectedProjectId}
-                    onChange={e => setSelectedProjectId(e.target.value)}
-                  >
-                    <option value="">-- New Project --</option>
-                    {workspacesFetcher?.data?.projects.map(w => (
-                      <option key={w._id} value={w._id}>
-                        {w.name}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-              </div>
+          <div className="form-row mt-2">
+            <div className="form-control form-control--outlined">
+              <label>
+                Select Project:
+                <select
+                  aria-label="Select Project"
+                  name="projectId"
+                  value={selectedProjectId}
+                  onChange={e => setSelectedProjectId(e.target.value)}
+                >
+                  <option value="">-- New Project --</option>
+                  {workspacesFetcher?.data?.projects.map(w => (
+                    <option key={w._id} value={w._id}>
+                      {w.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
             </div>
-          )}
+          </div>
           {shouldShowWorkspaceSelect && (
             <div className="form-row mt-2">
               <div className="form-control form-control--outlined">
@@ -614,7 +613,7 @@ const ImportResourcesForm = ({
           variant="contained"
           bg="surprise"
           disabled={disabled}
-          onClick={() => onImport(overrideBaseEnvironmentData, selectedWorkspaceId)}
+          onClick={() => onImport(overrideBaseEnvironmentData, selectedProjectId, selectedWorkspaceId)}
           className="btn h-10 gap-(--padding-sm)"
         >
           {loading ? (

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -345,10 +345,13 @@ const validateCurl = async (value: string) => {
       ? `Detected ${importedRequest.method} request to ${importedRequest.url}`
       : 'Invalid cURL request';
   } catch (error) {
-    console.log('[importer] error', error);
-    return error.message.includes('No importers found for file')
+    const rawMessage = error instanceof Error ? error.message : String(error);
+    const cleanedMessage = rawMessage.replace("Error invoking remote method 'parseImport': Error: ", '');
+    const finalMessage = rawMessage.includes('No importers found for file') ? 'Invalid cURL request' : cleanedMessage;
+    console.log('[importer] error', finalMessage);
+    return finalMessage.includes('No importers found for file')
       ? 'Invalid cURL request'
-      : error.message.replace("Error invoking remote method 'parseImport': Error: ", '');
+      : finalMessage.replace("Error invoking remote method 'parseImport': Error: ", '');
   }
 };
 const ScanResourcesForm = ({
@@ -459,7 +462,12 @@ const ScanResourcesForm = ({
           <div className="flex w-full justify-start py-1">
             <CurlIcon />
             cURL from{' '}
-            <Link className="px-2 font-bold underline" href={from.origin}>
+            <Link
+              className="px-2 font-bold underline"
+              onClick={() => {
+                window.main.openInBrowser(from.origin || '');
+              }}
+            >
               {' '}
               {from.origin}{' '}
             </Link>{' '}

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -492,14 +492,14 @@ const ImportResourcesForm = ({
             <div className="form-row mt-2">
               <div className="form-control form-control--outlined">
                 <label>
-                  Select Workspace:
+                  Select Collection:
                   <select
-                    aria-label="Select Workspace"
+                    aria-label="Select Collection"
                     name="workspaceId"
                     value={selectedWorkspaceId}
                     onChange={e => setSelectedWorkspaceId(e.target.value)}
                   >
-                    <option value="">-- New Workspace --</option>
+                    <option value="">-- New Collection --</option>
                     {workspacesForActiveProject.map(w => (
                       <option key={w._id} value={w._id}>
                         {w.name} - {formatDistanceToNowStrict(w.lastModifiedTimestamp)}


### PR DESCRIPTION
Motivation: reduce friction to import collections and single requests and add flexibility to import location.
Goal: make curl a reasonable way to deeplink into the app allowing them to be added separately or in a collection

TODO

- [x] stretch curl input box and fix overflow
- [x] add warning to top
- [x] add origin param 
- [x] improve curl import code quality
- [x] improve error handling
- [x] run validate straight away without hitting scan
- [x] add project select
- [x] disable invalid submit

<img width="781" height="592" alt="image" src="https://github.com/user-attachments/assets/3cd8a014-9483-4410-8894-6f613fdf1fac" />



future work
- [ ] use curlconverter in order to get more standard fallbacks and errors from bad inputs.


closes INS-1966
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
