### PR TITLE
feat(analytics): attach organization_id if available

### DIFF
--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -207,6 +207,7 @@ const main: Window['main'] = {
   secretStorage,
   trackSegmentEvent: options => ipcRenderer.send('trackSegmentEvent', options),
   trackPageView: options => ipcRenderer.send('trackPageView', options),
+  setCurrentOrganizationId: organizationId => ipcRenderer.send('analytics.setOrganizationId', organizationId),
   showNunjucksContextMenu: options => ipcRenderer.send('show-nunjucks-context-menu', options),
   showContextMenu: options => ipcRenderer.send('showContextMenu', options),
   database: {

--- a/packages/insomnia/src/main/analytics.ts
+++ b/packages/insomnia/src/main/analytics.ts
@@ -16,6 +16,12 @@ import {
 } from '../common/constants';
 import * as models from '../models/index';
 
+let _currentOrganizationId: string | undefined;
+
+export function setCurrentOrganizationId(id: string | undefined): void {
+  _currentOrganizationId = id;
+}
+
 const analytics = new Analytics({
   writeKey: getSegmentWriteKey(),
   httpClient: {
@@ -97,6 +103,7 @@ export async function trackSegmentEvent(event: SegmentEvent, properties?: Record
         {
           event,
           properties: {
+            ...(_currentOrganizationId && { organization_id: _currentOrganizationId }),
             ...properties,
             platform: 'app',
           },

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -141,6 +141,7 @@ export const ipcMainHandle = (
 ) => ipcMain.handle(channel, listener);
 export type MainOnChannels =
   | 'addExecutionStep'
+  | 'analytics.setOrganizationId'
   | 'cancelCurlRequest'
   | 'clear'
   | 'completeExecutionStep'

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -32,7 +32,7 @@ import type {
 import type { HiddenBrowserWindowBridgeAPI } from '../../entry.hidden-window';
 import type { PluginTemplateTag } from '../../templating/types';
 import type { SegmentEvent } from '../analytics';
-import { trackPageView, trackSegmentEvent } from '../analytics';
+import { setCurrentOrganizationId, trackPageView, trackSegmentEvent } from '../analytics';
 import {
   authorizeUserInDefaultBrowser,
   cancelAuthorizationInDefaultBrowser,
@@ -128,6 +128,7 @@ export interface RendererToMainBridgeAPI {
   secretStorage: secretStorageBridgeAPI;
   trackSegmentEvent: (options: { event: string; properties?: Record<string, unknown> }) => void;
   trackPageView: (options: { name: string }) => void;
+  setCurrentOrganizationId: (organizationId: string | undefined) => void;
   showNunjucksContextMenu: (options: {
     key: string;
     nunjucksTag?: { template: string; range: MarkerRange };
@@ -338,6 +339,9 @@ export function registerMainHandlers() {
   });
   ipcMainOn('trackPageView', (_, options: { name: string }): void => {
     trackPageView(options.name);
+  });
+  ipcMainOn('analytics.setOrganizationId', (_, organizationId: string | undefined): void => {
+    setCurrentOrganizationId(organizationId);
   });
 
   ipcMainHandle('installPlugin', (_, lookupName: string, allowScopedPackageNames = false) => {

--- a/packages/insomnia/src/routes/organization.tsx
+++ b/packages/insomnia/src/routes/organization.tsx
@@ -212,6 +212,11 @@ const Component = ({ loaderData }: Route.ComponentProps) => {
     }
   }, [organizationId, untrackedProjectsFetcher]);
 
+  useEffect(() => {
+    window.main.setCurrentOrganizationId(organizationId);
+    return () => window.main.setCurrentOrganizationId(undefined);
+  }, [organizationId]);
+
   const untrackedProjects = untrackedProjectsFetcher.data?.untrackedProjects || [];
   const untrackedWorkspaces = untrackedProjectsFetcher.data?.untrackedWorkspaces || [];
   const hasUntrackedData = untrackedProjects.length > 0 || untrackedWorkspaces.length > 0;


### PR DESCRIPTION
tested for a good chunk of events:
```json
"event": "quick-search-opened-by-mouse",
"originalTimestamp": "2026-03-19T15:09:17.047Z",
"properties": {
  "organization_id": "org_7df31910-29b1-4143-aad1-312b51626318", // local
  "platform": "app"
},
```