### PR TITLE
feat: socket.io handshake path

### DIFF
--- a/packages/insomnia-smoke-test/fixtures/socket-io.yaml
+++ b/packages/insomnia-smoke-test/fixtures/socket-io.yaml
@@ -20,6 +20,7 @@ collection:
       cookies:
         send: true
         store: true
+      path: /custom-path
     headers:
       - name: User-Agent
         value: insomnia/11.4.0-beta.0

--- a/packages/insomnia-smoke-test/server/socket-io.ts
+++ b/packages/insomnia-smoke-test/server/socket-io.ts
@@ -8,7 +8,9 @@ import { Server as SocketIOServer } from 'socket.io';
 export function startSocketIOServer() {
   const app = express();
   const server = createServer(app);
-  const io = new SocketIOServer(server);
+  const io = new SocketIOServer(server, {
+    path: '/custom-path',
+  });
 
   io.on('connection', socket => {
     console.log('socket.io connected:', socket.id);

--- a/packages/insomnia-smoke-test/tests/smoke/socket-io.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/socket-io.test.ts
@@ -23,7 +23,7 @@ test('can make socket.io connection', async ({ app, page }) => {
   await page.click('text=Connect');
   await expect.soft(statusTag).toContainText('Connected', { ignoreCase: true });
   await page.getByRole('tab', { name: 'Console' }).click();
-  await expect.soft(responseBody).toContainText('Connected to http://localhost:4020');
+  await expect.soft(responseBody).toContainText('Connecting to http://localhost:4020');
   await page.click('text=Disconnect');
   await expect.soft(responseBody).toContainText('io client disconnect');
 

--- a/packages/insomnia/src/common/import-v5-parser.ts
+++ b/packages/insomnia/src/common/import-v5-parser.ts
@@ -73,21 +73,18 @@ const CookieSchema = z.object({
     .default(() => crypto.randomUUID()),
   key: z.string().optional().default(''),
   value: z.string().optional().default(''),
-  expires: z.preprocess(
-    (val) => {
-      // Handle 'Infinity' string
-      if (val === 'Infinity') return null;
-      
-      // If it's already a Date, check if it's valid
-      if (val instanceof Date) {
-        return Number.isNaN(val.getTime()) ? null : val;
-      }
-      
-      // Let other values pass through to z.coerce.date()
-      return val;
-    },
-    z.coerce.date().nullable().default(null)
-  ),
+  expires: z.preprocess(val => {
+    // Handle 'Infinity' string
+    if (val === 'Infinity') return null;
+
+    // If it's already a Date, check if it's valid
+    if (val instanceof Date) {
+      return Number.isNaN(val.getTime()) ? null : val;
+    }
+
+    // Let other values pass through to z.coerce.date()
+    return val;
+  }, z.coerce.date().nullable().default(null)),
   domain: z.string().optional().default(''),
   path: z.string().optional().default('/'),
   secure: z.boolean().optional().default(false),
@@ -359,6 +356,7 @@ export const SocketIORequestSettingsSchema = z.object({
     store: z.boolean().optional().default(true),
     send: z.boolean().optional().default(true),
   }),
+  path: z.string().optional(),
 });
 
 export const RequestPathParametersSchema = z.array(

--- a/packages/insomnia/src/common/insomnia-v5.ts
+++ b/packages/insomnia/src/common/insomnia-v5.ts
@@ -628,6 +628,7 @@ function getCollection(
                 settingEncodeUrl: data.settings.encodeUrl,
                 settingSendCookies: data.settings.cookies.send,
                 settingStoreCookies: data.settings.cookies.store,
+                settingPath: data.settings.path,
                 pathParameters: data.pathParameters || [],
                 eventListeners: data.eventListeners || [],
               };
@@ -901,6 +902,7 @@ export async function getInsomniaV5DataExport({
                   send: resource.settingSendCookies,
                   store: resource.settingStoreCookies,
                 },
+                path: resource.settingPath,
               },
               authentication: resource.authentication,
               headers: mapHeaders(resource.headers),

--- a/packages/insomnia/src/main/network/socket-io.ts
+++ b/packages/insomnia/src/main/network/socket-io.ts
@@ -119,9 +119,10 @@ const writeEventLogAndNotify = ({
   });
 };
 
-const buildTimeline = (url: string) => {
+const buildTimeline = (url: string, path?: string) => {
   const timeline = [
-    { value: `Connected to ${url}`, name: 'Text', timestamp: Date.now() },
+    { value: `Connecting to ${url}`, name: 'Text', timestamp: Date.now() },
+    { value: `Handshake path: ${path || '/socket.io'}`, name: 'Text', timestamp: Date.now() },
     { value: `Current time is ${new Date().toISOString()}`, name: 'Text', timestamp: Date.now() },
   ];
   return timeline;
@@ -319,6 +320,9 @@ const openSocketIOConnection = async (
       socketIOoptions.path = options.path;
     }
 
+    const timeline = buildTimeline(url, options.path);
+    timeline.map(t => timelineFileStreams.get(options.requestId)?.write(JSON.stringify(t) + '\n'));
+
     const socket = SocketIOClient(url, socketIOoptions);
     SocketIOConnections.set(options.requestId, socket);
     const openedEvents = request.eventListeners.filter(event => event.isOpen && event.eventName);
@@ -347,8 +351,6 @@ const openSocketIOConnection = async (
         writeEventLogAndNotify({ requestId: options.requestId, data: JSON.stringify(infoEvent) + '\n' });
       }
 
-      const timeline = buildTimeline(url);
-      timeline.map(t => timelineFileStreams.get(options.requestId)?.write(JSON.stringify(t) + '\n'));
       const responsePatch: Partial<SocketIOResponse> = {
         _id: responseId,
         parentId: request._id,

--- a/packages/insomnia/src/main/network/socket-io.ts
+++ b/packages/insomnia/src/main/network/socket-io.ts
@@ -135,6 +135,7 @@ interface OpenSocketIORequestOptions {
   headers: RequestHeader[];
   authentication: RequestAuthentication;
   cookieJar: CookieJar;
+  path?: string;
   initialPayload?: string;
 }
 
@@ -312,6 +313,10 @@ const openSocketIOConnection = async (
       socketIOoptions.auth = {
         token: options.authentication.token || '',
       };
+    }
+
+    if (options.path) {
+      socketIOoptions.path = options.path;
     }
 
     const socket = SocketIOClient(url, socketIOoptions);

--- a/packages/insomnia/src/main/network/socket-io.ts
+++ b/packages/insomnia/src/main/network/socket-io.ts
@@ -321,7 +321,7 @@ const openSocketIOConnection = async (
     }
 
     const timeline = buildTimeline(url, options.path);
-    timeline.map(t => timelineFileStreams.get(options.requestId)?.write(JSON.stringify(t) + '\n'));
+    timeline.forEach(t => timelineFileStreams.get(options.requestId)?.write(JSON.stringify(t) + '\n'));
 
     const socket = SocketIOClient(url, socketIOoptions);
     SocketIOConnections.set(options.requestId, socket);

--- a/packages/insomnia/src/models/socket-io-request.ts
+++ b/packages/insomnia/src/models/socket-io-request.ts
@@ -31,6 +31,7 @@ export interface BaseSocketIORequest {
   settingEncodeUrl: boolean;
   settingStoreCookies: boolean;
   settingSendCookies: boolean;
+  settingPath?: string;
   eventListeners: SocketIOEventListener[];
 }
 
@@ -51,6 +52,7 @@ export const init = (): BaseSocketIORequest => ({
   settingEncodeUrl: true,
   settingStoreCookies: true,
   settingSendCookies: true,
+  settingPath: undefined,
   description: '',
   eventListeners: [],
 });

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.connect.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.connect.tsx
@@ -25,6 +25,7 @@ export interface ConnectActionParams {
   suppressUserAgent: boolean;
   transportType?: McpTransportType;
   query?: Record<string, string>;
+  path?: string;
   env?: Record<string, string>;
 }
 
@@ -92,6 +93,7 @@ export async function clientAction({ params, request }: Route.ClientActionArgs) 
       cookieJar: rendered.cookieJar,
       authentication: rendered.authentication,
       query: rendered.query || {},
+      path: rendered.path,
     });
   }
   if (models.mcpRequest.isMcpRequest(req)) {

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from 'react-router';
 import type { McpRequest } from '~/insomnia-data';
 import { useProjectListWorkspacesLoaderFetcher } from '~/routes/organization.$organizationId.project.$projectId.list-workspaces';
 import { useRequestDuplicateActionFetcher } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.duplicate';
+import { useReadyState } from '~/ui/hooks/use-ready-state';
 
 import { isNotNullOrUndefined } from '../../../common/misc';
 import * as models from '../../../models';
@@ -26,6 +27,27 @@ import { Icon } from '../icon';
 export interface RequestSettingsModalOptions {
   request: Request | GrpcRequest | WebSocketRequest | SocketIORequest | McpRequest;
 }
+
+export const SocketIOPathSettings = ({
+  request,
+  patchRequest,
+}: {
+  request: SocketIORequest;
+  patchRequest: (id: string, patch: Partial<SocketIORequest>) => void;
+}) => {
+  const readyState = useReadyState({ requestId: request._id, protocol: 'socketIO' });
+  return (
+    <Input
+      label="Socket.IO Handshake Path"
+      description="The path where the Socket.IO server is listening. Leave empty to use the default /socket.io/"
+      placeholder="/custom-path/"
+      name="settingPath"
+      defaultValue={request.settingPath || ''}
+      isDisabled={readyState}
+      onChange={value => patchRequest(request._id, { settingPath: value })}
+    />
+  );
+};
 
 export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSettingsModalOptions) => {
   const modalRef = useRef<ModalHandle>(null);
@@ -219,14 +241,7 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
               </>
             )}
             {request && isSocketIORequest(request) && (
-              <Input
-                label="Socket.IO Handshake Path"
-                description="The path where the Socket.IO server is listening. Leave empty to use the default /socket.io/"
-                placeholder="/custom-path/"
-                name="settingPath"
-                defaultValue={request.settingPath || ''}
-                onChange={value => patchRequest(request._id, { settingPath: value })}
-              />
+              <SocketIOPathSettings request={request} patchRequest={patchRequest} />
             )}
             {request && isGrpcRequest(request) && (
               <>

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -11,11 +11,12 @@ import * as models from '../../../models';
 import { type GrpcRequest, isGrpcRequest } from '../../../models/grpc-request';
 import { isScratchpadOrganizationId } from '../../../models/organization';
 import { isRequest, type Request } from '../../../models/request';
-import type { SocketIORequest } from '../../../models/socket-io-request';
+import { isSocketIORequest, type SocketIORequest } from '../../../models/socket-io-request';
 import { isWebSocketRequest, type WebSocketRequest } from '../../../models/websocket-request';
 import { revalidateWorkspaceActiveRequest } from '../../../routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 import { invariant } from '../../../utils/invariant';
 import { useRequestPatcher } from '../../hooks/use-request';
+import { Input } from '../base/input';
 import { Modal, type ModalHandle, type ModalProps } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalHeader } from '../base/modal-header';
@@ -216,6 +217,16 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
                   </div>
                 </div>
               </>
+            )}
+            {request && isSocketIORequest(request) && (
+              <Input
+                label="Socket.IO Handshake Path"
+                description="The path where the Socket.IO server is listening. Leave empty to use the default /socket.io/"
+                placeholder="/socket.io/"
+                name="settingPath"
+                defaultValue={request.settingPath || ''}
+                onChange={value => patchRequest(request._id, { settingPath: value })}
+              />
             )}
             {request && isGrpcRequest(request) && (
               <>

--- a/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/request-settings-modal.tsx
@@ -222,7 +222,7 @@ export const RequestSettingsModal = ({ request, onHide }: ModalProps & RequestSe
               <Input
                 label="Socket.IO Handshake Path"
                 description="The path where the Socket.IO server is listening. Leave empty to use the default /socket.io/"
-                placeholder="/socket.io/"
+                placeholder="/custom-path/"
                 name="settingPath"
                 defaultValue={request.settingPath || ''}
                 onChange={value => patchRequest(request._id, { settingPath: value })}

--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -96,6 +96,7 @@ export const WebSocketActionBar = forwardRef<WebSocketActionBarHandle, ActionBar
         return {
           url: rendered.url,
           query,
+          path: request.settingPath,
           headers: rendered.headers,
           authentication: rendered.authentication,
           cookieJar: rendered.workspaceCookieJar,


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

**Support Socket.io [handshake path](https://socket.io/docs/v4/server-options/#path):**

- Add a new field `settingPath` to the socket.io request model
- Connect with the server with the `path` param
- disable path setting when connecting

<img width="954" height="357" alt="image" src="https://github.com/user-attachments/assets/77f6445e-fd5b-4804-a134-44647924f2b4" />

INS-1983
close #9442 
