### PR TITLE
refactor: migrate remaining apis - [INS-2162]

### DIFF
--- a/packages/insomnia-api/src/index.ts
+++ b/packages/insomnia-api/src/index.ts
@@ -6,5 +6,7 @@ export * from './project';
 export * from './collaborators';
 export * from './invite';
 export * from './organizations';
+export * from './mock';
+export * from './vcs';
 
 export { configureFetch, type FetchConfig, ResponseFailError, isApiError } from './fetch';

--- a/packages/insomnia-api/src/invite.ts
+++ b/packages/insomnia-api/src/invite.ts
@@ -50,3 +50,50 @@ export const revokeInvitation = ({
     sessionId,
   });
 };
+
+export interface ProjectKey {
+  projectId: string;
+  encKey: string;
+}
+
+export interface ProjectMember {
+  accountId: string;
+  projectId: string;
+  publicKey: string;
+}
+
+interface ResponseGetMyProjectKeys {
+  projectKeys: ProjectKey[];
+  members: ProjectMember[];
+}
+
+export interface MemberProjectKey {
+  accountId: string;
+  projectId: string;
+  encSymmetricKey: string;
+}
+
+export const getMyProjectKeys = ({ organizationId, sessionId }: { organizationId: string; sessionId: string }) => {
+  return fetch<ResponseGetMyProjectKeys>({
+    method: 'GET',
+    path: `/v1/organizations/${organizationId}/my-project-keys`,
+    sessionId,
+  });
+};
+
+export const reconcileFileKeys = ({
+  organizationId,
+  memberKeys,
+  sessionId,
+}: {
+  organizationId: string;
+  memberKeys: MemberProjectKey[];
+  sessionId: string;
+}) => {
+  return fetch({
+    method: 'POST',
+    path: `/v1/organizations/${organizationId}/reconcile-keys`,
+    sessionId,
+    data: { keys: memberKeys },
+  });
+};

--- a/packages/insomnia-api/src/mock.ts
+++ b/packages/insomnia-api/src/mock.ts
@@ -1,0 +1,67 @@
+import type * as Har from 'har-format';
+
+import { fetch } from './fetch';
+
+export interface MockbinLogOutput {
+  log: {
+    version: string;
+    creator: {
+      name: string;
+      version: string;
+    };
+    entries: [
+      {
+        startedDateTime: string;
+        clientIPAddress: string;
+        request: Har.Request;
+      },
+    ];
+  };
+}
+
+export const fetchMockbinLogs = ({
+  compoundId,
+  method,
+  sessionId,
+}: {
+  compoundId: string;
+  method: string;
+  sessionId: string;
+}) => {
+  return fetch<MockbinLogOutput>({
+    method: 'GET',
+    path: `/bin/log/${compoundId}`,
+    headers: {
+      'insomnia-mock-method': method,
+    },
+    sessionId,
+  });
+};
+
+export const upsertMockbin = ({
+  compoundId,
+  organizationId,
+  sessionId,
+  mockbinUrl,
+  method,
+  data,
+}: {
+  mockbinUrl: string;
+  compoundId: string;
+  organizationId: string;
+  sessionId: string;
+  method: string;
+  data: Har.Response;
+}) => {
+  return fetch({
+    origin: mockbinUrl,
+    path: `/bin/upsert/${compoundId}`,
+    method: 'PUT',
+    organizationId,
+    sessionId,
+    headers: {
+      'insomnia-mock-method': method,
+    },
+    data,
+  });
+};

--- a/packages/insomnia-api/src/mock.ts
+++ b/packages/insomnia-api/src/mock.ts
@@ -56,7 +56,7 @@ export const upsertMockbin = ({
   method: string;
   data: Har.Response;
 }) => {
-  return fetch({
+  return fetch<string>({
     origin: mockbinUrl,
     path: `/bin/upsert/${compoundId}`,
     method: 'PUT',

--- a/packages/insomnia-api/src/mock.ts
+++ b/packages/insomnia-api/src/mock.ts
@@ -23,12 +23,15 @@ export const fetchMockbinLogs = ({
   compoundId,
   method,
   sessionId,
+  mockbinUrl,
 }: {
   compoundId: string;
   method: string;
   sessionId: string;
+  mockbinUrl: string;
 }) => {
   return fetch<MockbinLogOutput>({
+    origin: mockbinUrl,
     method: 'GET',
     path: `/bin/log/${compoundId}`,
     headers: {

--- a/packages/insomnia-api/src/organizations.ts
+++ b/packages/insomnia-api/src/organizations.ts
@@ -4,9 +4,12 @@ interface Branding {
   logo_url: string;
 }
 
-export interface Metadata {
-  organizationType: string;
+export type OrganizationType = 'personal' | 'team' | 'enterprise';
+
+export interface OrganizationMetadata {
+  organizationType: OrganizationType;
   ownerAccountId: string;
+  description?: string;
 }
 
 export interface Organization {
@@ -14,7 +17,7 @@ export interface Organization {
   name: string;
   display_name: string;
   branding?: Branding;
-  metadata: Metadata;
+  metadata: OrganizationMetadata;
 }
 
 export interface OrganizationsResponse {
@@ -204,6 +207,14 @@ export const getOrganizationMemberRoles = ({
   return fetch<Role>({
     method: 'GET',
     path: `/v1/organizations/${organizationId}/members/${userId}/roles`,
+    sessionId,
+  });
+};
+
+export const getOrganizationDetail = ({ organizationId, sessionId }: { organizationId: string; sessionId: string }) => {
+  return fetch<Organization>({
+    method: 'GET',
+    path: `/v1/organizations/${organizationId}`,
     sessionId,
   });
 };

--- a/packages/insomnia-api/src/vcs.ts
+++ b/packages/insomnia-api/src/vcs.ts
@@ -1,0 +1,20 @@
+import { fetch } from './fetch';
+
+export const runVcsGraphQL = <T>({
+  name,
+  query,
+  variables,
+  sessionId,
+}: {
+  name: string;
+  query: string;
+  variables?: Record<string, any>;
+  sessionId: string;
+}) => {
+  return fetch<{ data: T; errors: [{ message: string }] }>({
+    method: 'POST',
+    path: '/graphql?' + name,
+    data: { query, variables },
+    sessionId,
+  });
+};

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -1,4 +1,5 @@
 import type { IconName, IconProp } from '@fortawesome/fontawesome-svg-core';
+import { getLearningFeature } from 'insomnia-api';
 import { Fragment, useEffect, useMemo, useState } from 'react';
 import {
   Button,
@@ -80,7 +81,6 @@ import { useInsomniaEventStreamContext } from '~/ui/context/app/insomnia-event-s
 import { useTabNavigate } from '~/ui/hooks/use-insomnia-tab';
 import { useLoaderDeferData } from '~/ui/hooks/use-loader-defer-data';
 import { useOrganizationPermissions } from '~/ui/hooks/use-organization-features';
-import { insomniaFetch } from '~/ui/insomnia-fetch';
 import { DEFAULT_STORAGE_RULES } from '~/ui/organization-utils';
 import { trackTempProjectOpened } from '~/ui/temp-segment-tracking';
 import { isPrimaryClickModifier } from '~/ui/utils';
@@ -317,7 +317,7 @@ interface LearningFeature {
   url: string;
 }
 
-const getLearningFeature = async (fallbackLearningFeature: LearningFeature) => {
+const getInsomniaLearningFeature = async (fallbackLearningFeature: LearningFeature) => {
   let learningFeature = fallbackLearningFeature;
   const lastFetchedString = window.localStorage.getItem('learning-feature-last-fetch');
   const lastFetched = lastFetchedString ? Number.parseInt(lastFetchedString, 10) : 0;
@@ -327,12 +327,7 @@ const getLearningFeature = async (fallbackLearningFeature: LearningFeature) => {
   const wasNotDismissedAndOneDayHasPassed = !wasDismissed && hasOneDayPassedSinceLastFetch;
   if (wasNotDismissedAndOneDayHasPassed) {
     try {
-      learningFeature = await insomniaFetch<LearningFeature>({
-        method: 'GET',
-        path: '/insomnia-production-public-assets/inapp-learning.json',
-        origin: 'https://storage.googleapis.com',
-        sessionId: '',
-      });
+      learningFeature = await getLearningFeature();
       window.localStorage.setItem('learning-feature-last-fetch', Date.now().toString());
     } catch {
       console.log('[project] Could not fetch learning feature data.');
@@ -402,7 +397,7 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
   ]);
 
   const remoteFilesPromise = getAllRemoteFiles({ projectId, organizationId });
-  const learningFeaturePromise = getLearningFeature(fallbackLearningFeature);
+  const learningFeaturePromise = getInsomniaLearningFeature(fallbackLearningFeature);
 
   const projects = sortProjects(organizationProjects);
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId.tsx
@@ -1,4 +1,5 @@
 import type * as Har from 'har-format';
+import { isApiError, upsertMockbin } from 'insomnia-api';
 import { useCallback } from 'react';
 import { Button, Tab, TabList, TabPanel, Tabs, Toolbar } from 'react-aria-components';
 import { useParams, useRouteLoaderData } from 'react-router';
@@ -36,7 +37,6 @@ import { AlertModal } from '~/ui/components/modals/alert-modal';
 import { EmptyStatePane } from '~/ui/components/panes/empty-state-pane';
 import { Pane, PaneBody, PaneHeader } from '~/ui/components/panes/pane';
 import { SvgIcon } from '~/ui/components/svg-icon';
-import { insomniaFetch } from '~/ui/insomnia-fetch';
 import { invariant } from '~/utils/invariant';
 
 import type { Route } from './+types/organization.$organizationId.project.$projectId.workspace.$workspaceId.mock-server.mock-route.$mockRouteId';
@@ -164,23 +164,14 @@ export const MockRouteRoute = () => {
     workspaceId: string;
   };
 
-  const upsertBinOnRemoteFromResponse = async (compoundId: string | null): Promise<string> => {
+  const upsertBinOnRemoteFromResponse = async (compoundId: string): Promise<string> => {
     try {
-      const res = await insomniaFetch<
-        | string
-        | {
-            error: string;
-            message: string;
-          }
-      >({
-        origin: mockbinUrl,
-        path: `/bin/upsert/${compoundId}`,
-        method: 'PUT',
+      const res = await upsertMockbin({
+        mockbinUrl,
+        compoundId,
         organizationId,
         sessionId: userSession.id,
-        headers: {
-          'insomnia-mock-method': mockRoute.method,
-        },
+        method: mockRoute.method,
         data: mockRouteToHar({
           statusCode: mockRoute.statusCode,
           statusText: mockRoute.statusText,
@@ -189,10 +180,6 @@ export const MockRouteRoute = () => {
           body: mockRoute.body,
         }),
       });
-      if (typeof res === 'object' && 'message' in res && 'error' in res) {
-        console.error('error response', res);
-        return `Mock API ${res.error}:\n${res.message}`;
-      }
 
       if (typeof res === 'string') {
         return '';
@@ -200,6 +187,10 @@ export const MockRouteRoute = () => {
       console.log('[mock] Error: invalid response from remote', { res, mockbinUrl });
       return 'Unexpected response, see console for details';
     } catch (e) {
+      if (isApiError(e)) {
+        console.error('error response', e);
+        return `Mock API ${e.name}:\n${e.message}`;
+      }
       const errorMessage = e instanceof Error ? e.message : String(e);
       return `Unhandled contacting Mock API at ${mockbinUrl}\n${errorMessage}`;
     }

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { upsertMockbin } from 'insomnia-api';
 import { href, redirect } from 'react-router';
 
 import { getAppVersion, getMockServiceURL, METHOD_GET } from '~/common/constants';
@@ -17,7 +18,6 @@ import { initializeLocalBackendProjectAndMarkForSync } from '~/sync/vcs/initiali
 import { VCSInstance } from '~/sync/vcs/insomnia-sync';
 import { SegmentEvent } from '~/ui/analytics';
 import { showToast } from '~/ui/components/toast-notification';
-import { insomniaFetch } from '~/ui/insomnia-fetch';
 import { invariant } from '~/utils/invariant';
 import { createFetcherSubmitHook } from '~/utils/router';
 
@@ -444,15 +444,12 @@ async function createMockRoutes(
       const mockbinUrl = mockServer.useInsomniaCloud ? getMockServiceURL() : mockServer.url;
 
       if (mockbinUrl && sessionId) {
-        await insomniaFetch({
-          origin: mockbinUrl,
-          path: `/bin/upsert/${compoundId}`,
-          method: 'PUT',
+        await upsertMockbin({
+          mockbinUrl,
+          compoundId,
           organizationId,
           sessionId,
-          headers: {
-            'insomnia-mock-method': route.method,
-          },
+          method: route.method,
           data: mockRouteToHar({
             statusCode: mockRoute.statusCode,
             statusText: mockRoute.statusText || '',

--- a/packages/insomnia/src/sync/vcs/vcs.ts
+++ b/packages/insomnia/src/sync/vcs/vcs.ts
@@ -5,6 +5,7 @@ import crypto from 'node:crypto';
 import path from 'node:path';
 
 import clone from 'clone';
+import { runVcsGraphQL } from 'insomnia-api';
 
 import { PLAYWRIGHT } from '~/common/constants';
 
@@ -13,7 +14,6 @@ import * as session from '../../account/session';
 import type { Operation } from '../../common/database';
 import { generateId } from '../../common/misc';
 import type { BaseModel } from '../../models';
-import { insomniaFetch } from '../../ui/insomnia-fetch';
 import Store from '../store';
 import type { BaseDriver } from '../store/drivers/base';
 import compress from '../store/hooks/compress';
@@ -888,12 +888,11 @@ export class VCS {
 
   async _runGraphQL<T>(query: string, variables: Record<string, any>, name: string): Promise<T> {
     const { sessionId } = await this._assertSession();
-
-    const { data, errors } = await insomniaFetch<{ data: T; errors: [{ message: string }] }>({
-      method: 'POST',
-      path: '/graphql?' + name,
-      data: { query, variables },
+    const { data, errors } = await runVcsGraphQL<T>({
+      query,
+      variables,
       sessionId,
+      name,
     });
 
     if (errors && errors.length) {

--- a/packages/insomnia/src/ui/components/mocks/mock-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/mocks/mock-response-pane.tsx
@@ -171,6 +171,7 @@ const HistoryViewWrapperComponentFactory = ({
     const mockbinUrl = mockServer.useInsomniaCloud ? getMockServiceURL() : mockServer.url;
     try {
       const res = await fetchMockbinLogs({
+        mockbinUrl,
         compoundId,
         method: mockRoute.method,
         sessionId: userSession.id,

--- a/packages/insomnia/src/ui/components/mocks/mock-response-pane.tsx
+++ b/packages/insomnia/src/ui/components/mocks/mock-response-pane.tsx
@@ -1,4 +1,4 @@
-import type * as Har from 'har-format';
+import { fetchMockbinLogs, type MockbinLogOutput } from 'insomnia-api';
 import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import { Button, Tab, TabList, TabPanel, Tabs, Toolbar } from 'react-aria-components';
 import * as reactUse from 'react-use';
@@ -25,7 +25,6 @@ import type { Response } from '../../../models/response';
 import { cancelRequestById } from '../../../network/cancellation';
 import { jsonPrettify } from '../../../utils/prettify/json';
 import { useExecutionState } from '../../hooks/use-execution-state';
-import { insomniaFetch } from '../../insomnia-fetch';
 import { Dropdown, DropdownItem, DropdownSection, ItemContent } from '../base/dropdown';
 import { Pane, PaneHeader } from '../panes/pane';
 import { PlaceholderResponsePane } from '../panes/placeholder-response-pane';
@@ -39,23 +38,6 @@ import { ResponseTimelineViewer } from '../viewers/response-timeline-viewer';
 import { ResponseViewer } from '../viewers/response-viewer';
 
 const { useInterval } = reactUse;
-
-interface MockbinLogOutput {
-  log: {
-    version: string;
-    creator: {
-      name: string;
-      version: string;
-    };
-    entries: [
-      {
-        startedDateTime: string;
-        clientIPAddress: string;
-        request: Har.Request;
-      },
-    ];
-  };
-}
 
 export const MockResponsePane = () => {
   const { mockServer, mockRoute, activeResponse } = useMockRouteLoaderData()!;
@@ -188,13 +170,9 @@ const HistoryViewWrapperComponentFactory = ({
     const compoundId = mockRoute.parentId + mockRoute.name;
     const mockbinUrl = mockServer.useInsomniaCloud ? getMockServiceURL() : mockServer.url;
     try {
-      const res = await insomniaFetch<MockbinLogOutput>({
-        origin: mockbinUrl,
-        path: `/bin/log/${compoundId}`,
-        method: 'GET',
-        headers: {
-          'insomnia-mock-method': mockRoute.method,
-        },
+      const res = await fetchMockbinLogs({
+        compoundId,
+        method: mockRoute.method,
         sessionId: userSession.id,
       });
       if (res?.log) {

--- a/packages/insomnia/src/ui/components/modals/invite-modal/encryption.ts
+++ b/packages/insomnia/src/ui/components/modals/invite-modal/encryption.ts
@@ -1,9 +1,15 @@
-import { finishAddingCollaborators, startAddingCollaborators } from 'insomnia-api';
+import {
+  finishAddingCollaborators,
+  getMyProjectKeys,
+  type MemberProjectKey,
+  type ProjectMember,
+  reconcileFileKeys,
+  startAddingCollaborators,
+} from 'insomnia-api';
 
 import { decryptRSAWithJWK, encryptRSAWithJWK } from '../../../../account/crypt';
 import { getCurrentSessionId, getPrivateKey } from '../../../../account/session';
 import { invariant } from '../../../../utils/invariant';
-import { insomniaFetch } from '../../../insomnia-fetch';
 
 interface InviteInstruction {
   inviteKeys: InviteKey[];
@@ -99,31 +105,9 @@ interface StartInviteParams {
   roleId: string;
 }
 
-interface ProjectKey {
-  projectId: string;
-  encKey: string;
-}
-
-interface ProjectMember {
-  accountId: string;
-  projectId: string;
-  publicKey: string;
-}
-
-interface ResponseGetMyProjectKeys {
-  projectKeys: ProjectKey[];
-  members: ProjectMember[];
-}
-
 interface DecryptedProjectKey {
   projectId: string;
   symmetricKey: string;
-}
-
-interface MemberProjectKey {
-  accountId: string;
-  projectId: string;
-  encSymmetricKey: string;
 }
 
 export async function startInvite({ emails, teamIds, organizationId, roleId }: StartInviteParams) {
@@ -139,11 +123,9 @@ export async function startInvite({ emails, teamIds, organizationId, roleId }: S
     teamIds,
   });
 
-  const myKeysInfo = await insomniaFetch<ResponseGetMyProjectKeys>({
-    method: 'GET',
-    path: `/v1/organizations/${organizationId}/my-project-keys`,
+  const myKeysInfo = await getMyProjectKeys({
+    organizationId,
     sessionId,
-    onlyResolveOnSuccess: true,
   });
 
   let memberKeys: MemberProjectKey[] = [];
@@ -165,12 +147,10 @@ export async function startInvite({ emails, teamIds, organizationId, roleId }: S
   }
 
   if (memberKeys.length) {
-    await insomniaFetch({
-      method: 'POST',
-      path: `/v1/organizations/${organizationId}/reconcile-keys`,
+    await reconcileFileKeys({
+      organizationId,
+      memberKeys,
       sessionId,
-      data: { keys: memberKeys },
-      onlyResolveOnSuccess: true,
     });
   }
 

--- a/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
@@ -3,10 +3,12 @@ import {
   type Collaborator,
   deleteOrganizationMember,
   type FeatureList,
+  getOrganizationDetail,
   getOrganizationFeatures,
   getOrganizationMemberRoles,
   getOrganizationRoles,
   getOrgUserPermissions,
+  type OrganizationDetail,
   type Permission,
   revokeInvitation,
   type Role,
@@ -40,7 +42,6 @@ import { PromptButton } from '~/ui/components/base/prompt-button';
 import { Icon } from '~/ui/components/icon';
 import { AlertModal } from '~/ui/components/modals/alert-modal';
 import { showModal } from '~/ui/components/modals/index';
-import { insomniaFetch } from '~/ui/insomnia-fetch';
 import { invariant } from '~/utils/invariant';
 
 import { InviteForm } from './invite-form';
@@ -600,25 +601,29 @@ export const InviteModalContainer: FC<{
   const [orgFeatures, setOrgFeatures] = useState<FeatureList | null>(null);
   const permissionRef = useRef<Record<Permission, boolean>>();
   const [currentUserAccountId, setCurrentUserAccountId] = useState('');
-  const [currentOrgInfo, setCurrentOrgInfo] = useState<OrganizationAuth0 | null>(null);
+  const [currentOrgInfo, setCurrentOrgInfo] = useState<OrganizationDetail | null>(null);
 
   const isCurrentUserOrganizationOwner = currentUserAccountId === currentOrgInfo?.metadata?.ownerAccountId;
 
   async function getBaseInfo(organizationId: string) {
+    const sessionId = await getCurrentSessionId();
     return Promise.all([
       getCurrentUserRoleInOrg(organizationId).then(setCurrentUserRoleInOrg),
       getOrganizationFeatures({
         organizationId,
-        sessionId: await getCurrentSessionId(),
+        sessionId,
       }).then(res => setOrgFeatures(res?.features)),
       getOrgUserPermissions({
         organizationId,
-        sessionId: await getCurrentSessionId(),
+        sessionId,
       }).then(permissions => {
         permissionRef.current = permissions;
       }),
       getAccountId().then(setCurrentUserAccountId),
-      getOrganization(organizationId).then(setCurrentOrgInfo),
+      getOrganizationDetail({
+        organizationId,
+        sessionId,
+      }).then(setCurrentOrgInfo),
     ]);
   }
 
@@ -706,33 +711,6 @@ export async function getCurrentUserRoleInOrg(organizationId: string): Promise<R
 export interface OrganizationBranding {
   logo_url: string;
   colors: string[];
-}
-
-export type OrganizationType = 'personal' | 'team' | 'enterprise';
-
-export interface Metadata {
-  organizationType: OrganizationType;
-  ownerAccountId?: string;
-  description?: string;
-}
-
-export interface OrganizationAuth0 {
-  id: string;
-  name: string;
-  display_name: string;
-  branding: OrganizationBranding;
-  metadata: Metadata;
-}
-
-async function getOrganization(organizationId: string): Promise<OrganizationAuth0> {
-  return insomniaFetch<OrganizationAuth0>({
-    method: 'GET',
-    path: `/v1/organizations/${organizationId}`,
-    sessionId: await getCurrentSessionId(),
-    onlyResolveOnSuccess: true,
-  }).catch(() => {
-    throw new Error('Failed to fetch organization');
-  });
 }
 
 async function unlinkTeam(organizationId: string, collaboratorId: string) {

--- a/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
@@ -8,7 +8,7 @@ import {
   getOrganizationMemberRoles,
   getOrganizationRoles,
   getOrgUserPermissions,
-  type OrganizationDetail,
+  type Organization,
   type Permission,
   revokeInvitation,
   type Role,
@@ -601,7 +601,7 @@ export const InviteModalContainer: FC<{
   const [orgFeatures, setOrgFeatures] = useState<FeatureList | null>(null);
   const permissionRef = useRef<Record<Permission, boolean>>();
   const [currentUserAccountId, setCurrentUserAccountId] = useState('');
-  const [currentOrgInfo, setCurrentOrgInfo] = useState<OrganizationDetail | null>(null);
+  const [currentOrgInfo, setCurrentOrgInfo] = useState<Organization | null>(null);
 
   const isCurrentUserOrganizationOwner = currentUserAccountId === currentOrgInfo?.metadata?.ownerAccountId;
 

--- a/packages/insomnia/src/ui/organization-utils.ts
+++ b/packages/insomnia/src/ui/organization-utils.ts
@@ -1,5 +1,4 @@
 import {
-  type CurrentPlan,
   getCurrentPlan,
   getOrganizations,
   getOrganizationStorageRule,
@@ -22,7 +21,6 @@ import {
   shouldMigrateProjectUnderOrganization,
 } from '../sync/vcs/migrate-projects-into-organization';
 import { invariant } from '../utils/invariant';
-import { insomniaFetch } from './insomnia-fetch';
 
 // Create an in-memory storage to store the storage rules
 const inMemoryStorageRuleCache: Map<string, StorageRules> = new Map<string, StorageRules>();
@@ -59,13 +57,7 @@ export function sortOrganizations(accountId: string, organizations: Organization
 }
 
 export async function syncCurrentPlan(sessionId: string, accountId: string) {
-  const [currentPlanResult] = await Promise.allSettled([
-    insomniaFetch<CurrentPlan | void>({
-      method: 'GET',
-      path: '/v1/billing/current-plan',
-      sessionId,
-    }),
-  ]);
+  const [currentPlanResult] = await Promise.allSettled([getCurrentPlan({ sessionId })]);
   if (currentPlanResult.status === 'fulfilled' && currentPlanResult.value) {
     localStorage.setItem(`${accountId}:currentPlan`, JSON.stringify(currentPlanResult.value));
   } else {


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

INS-2162

Migrate remaining APIs into the `insomnia-api` package which includes:

- invite encrypt
- mockbin
- vcs graphql
- some fragmented apis

