### PR TITLE
fix: add more error messages when calling LLM providers within AI Set…

### DIFF
--- a/packages/insomnia/src/ui/components/settings/llms/claude.tsx
+++ b/packages/insomnia/src/ui/components/settings/llms/claude.tsx
@@ -56,6 +56,9 @@ export const Claude = ({
           if (configuredLLMs.length === 1 && configuredLLMs[0].apiKey !== realApiKey) {
             saveLLMSettings(false, 'claude', { apiKey: realApiKey });
           }
+        } else {
+          console.error('Anthropic models response contained no data:', data);
+          setError('No models returned by the API.');
         }
       } catch (error) {
         console.error('Error fetching Claude models:', error);

--- a/packages/insomnia/src/ui/components/settings/llms/gemini.tsx
+++ b/packages/insomnia/src/ui/components/settings/llms/gemini.tsx
@@ -51,10 +51,18 @@ export const Gemini = ({
           const geminiModels = (data.models as GeminiModelData[])
             .filter(model => model.supportedGenerationMethods.includes('generateContent'))
             .sort((a, b) => b.name.localeCompare(a.name));
-          setAvailableModels(geminiModels);
-          if (configuredLLMs.length === 1 && configuredLLMs[0].apiKey !== realApiKey) {
-            saveLLMSettings(false, 'gemini', { apiKey: realApiKey });
+          if (geminiModels.length === 0) {
+            console.error('No compatible Gemini models found in response:', data.models);
+            setError('No compatible models found for this API key.');
+          } else {
+            setAvailableModels(geminiModels);
+            if (configuredLLMs.length === 1 && configuredLLMs[0].apiKey !== realApiKey) {
+              saveLLMSettings(false, 'gemini', { apiKey: realApiKey });
+            }
           }
+        } else {
+          console.error('Gemini models response contained no data:', data);
+          setError('No models returned by the API.');
         }
       } catch (error) {
         console.error('Error fetching Gemini models:', error);

--- a/packages/insomnia/src/ui/components/settings/llms/openai.tsx
+++ b/packages/insomnia/src/ui/components/settings/llms/openai.tsx
@@ -55,10 +55,18 @@ export const OpenAI = ({
           const gptModels = (data.data as OpenAIModelData[])
             .filter(model => model.id.includes('gpt') && model.object === 'model')
             .sort((a, b) => b.id.localeCompare(a.id));
-          setAvailableModels(gptModels);
-          if (configuredLLMs.length === 1 && configuredLLMs[0].apiKey !== realApiKey) {
-            saveLLMSettings(false, 'openai', { apiKey: realApiKey });
+          if (gptModels.length === 0) {
+            console.error('No compatible GPT models found in OpenAI response:', data.data);
+            setError('No compatible models found for this API key.');
+          } else {
+            setAvailableModels(gptModels);
+            if (configuredLLMs.length === 1 && configuredLLMs[0].apiKey !== realApiKey) {
+              saveLLMSettings(false, 'openai', { apiKey: realApiKey });
+            }
           }
+        } else {
+          console.error('OpenAI models response contained no data:', data);
+          setError('No models returned by the API.');
         }
       } catch (error) {
         console.error('Error fetching OpenAI models:', error);

--- a/packages/insomnia/src/ui/components/settings/llms/url.tsx
+++ b/packages/insomnia/src/ui/components/settings/llms/url.tsx
@@ -81,6 +81,11 @@ export const Url = ({
         }
 
         const models = (data.data as LLMModelData[]).filter(model => model.object === 'model');
+        if (models.length === 0) {
+          console.error('No compatible models found in URL response:', data.data);
+          setError('No compatible models found at this URL.');
+          return;
+        }
         setAvailableModels(models);
         saveLLMSettings(false, URL_BACKEND, { url: realUrl, model: 'default' });
       } catch (error) {


### PR DESCRIPTION
**Fix: Show error when "Load Models" returns no results**

Previously, if the models API responded successfully but returned no usable models (empty response body, or all models filtered out), the loading indicator would disappear silently with no feedback to the user.

**Changes:**

- `openai.tsx` — error shown when `data.data `is empty, or when no models pass the `gpt` + `object === 'model'` filter
- `gemini.tsx` — same pattern: error shown for empty `data.models`, or when no models pass the `generateContent` filter
- `claude.tsx` — error shown when `data.data` is empty (no client-side filter applied)
- `url.tsx `— error shown when models pass the API response check but none pass the `object === 'model'` filter (empty `data.data` was already handled)

All error paths include a `console.error` with the raw response data for debuggability.