### PR TITLE
fix: extract only origin

### DIFF
--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -77,7 +77,14 @@ const locationHistoryMiddleware: Route.ClientMiddlewareFunction = async ({ reque
     console.log('[locationHistoryMiddleware] Failed to store location history entry', err);
   }
 };
-
+const sanitizeUrlAndExtractOrigin = (url: string) => {
+  try {
+    const parsed = new URL(url);
+    return parsed.origin;
+  } catch {
+    return '';
+  }
+};
 export const clientMiddleware: Route.ClientMiddlewareFunction[] = [locationHistoryMiddleware];
 
 export const ErrorBoundary: FC<Route.ErrorBoundaryProps> = ({ error }) => {
@@ -344,6 +351,7 @@ const Root = () => {
 
         return logoutSubmit();
       }
+      // Supports params: uri, curl, origin
       if (urlWithoutParams === 'insomnia://app/import') {
         window.main.trackSegmentEvent({
           event: SegmentEvent.importStarted,
@@ -351,26 +359,19 @@ const Root = () => {
             source: 'import-url',
           },
         });
-        const sanitizeUrlAndExtractOrigin = (url: string) => {
-          try {
-            const parsed = new URL(url);
-            return parsed.origin;
-          } catch {
-            return '';
-          }
-        };
+
         if (params.uri) {
           return setImportObject({
             type: 'uri',
             defaultValue: params.uri,
-            origin: sanitizeUrlAndExtractOrigin(params.uri),
+            origin: sanitizeUrlAndExtractOrigin(params.origin),
           });
         }
         if (params.curl) {
           return setImportObject({
             type: 'curl',
             defaultValue: params.curl,
-            origin: sanitizeUrlAndExtractOrigin(params.curl),
+            origin: sanitizeUrlAndExtractOrigin(params.origin),
           });
         }
       }

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -351,11 +351,27 @@ const Root = () => {
             source: 'import-url',
           },
         });
+        const sanitizeUrlAndExtractOrigin = (url: string) => {
+          try {
+            const parsed = new URL(url);
+            return parsed.origin;
+          } catch {
+            return '';
+          }
+        };
         if (params.uri) {
-          return setImportObject({ type: 'uri', defaultValue: params.uri, origin: params.origin });
+          return setImportObject({
+            type: 'uri',
+            defaultValue: params.uri,
+            origin: sanitizeUrlAndExtractOrigin(params.uri),
+          });
         }
         if (params.curl) {
-          return setImportObject({ type: 'curl', defaultValue: params.curl, origin: params.origin });
+          return setImportObject({
+            type: 'curl',
+            defaultValue: params.curl,
+            origin: sanitizeUrlAndExtractOrigin(params.curl),
+          });
         }
       }
       if (urlWithoutParams === 'insomnia://plugins/install') {


### PR DESCRIPTION
In order to prevent an origin containing js being rendered, we parse it as a url and extract the origin which should prevent strings containing js being admitted.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
