### PR TITLE
fix: folder collapse & shortcuts when focusing the tab

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.tsx
@@ -122,6 +122,7 @@ import { useTabNavigate } from '~/ui/hooks/use-insomnia-tab';
 import { useReadyState } from '~/ui/hooks/use-ready-state';
 import {
   type CreateRequestType,
+  useRequestGroupMetaPatcher,
   useRequestGroupPatcher,
   useRequestMetaPatcher,
   useRequestPatcher,
@@ -1429,6 +1430,7 @@ const CollectionGridListItem = ({
   const patchRequestMeta = useRequestMetaPatcher();
 
   const tabNavigate = useTabNavigate();
+  const groupMetaPatcher = useRequestGroupMetaPatcher();
 
   const action = isRequestGroup(item.doc)
     ? `/organization/${organizationId}/project/${projectId}/workspace/${workspaceId}/debug/request-group/${item.doc._id}/update`
@@ -1466,6 +1468,12 @@ const CollectionGridListItem = ({
       style={style}
       onAction={() => {}}
       onPress={e => {
+        const id = item.doc._id;
+        // Toggle collapse if it's a request group
+        if (isRequestGroupId(id)) {
+          groupMetaPatcher(id, { collapsed: !item.collapsed });
+        }
+
         tabNavigate(
           {
             organization: organizationId,

--- a/packages/insomnia/src/ui/components/keydown-binder.ts
+++ b/packages/insomnia/src/ui/components/keydown-binder.ts
@@ -17,7 +17,7 @@ const keyCombinationToTinyKeyString = ({ ctrl, alt, shift, meta, keyCode }: KeyC
   Object.entries(keyboardKeys).find(([, { keyCode: kc }]) => kc === keyCode)?.[1].code;
 
 export function useKeyboardShortcuts(
-  getTarget: () => HTMLElement,
+  getTarget: () => HTMLElement | Window,
   listeners: Partial<Record<KeyboardShortcut, (event: KeyboardEvent) => any>>,
 ) {
   const { settings } = useRootLoaderData()!;
@@ -56,7 +56,7 @@ export function useKeyboardShortcuts(
 export function useDocBodyKeyboardShortcuts(
   listeners: Partial<Record<KeyboardShortcut, (event: KeyboardEvent) => any>>,
 ) {
-  useKeyboardShortcuts(() => document.body, listeners);
+  useKeyboardShortcuts(() => window, listeners);
 }
 
 export function createKeybindingsHandler(


### PR DESCRIPTION
## Background

- React Aria captures the focused elements' events on the document. When we bind the global shortcuts to the body, it cannot capture the events.
- Missing toggle the request group collapse state in the previous PR

## Changes

- Bind the global shortcuts to the window
- Add toggle request group collapse state