### PR TITLE
feat: Update docs link covering Insomnia metadata [INS-1475]

### DIFF
--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -1180,7 +1180,7 @@ export const GitProjectStagingModal: FC<{
                       <p>
                         <Icon icon="info-circle" className="mr-2" />
                         This file includes changes to{' '}
-                        <LearnMoreLink href="https://insomnia.rest/">Insomnia metadata</LearnMoreLink>, which is
+                        <LearnMoreLink href="https://developer.konghq.com/insomnia/git-sync/#metadata-changes">Insomnia metadata</LearnMoreLink>, which is
                         determined by the system and cannot be discarded.
                       </p>
                       {previewDiffItem && (


### PR DESCRIPTION
The actual documentation page URL wasn't available when the [original PR](https://github.com/Kong/insomnia/pull/9607/changes#diff-33dc06828fb670161eb65d5d9c954f2254ddbd686d7389619ea100d6b738f789R1183) was merged. This PR updates the URL to point to the actual expected URL.

Changes were tested by running the app locally. There are no contents in production at this URL yet so it'll render a 404 page, but the documentation will be deployed in tandem with the app release.