### PR TITLE
feat: support for middle mouse button click to open new tab

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -1108,6 +1108,12 @@ const Component = () => {
                           textValue={item.name}
                           // onAction is required for onPress with selectionMode='none' but we handle clicks in onPress
                           onAction={() => {}}
+                          onAuxClick={e => {
+                            if (e.button === 1) {
+                              e.preventDefault();
+                              item.action(true);
+                            }
+                          }}
                           onPress={e => {
                             item.action(isPrimaryClickModifier(e));
                           }}

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.tsx
@@ -309,6 +309,12 @@ const Component = () => {
                   id={item._id}
                   textValue={item.name}
                   className="group w-full outline-hidden select-none"
+                  onAuxClick={e => {
+                    if (e.button === 1) {
+                      e.preventDefault();
+                      mockRouteNavigateAction(item._id, true);
+                    }
+                  }}
                   onPress={e => {
                     mockRouteNavigateAction(item._id, isPrimaryClickModifier(e));
                   }}

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.test.tsx
@@ -387,6 +387,12 @@ const Component = () => {
                     id={item._id}
                     textValue={item.name}
                     className="group w-full outline-hidden select-none"
+                    onAuxClick={e => {
+                      if (e.button === 1) {
+                        e.preventDefault();
+                        navigateToTestSuite(item, true);
+                      }
+                    }}
                     onPress={e => {
                       navigateToTestSuite(item, isPrimaryClickModifier(e));
                     }}


### PR DESCRIPTION
## Background

Support middle mouse button click to open in a new tab.

As a supplement to #9685. 

## Changes

Added `onAuxClick` handlers to list items in the following components to support middle mouse button clicks:
  - Organization project index page
  - Mock server workspace page
  - Test suite workspace page