### PR TITLE
fix: Separate GUI & internal state of runner request delay [INS-2130]

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/runner.test.ts
@@ -239,6 +239,41 @@ test.describe('runner features tests', () => {
     await verifyResultRows(page, 0, 0, 4, expectedTestOrder, 1);
   });
 
+  test('delay input can be cleared to enter a new value', async ({ page }) => {
+    await page.getByTestId('run-collection-btn-quick').click();
+
+    const delayInput = page.locator('input[name="Delay"]');
+
+    // default value should be 0
+    await expect.soft(delayInput).toHaveValue('0');
+
+    // clear the input
+    await delayInput.clear();
+    await expect.soft(delayInput).toHaveValue('');
+
+    // type a new value
+    await delayInput.fill('500');
+    await expect.soft(delayInput).toHaveValue('500');
+  });
+
+  test('running with cleared delay input uses last valid value', async ({ page }) => {
+    await page.getByTestId('run-collection-btn-quick').click();
+
+    const delayInput = page.locator('input[name="Delay"]');
+
+    // set a valid delay
+    await delayInput.fill('100');
+    await expect.soft(delayInput).toHaveValue('100');
+
+    // clear the input without entering a new value
+    await delayInput.clear();
+    await expect.soft(delayInput).toHaveValue('');
+
+    // blur the input - it should restore to last valid value
+    await delayInput.blur();
+    await expect.soft(delayInput).toHaveValue('100');
+  });
+
   test('iterations input can be cleared to enter a new value', async ({ page }) => {
     await page.getByTestId('run-collection-btn-quick').click();
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.runner.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.runner.tsx
@@ -165,6 +165,7 @@ export const Runner: FC = () => {
   const { updateTabById } = useInsomniaTabContext();
   const { runnerStateMap, updateRunnerState } = useRunnerContext();
   const [zeroableIterationCount, setZeroableIterationCount] = useState<string>('1');
+  const [clearableDelay, setClearableDelay] = useState<string>('0');
   const {
     iterationCount = 1,
     delay = 0,
@@ -179,6 +180,10 @@ export const Runner: FC = () => {
   useEffect(() => {
     setZeroableIterationCount(String(iterationCount));
   }, [iterationCount]);
+
+  useEffect(() => {
+    setClearableDelay(String(delay));
+  }, [delay]);
 
   const { reqList, requestRows, entityMap } = useRunnerRequestList(organizationId, targetFolderId, runnerId);
 
@@ -519,16 +524,28 @@ export const Runner: FC = () => {
                     </span>
                     <span className="mr-6 text-sm">
                       <input
-                        value={delay}
+                        value={clearableDelay}
                         disabled={isRunning}
                         name="Delay"
                         onChange={e => {
+                          // Internal state "delay" and the local state "clearableDelay" have different
+                          // valid values: clearableDelay = {delay, ''}
                           try {
-                            const delay = Number.parseInt(e.target.value, 10);
-                            if (delay >= 0) {
-                              updateRunnerState(organizationId, runnerId, { delay }); // also update the temp settings
+                            const intValue = Number.parseInt(e.target.value, 10);
+
+                            // An empty string is a valid value to render in the GUI—a user can clear the field in order
+                            // to enter a new value—but not valid for the internal state.
+                            if (e.target.value === '' || intValue === delay) {
+                              setClearableDelay(e.target.value);
+                            }
+
+                            if (intValue >= 0) {
+                              updateRunnerState(organizationId, runnerId, { delay: intValue });
                             }
                           } catch {}
+                        }}
+                        onBlur={() => {
+                          setClearableDelay(String(delay));
                         }}
                         type="number"
                         className={inputStyle}


### PR DESCRIPTION
This PR implements a fix similar to the one in #9715, but for the request delay input in the runner. Details outlining the issue & fix are outlined in the previous. I've copied it over and adapted it for ease of access:

> This PR allows users to temporarily clear the Delay input in the Runner without impacting the internal delay that Insomnia tracks. In the current Insomnia version users can't change the delay in the input by deleting the existing value and typing a new one. For example, if the delay is set to 1 and the user would like to change it to 5. The following alternatives work:
> 
> * Highlighting 1 and typing 5.
> * Using the Up arrow key to increment the number input to 5.
> 
> This PR separates the local state displayed in the GUI from the internal state that's actually used during execution. The two states only deviate when the local state is an empty string.
> 
> A couple smoke tests have been added. The changes were tested locally as well by:
> 
> * Clearing a single digit delay and then typing a different digit.
> * Clearing a single digit delay and then typing the same digit.
> * Clearing the delay input and clicking Run without typing anything.