### PR TITLE
feat: skip curl import process

### DIFF
--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -19,6 +19,7 @@ import {
 } from 'react-router';
 
 import { EXTERNAL_VAULT_PLUGIN_NAME, isDevelopment } from '~/common/constants';
+import { setDefaults } from '~/main/importers/utils';
 import * as models from '~/models';
 import type { RequestBody, RequestParameter } from '~/models/request';
 import type { Settings } from '~/models/settings';
@@ -369,9 +370,19 @@ const Root = () => {
           if (organizationId && projectId) {
             try {
               const parseResult = await window.main.parseImport({ contentStr: params.curl }, { importerId: 'curl' });
-              const importedRequest = parseResult.data?.resources?.[0];
+              let importedRequest = parseResult.data?.resources?.[0];
               invariant(parseResult.data?.resources?.length === 1, 'Cannot auto import multiple requests');
               if (importedRequest?.url) {
+                // set defaults
+                importedRequest = {
+                  url: '',
+                  body: '',
+                  parameters: [],
+                  headers: [],
+                  authentication: {},
+                  ...importedRequest,
+                  method: (importedRequest.method || 'GET').toUpperCase(),
+                };
                 // use label to create mcp client, search for existing collection with matching name, or make new collection
                 let importedWorkspace = null;
                 if (params.scope === 'mcp') {
@@ -393,6 +404,9 @@ const Root = () => {
                   }
                 }
                 invariant(importedWorkspace, 'Failed to create workspace for imported request');
+                await models.environment.getOrCreateForParentId(importedWorkspace._id);
+                await models.cookieJar.getOrCreateForParentId(importedWorkspace._id);
+
                 const newRequest = await (params.scope === 'mcp'
                   ? models.mcpRequest.create({
                       parentId: importedWorkspace._id,
@@ -418,14 +432,10 @@ const Root = () => {
                     requests: 1,
                   },
                 });
-                const workspace = importedWorkspace;
-                if (workspace) {
-                  navigate(
-                    `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/debug/request/${newRequest._id}`,
-                  );
-                  return;
-                }
-                throw new Error('Failed to find or create workspace for imported request');
+
+                return navigate(
+                  `/organization/${organizationId}/project/${projectId}/workspace/${importedWorkspace._id}/debug/request/${newRequest._id}`,
+                );
               }
             } catch (err) {
               console.error('[deep-link] Failed to auto-import curl:', err);
@@ -439,40 +449,6 @@ const Root = () => {
             scope: params.scope,
           });
         }
-      }
-      if (urlWithoutParams === 'insomnia://plugins/install') {
-        if (!params.name || params.name.trim() === '') {
-          return showError({
-            title: 'Plugin Install',
-            message: 'Plugin name is required',
-          });
-        }
-
-        return showModal(AskModal, {
-          title: 'Plugin Install',
-          message: (
-            <p className="text-(--hl)">
-              Do you want to install <i className="font-bold text-(--hl)">{params.name}</i>?
-            </p>
-          ),
-          yesText: 'Install',
-          noText: 'Cancel',
-          onDone: async (isYes: boolean) => {
-            if (isYes) {
-              try {
-                // TODO (pavkout): Remove second parameter when we will decide about the @scoped packages name validation
-                await window.main.installPlugin(params.name.trim(), true);
-                showModal(SettingsModal, { tab: 'plugins' });
-              } catch (err) {
-                showError({
-                  title: 'Plugin Install',
-                  message: 'Failed to install plugin',
-                  error: err.message,
-                });
-              }
-            }
-          },
-        });
       }
       if (urlWithoutParams === 'insomnia://plugins/theme') {
         const parsedTheme = JSON.parse(decodeURIComponent(params.theme));

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -372,7 +372,7 @@ const Root = () => {
         }
         if (params.curl) {
           // Validate and auto-import if curl is valid, skipping the import UI
-          if (organizationId && projectId) {
+          if (organizationId && projectId && params.skipImport) {
             try {
               const parseResult = await window.main.parseImport({ contentStr: params.curl }, { importerId: 'curl' });
               const importedRequest = parseResult.data?.resources?.[0];
@@ -380,7 +380,11 @@ const Root = () => {
                 const scanResults = await scanImportResources({ source: 'curl', curl: params.curl });
                 const hasErrors = scanResults.some(r => r.errors?.length);
                 if (!hasErrors && scanResults.length > 0) {
-                  const importedWorkspaces = await importScannedResources({ organizationId, projectId });
+                  const importedWorkspaces = await importScannedResources({
+                    organizationId,
+                    projectId,
+                    options: { label: params.label, scope: params.scope },
+                  });
                   window.main.trackSegmentEvent({
                     event: SegmentEvent.importCompleted,
                     properties: {
@@ -388,7 +392,10 @@ const Root = () => {
                       requests: scanResults.map(r => r.requests?.length || 0),
                     },
                   });
-                  const workspace = Array.isArray(importedWorkspaces) && importedWorkspaces.length === 1 ? importedWorkspaces[0] : undefined;
+                  const workspace =
+                    Array.isArray(importedWorkspaces) && importedWorkspaces.length === 1
+                      ? importedWorkspaces[0]
+                      : undefined;
                   if (workspace) {
                     const requests = await requestOperations.findByParentId(workspace._id);
                     if (Array.isArray(requests) && requests.length === 1) {

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -371,8 +371,7 @@ const Root = () => {
               const importedRequest = parseResult.data?.resources?.[0];
               invariant(parseResult.data?.resources?.length === 1, 'Cannnot auto import multiple requests');
               if (importedRequest?.url) {
-                // use label to set mcp workspace name or search for existing workspace
-                let newWorkspaceId = null;
+                // use label to create mcp client, search for existing collection with matching name, or make new collection
                 let importedWorkspace = null;
                 if (params.scope === 'mcp') {
                   importedWorkspace = await models.workspace.create({
@@ -380,39 +379,32 @@ const Root = () => {
                     name: params.label || 'Imported MCP Client',
                     scope: 'mcp',
                   });
-                  newWorkspaceId = importedWorkspace._id;
                 } else {
                   const workspaces = await models.workspace.findByParentId(projectId);
-                  importedWorkspace = workspaces.find(workspace => workspace.name === params.label);
-                  if (importedWorkspace?._id) {
-                    newWorkspaceId = importedWorkspace._id;
-                  } else {
+                  importedWorkspace = workspaces.find(
+                    workspace => workspace.name === params.label && workspace.scope === 'collection',
+                  );
+                  if (!importedWorkspace) {
                     importedWorkspace = await models.workspace.create({
                       parentId: projectId,
                       name: params.label || 'Imported Collection',
                     });
-                    newWorkspaceId = importedWorkspace._id;
                   }
                 }
-                invariant(newWorkspaceId, 'Failed to create workspace for imported request');
-                let newRequestId = null;
-                if (params.scope === 'mcp') {
-                  const mcpRequest = await models.mcpRequest.create({
-                    parentId: newWorkspaceId,
-                    name: params.label || 'Imported MCP Request',
-                    url: importedRequest.url,
-                    headers: importedRequest.headers,
-                    authentication: importedRequest.authentication,
-                  });
-                  newRequestId = mcpRequest._id;
-                } else {
-                  const request = await models.request.create({
-                    parentId: newWorkspaceId,
-                    name: importedRequest.name || 'Imported Request',
-                    ...importedRequest,
-                  });
-                  newRequestId = request._id;
-                }
+                invariant(importedWorkspace, 'Failed to create workspace for imported request');
+                const newRequest = await (params.scope === 'mcp'
+                  ? models.mcpRequest.create({
+                      parentId: importedWorkspace._id,
+                      name: params.label || 'Imported MCP Request',
+                      url: importedRequest.url,
+                      headers: importedRequest.headers,
+                      authentication: importedRequest.authentication,
+                    })
+                  : models.request.create({
+                      parentId: importedWorkspace._id,
+                      name: importedRequest.name || 'Imported Request',
+                      ...importedRequest,
+                    }));
 
                 window.main.trackSegmentEvent({
                   event: SegmentEvent.importCompleted,
@@ -423,7 +415,7 @@ const Root = () => {
                 const workspace = importedWorkspace;
                 if (workspace) {
                   navigate(
-                    `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/debug/request/${newRequestId}`,
+                    `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/debug/request/${newRequest._id}`,
                   );
                   return;
                 }

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -440,6 +440,40 @@ const Root = () => {
           });
         }
       }
+      if (urlWithoutParams === 'insomnia://plugins/install') {
+        if (!params.name || params.name.trim() === '') {
+          return showError({
+            title: 'Plugin Install',
+            message: 'Plugin name is required',
+          });
+        }
+
+        return showModal(AskModal, {
+          title: 'Plugin Install',
+          message: (
+            <p className="text-(--hl)">
+              Do you want to install <i className="font-bold text-(--hl)">{params.name}</i>?
+            </p>
+          ),
+          yesText: 'Install',
+          noText: 'Cancel',
+          onDone: async (isYes: boolean) => {
+            if (isYes) {
+              try {
+                // TODO (pavkout): Remove second parameter when we will decide about the @scoped packages name validation
+                await window.main.installPlugin(params.name.trim(), true);
+                showModal(SettingsModal, { tab: 'plugins' });
+              } catch (err) {
+                showError({
+                  title: 'Plugin Install',
+                  message: 'Failed to install plugin',
+                  error: err.message,
+                });
+              }
+            }
+          },
+        });
+      }
       if (urlWithoutParams === 'insomnia://plugins/theme') {
         const parsedTheme = JSON.parse(decodeURIComponent(params.theme));
         showModal(AskModal, {

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -20,10 +20,8 @@ import {
 
 import { EXTERNAL_VAULT_PLUGIN_NAME, isDevelopment } from '~/common/constants';
 import * as models from '~/models';
-import * as requestOperations from '~/models/helpers/request-operations';
 import type { Settings } from '~/models/settings';
 import type { UserSession } from '~/models/user-session';
-import { scopeToActivity } from '~/models/workspace';
 import { executePluginMainAction, reloadPlugins } from '~/plugins';
 import { createPlugin } from '~/plugins/create';
 import { setTheme } from '~/plugins/misc';
@@ -32,8 +30,6 @@ import { useDefaultBrowserRedirectActionFetcher } from '~/routes/auth.default-br
 import { useLogoutFetcher } from '~/routes/auth.logout';
 import { useCreateCloudCredentialActionFetcher } from '~/routes/cloud-credentials.create';
 import { useGitProviderCompleteSignInFetcher } from '~/routes/git-credentials.complete-sign-in';
-import { importScannedResources } from '~/routes/import.resources';
-import { scanImportResources } from '~/routes/import.scan';
 import { SegmentEvent } from '~/ui/analytics';
 import { getLoginUrl } from '~/ui/auth-session-provider.client';
 import { CopyButton } from '~/ui/components/base/copy-button';
@@ -48,6 +44,7 @@ import { Toaster } from '~/ui/components/toast-notification';
 import { AppHooks } from '~/ui/containers/app-hooks';
 import cssHref from '~/ui/css/styles.css?url';
 import Modals from '~/ui/modals';
+import { invariant } from '~/utils/invariant';
 
 import type { Route } from './+types/root';
 
@@ -372,42 +369,65 @@ const Root = () => {
             try {
               const parseResult = await window.main.parseImport({ contentStr: params.curl }, { importerId: 'curl' });
               const importedRequest = parseResult.data?.resources?.[0];
+              invariant(parseResult.data?.resources?.length === 1, 'Cannnot auto import multiple requests');
               if (importedRequest?.url) {
-                const scanResults = await scanImportResources({ source: 'curl', curl: params.curl });
-                const hasErrors = scanResults.some(r => r.errors?.length);
-                if (!hasErrors && scanResults.length > 0) {
-                  const importedWorkspaces = await importScannedResources({
-                    organizationId,
-                    projectId,
-                    options: { label: params.label, scope: params.scope },
+                // use label to set mcp workspace name or search for existing workspace
+                let newWorkspaceId = null;
+                let importedWorkspace = null;
+                if (params.scope === 'mcp') {
+                  importedWorkspace = await models.workspace.create({
+                    parentId: projectId,
+                    name: params.label || 'Imported MCP Client',
+                    scope: 'mcp',
                   });
-                  window.main.trackSegmentEvent({
-                    event: SegmentEvent.importCompleted,
-                    properties: {
-                      workspaces: scanResults.map(r => r.workspaces?.length || 0),
-                      requests: scanResults.map(r => r.requests?.length || 0),
-                    },
-                  });
-                  const workspace =
-                    Array.isArray(importedWorkspaces) && importedWorkspaces.length === 1
-                      ? importedWorkspaces[0]
-                      : undefined;
-                  if (workspace) {
-                    const requests = await requestOperations.findByParentId(workspace._id);
-                    if (Array.isArray(requests) && requests.length === 1) {
-                      navigate(
-                        `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/debug/request/${requests[0]._id}`,
-                      );
-                      return;
-                    }
-                    navigate(
-                      `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/${scopeToActivity(workspace.scope)}`,
-                    );
-                    return;
+                  newWorkspaceId = importedWorkspace._id;
+                } else {
+                  const workspaces = await models.workspace.findByParentId(projectId);
+                  importedWorkspace = workspaces.find(workspace => workspace.name === params.label);
+                  if (importedWorkspace?._id) {
+                    newWorkspaceId = importedWorkspace._id;
+                  } else {
+                    importedWorkspace = await models.workspace.create({
+                      parentId: projectId,
+                      name: params.label || 'Imported Collection',
+                    });
+                    newWorkspaceId = importedWorkspace._id;
                   }
-                  navigate(`/organization/${organizationId}/project/${projectId}`);
+                }
+                invariant(newWorkspaceId, 'Failed to create workspace for imported request');
+                let newRequestId = null;
+                if (params.scope === 'mcp') {
+                  const mcpRequest = await models.mcpRequest.create({
+                    parentId: newWorkspaceId,
+                    name: params.label || 'Imported MCP Request',
+                    url: importedRequest.url,
+                    headers: importedRequest.headers,
+                    authentication: importedRequest.authentication,
+                  });
+                  newRequestId = mcpRequest._id;
+                } else {
+                  const request = await models.request.create({
+                    parentId: newWorkspaceId,
+                    name: importedRequest.name || 'Imported Request',
+                    ...importedRequest,
+                  });
+                  newRequestId = request._id;
+                }
+
+                window.main.trackSegmentEvent({
+                  event: SegmentEvent.importCompleted,
+                  properties: {
+                    requests: 1,
+                  },
+                });
+                const workspace = importedWorkspace;
+                if (workspace) {
+                  navigate(
+                    `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/debug/request/${newRequestId}`,
+                  );
                   return;
                 }
+                throw new Error('Failed to find or create workspace for imported request');
               }
             } catch (err) {
               console.error('[deep-link] Failed to auto-import curl:', err);
@@ -421,40 +441,6 @@ const Root = () => {
             scope: params.scope,
           });
         }
-      }
-      if (urlWithoutParams === 'insomnia://plugins/install') {
-        if (!params.name || params.name.trim() === '') {
-          return showError({
-            title: 'Plugin Install',
-            message: 'Plugin name is required',
-          });
-        }
-
-        return showModal(AskModal, {
-          title: 'Plugin Install',
-          message: (
-            <p className="text-(--hl)">
-              Do you want to install <i className="font-bold text-(--hl)">{params.name}</i>?
-            </p>
-          ),
-          yesText: 'Install',
-          noText: 'Cancel',
-          onDone: async (isYes: boolean) => {
-            if (isYes) {
-              try {
-                // TODO (pavkout): Remove second parameter when we will decide about the @scoped packages name validation
-                await window.main.installPlugin(params.name.trim(), true);
-                showModal(SettingsModal, { tab: 'plugins' });
-              } catch (err) {
-                showError({
-                  title: 'Plugin Install',
-                  message: 'Failed to install plugin',
-                  error: err.message,
-                });
-              }
-            }
-          },
-        });
       }
       if (urlWithoutParams === 'insomnia://plugins/theme') {
         const parsedTheme = JSON.parse(decodeURIComponent(params.theme));

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -449,6 +449,40 @@ const Root = () => {
           });
         }
       }
+      if (urlWithoutParams === 'insomnia://plugins/install') {
+        if (!params.name || params.name.trim() === '') {
+          return showError({
+            title: 'Plugin Install',
+            message: 'Plugin name is required',
+          });
+        }
+
+        return showModal(AskModal, {
+          title: 'Plugin Install',
+          message: (
+            <p className="text-(--hl)">
+              Do you want to install <i className="font-bold text-(--hl)">{params.name}</i>?
+            </p>
+          ),
+          yesText: 'Install',
+          noText: 'Cancel',
+          onDone: async (isYes: boolean) => {
+            if (isYes) {
+              try {
+                // TODO (pavkout): Remove second parameter when we will decide about the @scoped packages name validation
+                await window.main.installPlugin(params.name.trim(), true);
+                showModal(SettingsModal, { tab: 'plugins' });
+              } catch (err) {
+                showError({
+                  title: 'Plugin Install',
+                  message: 'Failed to install plugin',
+                  error: err.message,
+                });
+              }
+            }
+          },
+        });
+      }
       if (urlWithoutParams === 'insomnia://plugins/theme') {
         const parsedTheme = JSON.parse(decodeURIComponent(params.theme));
         showModal(AskModal, {

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -20,8 +20,10 @@ import {
 
 import { EXTERNAL_VAULT_PLUGIN_NAME, isDevelopment } from '~/common/constants';
 import * as models from '~/models';
+import * as requestOperations from '~/models/helpers/request-operations';
 import type { Settings } from '~/models/settings';
 import type { UserSession } from '~/models/user-session';
+import { scopeToActivity } from '~/models/workspace';
 import { executePluginMainAction, reloadPlugins } from '~/plugins';
 import { createPlugin } from '~/plugins/create';
 import { setTheme } from '~/plugins/misc';
@@ -30,7 +32,8 @@ import { useDefaultBrowserRedirectActionFetcher } from '~/routes/auth.default-br
 import { useLogoutFetcher } from '~/routes/auth.logout';
 import { useCreateCloudCredentialActionFetcher } from '~/routes/cloud-credentials.create';
 import { useGitProviderCompleteSignInFetcher } from '~/routes/git-credentials.complete-sign-in';
-import type { SourceType } from '~/routes/import.scan';
+import { importScannedResources } from '~/routes/import.resources';
+import { scanImportResources, type SourceType } from '~/routes/import.scan';
 import { SegmentEvent } from '~/ui/analytics';
 import { getLoginUrl } from '~/ui/auth-session-provider.client';
 import { CopyButton } from '~/ui/components/base/copy-button';
@@ -368,6 +371,45 @@ const Root = () => {
           });
         }
         if (params.curl) {
+          // Validate and auto-import if curl is valid, skipping the import UI
+          if (organizationId && projectId) {
+            try {
+              const parseResult = await window.main.parseImport({ contentStr: params.curl }, { importerId: 'curl' });
+              const importedRequest = parseResult.data?.resources?.[0];
+              if (importedRequest?.url) {
+                const scanResults = await scanImportResources({ source: 'curl', curl: params.curl });
+                const hasErrors = scanResults.some(r => r.errors?.length);
+                if (!hasErrors && scanResults.length > 0) {
+                  const importedWorkspaces = await importScannedResources({ organizationId, projectId });
+                  window.main.trackSegmentEvent({
+                    event: SegmentEvent.importCompleted,
+                    properties: {
+                      workspaces: scanResults.map(r => r.workspaces?.length || 0),
+                      requests: scanResults.map(r => r.requests?.length || 0),
+                    },
+                  });
+                  const workspace = Array.isArray(importedWorkspaces) && importedWorkspaces.length === 1 ? importedWorkspaces[0] : undefined;
+                  if (workspace) {
+                    const requests = await requestOperations.findByParentId(workspace._id);
+                    if (Array.isArray(requests) && requests.length === 1) {
+                      navigate(
+                        `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/debug/request/${requests[0]._id}`,
+                      );
+                      return;
+                    }
+                    navigate(
+                      `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/${scopeToActivity(workspace.scope)}`,
+                    );
+                    return;
+                  }
+                  navigate(`/organization/${organizationId}/project/${projectId}`);
+                  return;
+                }
+              }
+            } catch (err) {
+              console.error('[deep-link] Failed to auto-import curl:', err);
+            }
+          }
           return setImportObject({
             type: 'curl',
             defaultValue: params.curl,
@@ -571,6 +613,8 @@ const Root = () => {
     gitProviderCompleteSignInSubmit,
     logoutSubmit,
     navigate,
+    organizationId,
+    projectId,
     redirectToDefaultBrowserSubmit,
   ]);
 

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -317,6 +317,8 @@ const Root = () => {
     type: SourceType;
     defaultValue: string;
     origin?: string;
+    label?: string;
+    scope?: string;
   });
   const { submit: createCloudCredentials } = useCreateCloudCredentialActionFetcher();
   const { submit: authorizeSubmit } = useAuthorizeActionFetcher();
@@ -421,6 +423,8 @@ const Root = () => {
             type: 'curl',
             defaultValue: params.curl,
             origin: sanitizeUrlAndExtractOrigin(params.origin),
+            label: params.label,
+            scope: params.scope,
           });
         }
       }

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -374,7 +374,7 @@ const Root = () => {
         }
         if (params.curl) {
           // Validate and auto-import if curl is valid, skipping the import UI
-          if (organizationId && projectId && params.skipImport) {
+          if (organizationId && projectId) {
             try {
               const parseResult = await window.main.parseImport({ contentStr: params.curl }, { importerId: 'curl' });
               const importedRequest = parseResult.data?.resources?.[0];

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -370,7 +370,7 @@ const Root = () => {
             try {
               const parseResult = await window.main.parseImport({ contentStr: params.curl }, { importerId: 'curl' });
               const importedRequest = parseResult.data?.resources?.[0];
-              invariant(parseResult.data?.resources?.length === 1, 'Cannnot auto import multiple requests');
+              invariant(parseResult.data?.resources?.length === 1, 'Cannot auto import multiple requests');
               if (importedRequest?.url) {
                 // use label to create mcp client, search for existing collection with matching name, or make new collection
                 let importedWorkspace = null;

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -33,7 +33,7 @@ import { useLogoutFetcher } from '~/routes/auth.logout';
 import { useCreateCloudCredentialActionFetcher } from '~/routes/cloud-credentials.create';
 import { useGitProviderCompleteSignInFetcher } from '~/routes/git-credentials.complete-sign-in';
 import { importScannedResources } from '~/routes/import.resources';
-import { scanImportResources, type SourceType } from '~/routes/import.scan';
+import { scanImportResources } from '~/routes/import.scan';
 import { SegmentEvent } from '~/ui/analytics';
 import { getLoginUrl } from '~/ui/auth-session-provider.client';
 import { CopyButton } from '~/ui/components/base/copy-button';
@@ -42,7 +42,7 @@ import { Icon } from '~/ui/components/icon';
 import { showError, showModal } from '~/ui/components/modals';
 import { AlertModal } from '~/ui/components/modals/alert-modal';
 import { AskModal } from '~/ui/components/modals/ask-modal';
-import { ImportModal } from '~/ui/components/modals/import-modal/import-modal';
+import { ImportModal, type ImportSourceType } from '~/ui/components/modals/import-modal/import-modal';
 import { SettingsModal } from '~/ui/components/modals/settings-modal';
 import { Toaster } from '~/ui/components/toast-notification';
 import { AppHooks } from '~/ui/containers/app-hooks';
@@ -313,13 +313,7 @@ const Root = () => {
     projectId: string;
   };
 
-  const [importObject, setImportObject] = useState({ type: 'clipboard', defaultValue: '' } as {
-    type: SourceType;
-    defaultValue: string;
-    origin?: string;
-    label?: string;
-    scope?: string;
-  });
+  const [importObject, setImportObject] = useState({ type: 'clipboard', defaultValue: '' } as ImportSourceType);
   const { submit: createCloudCredentials } = useCreateCloudCredentialActionFetcher();
   const { submit: authorizeSubmit } = useAuthorizeActionFetcher();
   const { submit: logoutSubmit } = useLogoutFetcher();

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -19,7 +19,6 @@ import {
 } from 'react-router';
 
 import { EXTERNAL_VAULT_PLUGIN_NAME, isDevelopment } from '~/common/constants';
-import { setDefaults } from '~/main/importers/utils';
 import * as models from '~/models';
 import type { RequestBody, RequestParameter } from '~/models/request';
 import type { Settings } from '~/models/settings';

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -20,6 +20,7 @@ import {
 
 import { EXTERNAL_VAULT_PLUGIN_NAME, isDevelopment } from '~/common/constants';
 import * as models from '~/models';
+import type { RequestBody, RequestParameter } from '~/models/request';
 import type { Settings } from '~/models/settings';
 import type { UserSession } from '~/models/user-session';
 import { executePluginMainAction, reloadPlugins } from '~/plugins';
@@ -402,8 +403,13 @@ const Root = () => {
                     })
                   : models.request.create({
                       parentId: importedWorkspace._id,
-                      name: importedRequest.name || 'Imported Request',
-                      ...importedRequest,
+                      name: params.label || 'Imported Request',
+                      url: importedRequest.url,
+                      method: importedRequest.method,
+                      headers: importedRequest.headers,
+                      authentication: importedRequest.authentication,
+                      parameters: importedRequest.parameters as RequestParameter[],
+                      body: importedRequest.body as RequestBody,
                     }));
 
                 window.main.trackSegmentEvent({

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -43,7 +43,7 @@ export const importScannedResources = async ({
     if (options.scope === 'mcp') {
       const newWorkspace = await models.workspace.create({
         parentId: projectId,
-        name: options.label,
+        name: options.label || 'Imported MCP Client',
         scope: 'mcp',
       });
       workspaceId = newWorkspace._id;

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -22,8 +22,6 @@ interface ImportScannedResourcesParams {
   workspaceId?: string;
   options?: {
     overrideBaseEnvironmentData?: boolean;
-    label?: string;
-    scope?: string;
   };
 }
 
@@ -38,29 +36,6 @@ export const importScannedResources = async ({
 
   const project = await models.project.getById(projectId);
   invariant(project, 'Project not found.');
-  // use label to set mcp workspace name or search for existing workspace
-  if (!workspaceId && options?.label) {
-    if (options.scope === 'mcp') {
-      const newWorkspace = await models.workspace.create({
-        parentId: projectId,
-        name: options.label || 'Imported MCP Client',
-        scope: 'mcp',
-      });
-      workspaceId = newWorkspace._id;
-    } else {
-      const workspaces = await models.workspace.findByParentId(projectId);
-      const matchedWorkspace = workspaces.find(workspace => workspace.name === options.label);
-      if (matchedWorkspace) {
-        workspaceId = matchedWorkspace._id;
-      } else {
-        const newWorkspace = await models.workspace.create({
-          parentId: projectId,
-          name: options.label || 'Imported Collection',
-        });
-        workspaceId = newWorkspace._id;
-      }
-    }
-  }
 
   return await (typeof workspaceId === 'string' && workspaceId
     ? importResourcesToWorkspace({

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -52,6 +52,12 @@ export const importScannedResources = async ({
       const matchedWorkspace = workspaces.find(workspace => workspace.name === options.label);
       if (matchedWorkspace) {
         workspaceId = matchedWorkspace._id;
+      } else {
+        const newWorkspace = await models.workspace.create({
+          parentId: projectId,
+          name: options.label || 'Imported Collection',
+        });
+        workspaceId = newWorkspace._id;
       }
     }
   }

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -22,6 +22,8 @@ interface ImportScannedResourcesParams {
   workspaceId?: string;
   options?: {
     overrideBaseEnvironmentData?: boolean;
+    label?: string;
+    scope?: string;
   };
 }
 
@@ -36,6 +38,23 @@ export const importScannedResources = async ({
 
   const project = await models.project.getById(projectId);
   invariant(project, 'Project not found.');
+  // use label to set mcp workspace name or search for existing workspace
+  if (!workspaceId && options?.label) {
+    if (options.scope === 'mcp') {
+      const newWorkspace = await models.workspace.create({
+        parentId: projectId,
+        name: options.label,
+        scope: 'mcp',
+      });
+      workspaceId = newWorkspace._id;
+    } else {
+      const workspaces = await models.workspace.findByParentId(projectId);
+      const matchedWorkspace = workspaces.find(workspace => workspace.name === options.label);
+      if (matchedWorkspace) {
+        workspaceId = matchedWorkspace._id;
+      }
+    }
+  }
 
   return await (typeof workspaceId === 'string' && workspaceId
     ? importResourcesToWorkspace({

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -340,7 +340,7 @@ export const ImportModal: FC<ImportModalProps> = ({
 };
 const validateCurl = async (value: string) => {
   if (!value) {
-    return 'Invalid cURL request';
+    return '';
   }
   try {
     const { data } = await window.main.parseImport({ contentStr: value }, { importerId: 'curl' });
@@ -437,7 +437,7 @@ const ScanResourcesForm = ({
           {selectedTab === 'uri' && (
             <div className="form-control form-control--outlined">
               <label>
-                Url:
+                Url
                 <input
                   type="text"
                   name="uri"
@@ -450,7 +450,7 @@ const ScanResourcesForm = ({
           {selectedTab === 'curl' && (
             <div className="form-control form-control--outlined">
               <label>
-                cURL:
+                cURL
                 <textarea
                   className="h-[200px] resize-none font-mono"
                   name="curl"

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -309,8 +309,6 @@ export const ImportModal: FC<ImportModalProps> = ({
                 workspaceId: selectedWorkspaceId || (shouldImportToWorkspace ? defaultWorkspaceId : undefined),
                 options: {
                   overrideBaseEnvironmentData,
-                  label: from.type === 'curl' ? from.label : undefined,
-                  scope: from.type === 'curl' ? from.scope : undefined,
                 },
               });
               scanResourcesFetcherData

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -21,7 +21,7 @@ import { ModalHeader } from '../../base/modal-header';
 import { HelpTooltip } from '../../help-tooltip';
 import { Icon } from '../../icon';
 import { Button } from '../../themed-button';
-import { CurlIcon, disclaimer, ScanResultsTable, SupportedFormats, validImportExtensions } from './shared';
+import { CurlIcon, ScanResultsTable, SupportedFormats, validImportExtensions } from './shared';
 
 export const Radio: FC<{
   name: string;

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -388,9 +388,6 @@ const ScanResourcesForm = ({
   return (
     <Fragment>
       <div className="flex flex-col overflow-y-auto">
-        <div className="mb-4 w-full items-center gap-4 rounded-lg border border-solid border-[rgba(var(--color-warning-rgb),1)] bg-(--color-bg) px-3 py-2 text-sm text-wrap text-[rgba(var(--color-warning-rgb),1)] shadow-lg outline-hidden">
-          ⚠️ Make sure that you trust the import source before continuing.
-        </div>
         <form
           aria-label="Import from"
           id={id}
@@ -471,11 +468,12 @@ const ScanResourcesForm = ({
             <ScanResultsTable scanResults={scanResults} />
           </div>
         )}
-        {selectedTab === 'curl' && message && <div className="truncate">{message}</div>}
-        {from?.type === 'curl' && from.origin && (
-          <div className="flex w-full justify-start py-1">
-            <CurlIcon />
-            cURL from{' '}
+        {selectedTab === 'curl' && message && (
+          <div className={`truncate ${isValidCurl ? '' : 'text-(--color-danger)'}`}>{message}</div>
+        )}
+        {from?.origin && (
+          <div className="flex w-full justify-start py-2">
+            from{' '}
             <Link
               className="px-2 font-bold underline"
               onClick={() => {
@@ -488,6 +486,9 @@ const ScanResourcesForm = ({
             ⚠️
           </div>
         )}
+        <div className="mt-4 w-full items-center gap-4 text-wrap outline-hidden">
+          ⚠️ Make sure that you trust the import source before continuing.
+        </div>
       </div>
 
       <div className="flex items-end justify-between gap-(--padding-sm)">
@@ -627,10 +628,7 @@ const ImportResourcesForm = ({
         </div>
       </div>
 
-      <div className="flex w-full items-end justify-between gap-(--padding-sm)">
-        <div>
-          <div className="pb-(--padding-sm)">{disclaimer}</div>
-        </div>
+      <div className="flex w-full items-end justify-end gap-(--padding-sm)">
         <Button
           variant="contained"
           bg="surprise"

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -165,7 +165,29 @@ const FileField: FC = () => {
     </div>
   );
 };
-
+export type ImportSourceType =
+  | {
+      type: 'file';
+      origin?: string;
+      defaultValue?: string;
+    }
+  | {
+      type: 'uri';
+      defaultValue?: string;
+      origin?: string;
+    }
+  | {
+      type: 'curl';
+      defaultValue?: string;
+      origin?: string;
+      label?: string;
+      scope?: string;
+    }
+  | {
+      type: 'clipboard';
+      origin?: string;
+      defaultValue?: string;
+    };
 interface ImportModalProps extends ModalProps {
   organizationId: string;
   projectName: string;
@@ -175,25 +197,7 @@ interface ImportModalProps extends ModalProps {
   defaultProjectId: string;
   // undefined when in workspace selection page
   defaultWorkspaceId?: string;
-  from:
-    | {
-        type: 'file';
-        origin?: string;
-      }
-    | {
-        type: 'uri';
-        defaultValue?: string;
-        origin?: string;
-      }
-    | {
-        type: 'curl';
-        defaultValue?: string;
-        origin?: string;
-      }
-    | {
-        type: 'clipboard';
-        origin?: string;
-      };
+  from: ImportSourceType;
 }
 
 export const ImportModal: FC<ImportModalProps> = ({
@@ -305,6 +309,8 @@ export const ImportModal: FC<ImportModalProps> = ({
                 workspaceId: selectedWorkspaceId || (shouldImportToWorkspace ? defaultWorkspaceId : undefined),
                 options: {
                   overrideBaseEnvironmentData,
+                  label: from.type === 'curl' ? from.label : undefined,
+                  scope: from.type === 'curl' ? from.scope : undefined,
                 },
               });
               scanResourcesFetcherData
@@ -497,7 +503,7 @@ const ScanResourcesForm = ({
           className="btn h-10 gap-(--padding-sm)"
         >
           <i className="fa fa-file-import" /> Scan
-          {loading && <Icon icon="spinner" className="ml-[4px] animate-spin" />}
+          {loading && <Icon icon="spinner" className="ml-1 animate-spin" />}
         </Button>
       </div>
     </Fragment>

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -366,7 +366,7 @@ const ScanResourcesForm = ({
   loading: boolean;
 }) => {
   const id = useId();
-  const [importFrom, setImportFrom] = useState(from?.type || 'uri');
+  const [selectedTab, setSelectedTab] = useState(from?.type || 'uri');
   const [message, setMessage] = useState('');
 
   useEffect(() => {
@@ -380,7 +380,7 @@ const ScanResourcesForm = ({
       isMounted = false;
     };
   }, [from]);
-  const isValidCurl = (importFrom === 'curl' && message && message.startsWith('Detected')) || importFrom !== 'curl';
+  const isValidCurl = (selectedTab === 'curl' && message && message.startsWith('Detected')) || selectedTab !== 'curl';
   return (
     <Fragment>
       <div className="flex flex-col overflow-y-auto">
@@ -396,31 +396,41 @@ const ScanResourcesForm = ({
         >
           <fieldset className="flex flex-col gap-(--padding-md)">
             <div className="flex rounded-md border border-solid border-(--hl-md) bg-(--hl-xs) p-(--padding-xs)">
-              <Radio onChange={() => setImportFrom('file')} name="source" value="file" checked={importFrom === 'file'}>
+              <Radio
+                onChange={() => setSelectedTab('file')}
+                name="source"
+                value="file"
+                checked={selectedTab === 'file'}
+              >
                 <i className="fa fa-plus" />
                 File
               </Radio>
-              <Radio onChange={() => setImportFrom('uri')} name="source" value="uri" checked={importFrom === 'uri'}>
+              <Radio onChange={() => setSelectedTab('uri')} name="source" value="uri" checked={selectedTab === 'uri'}>
                 <i className="fa fa-link" />
                 Url
               </Radio>
-              <Radio onChange={() => setImportFrom('curl')} name="source" value="curl" checked={importFrom === 'curl'}>
+              <Radio
+                onChange={() => setSelectedTab('curl')}
+                name="source"
+                value="curl"
+                checked={selectedTab === 'curl'}
+              >
                 <CurlIcon />
                 cURL
               </Radio>
               <Radio
-                onChange={() => setImportFrom('clipboard')}
+                onChange={() => setSelectedTab('clipboard')}
                 name="source"
                 value="clipboard"
-                checked={importFrom === 'clipboard'}
+                checked={selectedTab === 'clipboard'}
               >
                 <i className="fa fa-clipboard" />
                 Clipboard
               </Radio>
             </div>
           </fieldset>
-          {importFrom === 'file' && <FileField />}
-          {importFrom === 'uri' && (
+          {selectedTab === 'file' && <FileField />}
+          {selectedTab === 'uri' && (
             <div className="form-control form-control--outlined">
               <label>
                 Url:
@@ -433,7 +443,7 @@ const ScanResourcesForm = ({
               </label>
             </div>
           )}
-          {importFrom === 'curl' && (
+          {selectedTab === 'curl' && (
             <div className="form-control form-control--outlined">
               <label>
                 cURL:
@@ -457,7 +467,7 @@ const ScanResourcesForm = ({
             <ScanResultsTable scanResults={scanResults} />
           </div>
         )}
-        {importFrom === 'curl' && message && <div className="truncate">{message}</div>}
+        {selectedTab === 'curl' && message && <div className="truncate">{message}</div>}
         {from?.type === 'curl' && from.origin && (
           <div className="flex w-full justify-start py-1">
             <CurlIcon />


### PR DESCRIPTION
motivation: lower friction from deeplink to request send time. Also support mcp.
If curl is valid, we redirect directly to the request.

TODO:
- [x] add inline import logic and redirect before starting ux
- [x] add scope param for mcp
- [x] add label for mcp workspace name, search in current project, or default new workspace name
- [x] add mcp and label drilling for regular ux

Cases supported

create new collection/add to existing with label name
`insomniadev://app/import?label=Testname&curl=curl 'http://en.wikipedia.org/'`
invalid input
`insomniadev://app/import?label=Testname&curl=curl broken input`
create new mcp client
`insomniadev://app/import?label=Testname&scope=mcp&curl=curl 'http://en.wikipedia.org/'`

<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
