### PR TITLE
Fix: Bearer authorization header is not imported when parsing curl command with multiple headers

### DIFF
--- a/packages/insomnia/src/main/importers/importers/curl.test.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.test.ts
@@ -229,7 +229,7 @@ describe('curl', () => {
       },
     },
     {
-      name: 'should handle bearer auth and nomral header auth together',
+      name: 'should handle bearer auth and normal header auth together',
       curl: `curl http://httpbin.org/get -H 'x-foo: x-bar' -H 'Authorization: Bearer mytoken123' `,
       expected: {
         authentication: { type: 'bearer', token: 'mytoken123' },

--- a/packages/insomnia/src/main/importers/importers/curl.test.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.test.ts
@@ -228,6 +228,14 @@ describe('curl', () => {
         headers: [],
       },
     },
+    {
+      name: 'should handle bearer auth and nomral header auth together',
+      curl: `curl http://httpbin.org/get -H 'x-foo: x-bar' -H 'Authorization: Bearer mytoken123' `,
+      expected: {
+        authentication: { type: 'bearer', token: 'mytoken123' },
+        headers: [{ name: 'x-foo', value: 'x-bar' }],
+      },
+    },
   ];
 
   it.each(testCases)('$name', ({ curl, expected }) => {

--- a/packages/insomnia/src/main/importers/importers/curl.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.ts
@@ -103,8 +103,16 @@ const isBearerAuth = (header?: string, value?: string) =>
   header?.toLowerCase() === 'authorization' && value?.trim().toLowerCase().startsWith('bearer');
 const extractAuth = (pairsByName: PairsByName): RequestAuthentication | {} => {
   const [username, password] = getPairValue(pairsByName, '', ['u', 'user']).split(/:(.*)$/);
-  const [header, value] = getPairValue(pairsByName, '', ['H', 'header']).split(/:(.*)$/);
-  if (isBearerAuth(header, value)) {
+  const allHeaders = [
+    ...((pairsByName.H as string[] | undefined) || []),
+    ...((pairsByName.header as string[] | undefined) || []),
+  ];
+  const bearerAuthHeader = allHeaders.find(h => {
+    const [name, value] = h.split(/:(.*)$/);
+    return isBearerAuth(name, value);
+  });
+  if (bearerAuthHeader) {
+    const [_, value] = bearerAuthHeader.split(/:(.*)$/);
     return { type: 'bearer', token: value.trim().slice(7) };
   }
   return username


### PR DESCRIPTION
**Background:**
When importing a request from a curl command, the Bearer auth header is not correctly parsed and imported if the command contains multiple headers like the curl command below:
```
curl 'https://api.example.dev/v1/fields?' \
  -H 'x-region: my-xregion' \
  -H 'agent: my special agent' \
  -H 'authorization: Bearer ey....'
```
**Changes**
- Check all existing header pairs which might contain Bearer auth rather than only the first header pair.
- Add related unit test

Close https://github.com/Kong/insomnia/issues/9699
[INS-2220](https://konghq.atlassian.net/browse/INS-2220)

[INS-2220]: https://konghq.atlassian.net/browse/INS-2220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ