### PR TITLE
fix: Improve preferences data access folders input UX with validation and guidance

### DIFF
--- a/packages/insomnia/src/common/misc.ts
+++ b/packages/insomnia/src/common/misc.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import zlib from 'node:zlib';
 
 import fuzzysort from 'fuzzysort';
@@ -264,6 +265,8 @@ export function unescapeForwardSlash(str: string): string {
     return match;
   });
 }
+
+export const normalizeFolderPath = (p: string) => path.normalize(p).replace(/[/\\]+$/, '');
 
 export function cannotAccessPathError(accessingPath: string): string {
   return process.type === 'renderer' || process.type === 'browser'

--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -245,7 +245,7 @@ export const General: FC = () => {
           label="What folders can Insomnia access?"
           setting="dataFolders"
           help="This allows you to control what folders Insomnia (and scripts within Insomnia) can read/write to."
-          placeholder=""
+          placeholder="e.g., /Users/folder1"
         />
       </div>
 

--- a/packages/insomnia/src/ui/components/settings/text-array-setting.test.ts
+++ b/packages/insomnia/src/ui/components/settings/text-array-setting.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeFolderPath } from '../../../common/misc';
+
+const isWindows = process.platform === 'win32';
+
+describe('normalizeFolderPath', () => {
+  describe.skipIf(isWindows)('POSIX paths', () => {
+    it.each([
+      { input: '/Users/foo/bar', expected: '/Users/foo/bar' },
+      { input: '/Users/foo/bar/', expected: '/Users/foo/bar' },
+      { input: '/Users/foo/bar///', expected: '/Users/foo/bar' },
+      { input: '/Users//foo//bar', expected: '/Users/foo/bar' },
+      { input: '/Volumes/External/data/', expected: '/Volumes/External/data' },
+      { input: '/Applications/Insomnia.app/Contents/', expected: '/Applications/Insomnia.app/Contents' },
+    ])('normalizes "$input" to "$expected"', ({ input, expected }) => {
+      expect(normalizeFolderPath(input)).toBe(expected);
+    });
+  });
+
+  describe.runIf(isWindows)('Windows paths', () => {
+    it.each([
+      { input: 'C:\\Users\\foo\\bar', expected: 'C:\\Users\\foo\\bar' },
+      { input: 'C:\\Users\\foo\\bar\\', expected: 'C:\\Users\\foo\\bar' },
+      { input: 'C:\\Users\\foo\\bar\\\\\\', expected: 'C:\\Users\\foo\\bar' },
+      { input: 'C:\\Users\\\\foo\\\\bar', expected: 'C:\\Users\\foo\\bar' },
+    ])('normalizes "$input" to "$expected"', ({ input, expected }) => {
+      expect(normalizeFolderPath(input)).toBe(expected);
+    });
+  });
+});

--- a/packages/insomnia/src/ui/components/settings/text-array-setting.tsx
+++ b/packages/insomnia/src/ui/components/settings/text-array-setting.tsx
@@ -8,7 +8,6 @@ import type { SettingsOfType } from '../../../common/settings';
 import { useSettingsPatcher } from '../../hooks/use-request';
 import { PromptButton } from '../base/prompt-button';
 import { HelpTooltip } from '../help-tooltip';
-import { Tooltip } from '../tooltip';
 
 export const TextArraySetting: FC<{
   disabled?: InputHTMLAttributes<HTMLInputElement>['disabled'];
@@ -22,6 +21,7 @@ export const TextArraySetting: FC<{
 
   const patchSettings = useSettingsPatcher();
   const [folderToAdd, setFolderToAdd] = useState('');
+  const [validationError, setValidationError] = useState('');
 
   let currentValue = settings[setting];
   if (!Array.isArray(currentValue)) {
@@ -30,13 +30,20 @@ export const TextArraySetting: FC<{
 
   const onAddDataFolder = useCallback(async () => {
     const validValue = folderToAdd ? folderToAdd.trim() : '';
+    if (validValue === '') {
+      setValidationError('Enter a folder path to add.');
+      return;
+    }
     const normalizedValue = validValue.replace(/\/+$/, '') || validValue;
     const exists = currentValue.some(v => (v.replace(/\/+$/, '') || v) === normalizedValue);
-    if (folderToAdd !== '' && !exists) {
-      const updatedValue = [...currentValue, validValue];
-      patchSettings({ [setting]: updatedValue });
+    if (exists) {
+      setValidationError('Duplicate folders are not allowed.');
+      return;
     }
+    const updatedValue = [...currentValue, validValue];
+    patchSettings({ [setting]: updatedValue });
     setFolderToAdd('');
+    setValidationError('');
   }, [patchSettings, setting, currentValue, folderToAdd]);
 
   const onDeleteDataFolder = useCallback(
@@ -47,17 +54,6 @@ export const TextArraySetting: FC<{
     },
     [currentValue, patchSettings, setting],
   );
-
-  const trimmedInput = folderToAdd.trim();
-  const normalizedInput = trimmedInput.replace(/\/+$/, '') || trimmedInput;
-  const isDuplicate =
-    normalizedInput.length > 0 && currentValue.some(v => (v.replace(/\/+$/, '') || v) === normalizedInput);
-  const isAddDisabled = disabled || trimmedInput.length === 0 || isDuplicate;
-  const addButtonTooltip = isDuplicate
-    ? 'Duplicate folders are not allowed.'
-    : trimmedInput.length === 0
-      ? 'Enter a folder path to add.'
-      : '';
 
   return (
     <div className="form-control form-control--outlined">
@@ -71,27 +67,25 @@ export const TextArraySetting: FC<{
             name={setting}
             onChange={e => {
               setFolderToAdd(e.target.value);
+              setValidationError('');
             }}
             placeholder={placeholder}
             type={'text'}
             data-testid={setting}
-            style={isDuplicate ? { border: '1px solid var(--color-danger)' } : undefined}
+            style={validationError ? { border: '1px solid var(--color-danger)' } : undefined}
           />
-          <Tooltip message={addButtonTooltip} position="top" isDisabled={!addButtonTooltip}>
-            <button
-              className="btn btn--outlined btn--super-compact flex items-center gap-2"
-              data-testid={`${setting}-btn`}
-              disabled={isAddDisabled}
-              style={{ cursor: isAddDisabled ? 'not-allowed' : 'pointer' }}
-              onClick={onAddDataFolder}
-            >
-              Add
-            </button>
-          </Tooltip>
+          <button
+            className="btn btn--outlined btn--super-compact flex items-center gap-2"
+            data-testid={`${setting}-btn`}
+            disabled={disabled}
+            onClick={onAddDataFolder}
+          >
+            Add
+          </button>
         </div>
-        {isDuplicate && (
+        {validationError && (
           <p className="margin-top-xs text-sm" style={{ color: 'var(--color-danger)' }}>
-            Duplicate folders are not allowed.
+            {validationError}
           </p>
         )}
       </label>

--- a/packages/insomnia/src/ui/components/settings/text-array-setting.tsx
+++ b/packages/insomnia/src/ui/components/settings/text-array-setting.tsx
@@ -4,6 +4,7 @@ import { ListBox, ListBoxItem } from 'react-aria-components';
 import { useRootLoaderData } from '~/root';
 import { invariant } from '~/utils/invariant';
 
+import { normalizeFolderPath } from '../../../common/misc';
 import type { SettingsOfType } from '../../../common/settings';
 import { useSettingsPatcher } from '../../hooks/use-request';
 import { PromptButton } from '../base/prompt-button';
@@ -34,8 +35,12 @@ export const TextArraySetting: FC<{
       setValidationError('Enter a folder path to add.');
       return;
     }
-    const normalizedValue = validValue.replace(/\/+$/, '') || validValue;
-    const exists = currentValue.some(v => (v.replace(/\/+$/, '') || v) === normalizedValue);
+    const normalizedValue = normalizeFolderPath(validValue);
+    if (validValue !== normalizedValue) {
+      setValidationError(`Invalid path format. Did you mean "${normalizedValue}"?`);
+      return;
+    }
+    const exists = currentValue.some(v => normalizeFolderPath(v) === normalizedValue);
     if (exists) {
       setValidationError('Duplicate folders are not allowed.');
       return;

--- a/packages/insomnia/src/ui/components/settings/text-array-setting.tsx
+++ b/packages/insomnia/src/ui/components/settings/text-array-setting.tsx
@@ -8,6 +8,7 @@ import type { SettingsOfType } from '../../../common/settings';
 import { useSettingsPatcher } from '../../hooks/use-request';
 import { PromptButton } from '../base/prompt-button';
 import { HelpTooltip } from '../help-tooltip';
+import { Tooltip } from '../tooltip';
 
 export const TextArraySetting: FC<{
   disabled?: InputHTMLAttributes<HTMLInputElement>['disabled'];
@@ -48,7 +49,12 @@ export const TextArraySetting: FC<{
 
   const trimmedInput = folderToAdd.trim();
   const isDuplicate = trimmedInput.length > 0 && currentValue.includes(trimmedInput);
-  const isAddDisabled = disabled || folderToAdd.trim().length === 0 || isDuplicate;
+  const isAddDisabled = disabled || trimmedInput.length === 0 || isDuplicate;
+  const addButtonTooltip = isDuplicate
+    ? 'Duplicate folders are not allowed.'
+    : trimmedInput.length === 0
+      ? 'Enter a folder path to add.'
+      : '';
 
   return (
     <div className="form-control form-control--outlined">
@@ -68,15 +74,17 @@ export const TextArraySetting: FC<{
             data-testid={setting}
             style={isDuplicate ? { border: '1px solid var(--color-danger)' } : undefined}
           />
-          <button
-            className="btn btn--outlined btn--super-compact flex items-center gap-2"
-            data-testid={`${setting}-btn`}
-            disabled={isAddDisabled}
-            style={{ cursor: isAddDisabled ? 'not-allowed' : 'pointer' }}
-            onClick={onAddDataFolder}
-          >
-            Add
-          </button>
+          <Tooltip message={addButtonTooltip} position="top">
+            <button
+              className="btn btn--outlined btn--super-compact flex items-center gap-2"
+              data-testid={`${setting}-btn`}
+              disabled={isAddDisabled}
+              style={{ cursor: isAddDisabled ? 'not-allowed' : 'pointer' }}
+              onClick={onAddDataFolder}
+            >
+              Add
+            </button>
+          </Tooltip>
         </div>
         {isDuplicate && (
           <p className="margin-top-xs text-sm" style={{ color: 'var(--color-danger)' }}>

--- a/packages/insomnia/src/ui/components/settings/text-array-setting.tsx
+++ b/packages/insomnia/src/ui/components/settings/text-array-setting.tsx
@@ -46,6 +46,10 @@ export const TextArraySetting: FC<{
     [currentValue, patchSettings, setting],
   );
 
+  const trimmedInput = folderToAdd.trim();
+  const isDuplicate = trimmedInput.length > 0 && currentValue.includes(trimmedInput);
+  const isAddDisabled = disabled || folderToAdd.trim().length === 0 || isDuplicate;
+
   return (
     <div className="form-control form-control--outlined">
       <label>
@@ -62,16 +66,23 @@ export const TextArraySetting: FC<{
             placeholder={placeholder}
             type={'text'}
             data-testid={setting}
+            style={isDuplicate ? { border: '1px solid var(--color-danger)' } : undefined}
           />
           <button
             className="btn btn--outlined btn--super-compact flex items-center gap-2"
             data-testid={`${setting}-btn`}
-            disabled={disabled}
+            disabled={isAddDisabled}
+            style={{ cursor: isAddDisabled ? 'not-allowed' : 'pointer' }}
             onClick={onAddDataFolder}
           >
             Add
           </button>
         </div>
+        {isDuplicate && (
+          <p className="margin-top-xs text-sm" style={{ color: 'var(--color-danger)' }}>
+            Duplicate folders are not allowed.
+          </p>
+        )}
       </label>
 
       <ListBox aria-label="data folders" className="margin-top-sm flex w-full flex-col overflow-y-auto">

--- a/packages/insomnia/src/ui/components/settings/text-array-setting.tsx
+++ b/packages/insomnia/src/ui/components/settings/text-array-setting.tsx
@@ -30,7 +30,8 @@ export const TextArraySetting: FC<{
 
   const onAddDataFolder = useCallback(async () => {
     const validValue = folderToAdd ? folderToAdd.trim() : '';
-    const exists = currentValue.includes(validValue);
+    const normalizedValue = validValue.replace(/\/+$/, '') || validValue;
+    const exists = currentValue.some(v => (v.replace(/\/+$/, '') || v) === normalizedValue);
     if (folderToAdd !== '' && !exists) {
       const updatedValue = [...currentValue, validValue];
       patchSettings({ [setting]: updatedValue });
@@ -48,7 +49,9 @@ export const TextArraySetting: FC<{
   );
 
   const trimmedInput = folderToAdd.trim();
-  const isDuplicate = trimmedInput.length > 0 && currentValue.includes(trimmedInput);
+  const normalizedInput = trimmedInput.replace(/\/+$/, '') || trimmedInput;
+  const isDuplicate =
+    normalizedInput.length > 0 && currentValue.some(v => (v.replace(/\/+$/, '') || v) === normalizedInput);
   const isAddDisabled = disabled || trimmedInput.length === 0 || isDuplicate;
   const addButtonTooltip = isDuplicate
     ? 'Duplicate folders are not allowed.'
@@ -74,7 +77,7 @@ export const TextArraySetting: FC<{
             data-testid={setting}
             style={isDuplicate ? { border: '1px solid var(--color-danger)' } : undefined}
           />
-          <Tooltip message={addButtonTooltip} position="top">
+          <Tooltip message={addButtonTooltip} position="top" isDisabled={!addButtonTooltip}>
             <button
               className="btn btn--outlined btn--super-compact flex items-center gap-2"
               data-testid={`${setting}-btn`}

--- a/packages/insomnia/src/ui/components/tooltip.tsx
+++ b/packages/insomnia/src/ui/components/tooltip.tsx
@@ -14,14 +14,15 @@ interface Props {
   wide?: boolean;
   style?: CSSProperties;
   onClick?: () => void;
+  isDisabled?: boolean;
 }
 
 export const Tooltip = (props: Props) => {
-  const { children, message, className, wide, selectable, delay = 400, position, style } = props;
+  const { children, message, className, wide, selectable, delay = 400, position, style, isDisabled } = props;
   const triggerRef = React.useRef<HTMLDivElement>(null);
   const overlayRef = React.useRef<HTMLDivElement>(null);
 
-  const state = useTooltipTriggerState({ delay });
+  const state = useTooltipTriggerState({ delay, isDisabled });
   const trigger = useTooltipTrigger(props, state, triggerRef);
   const tooltip = useTooltip(trigger.tooltipProps, state);
 

--- a/packages/insomnia/src/ui/components/tooltip.tsx
+++ b/packages/insomnia/src/ui/components/tooltip.tsx
@@ -14,15 +14,14 @@ interface Props {
   wide?: boolean;
   style?: CSSProperties;
   onClick?: () => void;
-  isDisabled?: boolean;
 }
 
 export const Tooltip = (props: Props) => {
-  const { children, message, className, wide, selectable, delay = 400, position, style, isDisabled } = props;
+  const { children, message, className, wide, selectable, delay = 400, position, style } = props;
   const triggerRef = React.useRef<HTMLDivElement>(null);
   const overlayRef = React.useRef<HTMLDivElement>(null);
 
-  const state = useTooltipTriggerState({ delay, isDisabled });
+  const state = useTooltipTriggerState({ delay });
   const trigger = useTooltipTrigger(props, state, triggerRef);
   const tooltip = useTooltip(trigger.tooltipProps, state);
 


### PR DESCRIPTION
 ## Summary

Improves the UX of the "File Access" data folders setting (Preferences → General → Security -> "What folders can Insomnia access?") to address confusion reported in #9064 (specifically [this comment](https://github.com/Kong/insomnia/issues/9064#issuecomment-3323827519)), where users found the Add button misleading — it wasn't clear that a path must be entered first, and clicking Add with an empty input silently did nothing.

This PR does **not** close #9064 (which covers broader file access UX concerns) but addresses the specific input usability pain points discussed there.


 ## Changes

  - On-click validation for empty input: Clicking Add with an empty input now shows a red-bordered input with the message "Enter a folder path to add." instead of silently doing nothing.
  - Duplicate folder path validation: If the user enters a path that already exists in the list and clicks Add, the input is
  highlighted with a red border and a "Duplicate folders are not allowed." message is shown — preventing duplicate entries.
  - Trailing slash normalization: Paths like /Users/foo and /Users/foo/ are as duplicates by stripping trailing slashes before comparison.
  - Validation clears on edit: The error state is dismissed as soon as the user modifies the input.
  - Placeholder example: Added a placeholder (e.g., /Users/folder1) to the data folders input to guide users on the expected
  format.

https://github.com/user-attachments/assets/3d300146-f57d-4b18-9b1f-a26deb94e663


  Related to #9064