### PR TITLE
fix: Use flexbox layout in Invite modal to allow for scrolling on longer lists [INS-2101]

### DIFF
--- a/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
@@ -157,10 +157,10 @@ const InviteModal: FC<{
       onOpenChange={setIsOpen}
       className="theme--transparent-overlay fixed top-0 left-0 z-10 flex h-(--visual-viewport-height) w-full items-center justify-center bg-(--color-bg)"
     >
-      <Modal className="theme--dialog fixed top-[100px] h-fit w-full max-w-[900px] rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-[32px] text-(--color-font)">
-        <Dialog className="relative outline-hidden">
+      <Modal className="theme--dialog flex max-h-[calc(var(--visual-viewport-height)-140px)] w-full max-w-[900px] flex-col overflow-hidden rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-[32px] text-(--color-font)">
+        <Dialog className="relative flex h-full flex-1 flex-col overflow-hidden outline-hidden">
           {({ close }) => (
-            <>
+            <div className="flex h-full flex-col overflow-hidden">
               <Heading slot="title" className="mb-[24px] text-[22px] leading-[34px]">
                 Invite collaborators
               </Heading>
@@ -207,66 +207,68 @@ const InviteModal: FC<{
                   )}
                 </Group>
               </div>
-              {collaboratorListError && (
-                <div className="flex h-[200px] items-center justify-center">
-                  <p className="text-[12px] text-(--color-danger) first-letter:capitalize">{collaboratorListError}</p>
-                </div>
-              )}
-              {collaborators?.length === 0 && page === 0 ? (
-                !collaboratorListError && (
+              <div className="flex-1 overflow-y-auto">
+                {collaboratorListError && (
                   <div className="flex h-[200px] items-center justify-center">
-                    <p className="text-[14px] text-(--color-font)">
-                      {queryInputString
-                        ? `No member or team found for the search: "${queryInputString}"`
-                        : 'No members or teams'}
-                    </p>
+                    <p className="text-[12px] text-(--color-danger) first-letter:capitalize">{collaboratorListError}</p>
                   </div>
-                )
-              ) : (
-                <>
-                  <ListBox aria-label="Invitation list" className="flex flex-col gap-1">
-                    {collaborators?.map((member: Collaborator) => (
-                      <MemberListItem
-                        key={member.id}
-                        organizationId={organizationId}
-                        member={member}
-                        currentUserAccountId={currentUserAccountId}
-                        currentUserRoleInOrg={currentUserRoleInOrg}
-                        allRoles={allRoles}
-                        isCurrentUserOrganizationOwner={isCurrentUserOrganizationOwner}
-                        orgFeatures={orgFeatures}
-                        permissionRef={permissionRef}
-                        revalidateCurrentUserRoleAndPermissionsInOrg={revalidateCurrentUserRoleAndPermissionsInOrg}
-                        onResetCurrentPage={resetCurrentPage}
-                        onError={setError}
-                        onRemoveMember={() => {
-                          collaboratorsCheckSeatsLoaderLoad({ organizationId });
-                        }}
-                      />
-                    ))}
-                  </ListBox>
-                  <PaginationBar
-                    isPrevDisabled={page === 0}
-                    isNextDisabled={total <= ItemsPerPage || total <= (page + 1) * ItemsPerPage}
-                    isHidden={total <= ItemsPerPage && page === 0}
-                    onPrevPress={() => {
-                      collaboratorsListLoader.load({ organizationId, page: page - 1, per_page: ItemsPerPage });
-                      setSearchParams(getSearchParamsString(searchParams, { page: page - 1 }));
-                    }}
-                    onNextPress={() => {
-                      collaboratorsListLoader.load({ organizationId, page: page + 1, per_page: ItemsPerPage });
-
-                      setSearchParams(getSearchParamsString(searchParams, { page: page + 1 }));
-                    }}
-                  />
-                  {error && (
-                    <div className="mt-[16px] flex justify-center">
-                      <p className="text-[12px] text-(--color-danger)">{error}</p>
+                )}
+                {collaborators?.length === 0 && page === 0 ? (
+                  !collaboratorListError && (
+                    <div className="flex h-[200px] items-center justify-center">
+                      <p className="text-[14px] text-(--color-font)">
+                        {queryInputString
+                          ? `No member or team found for the search: "${queryInputString}"`
+                          : 'No members or teams'}
+                      </p>
                     </div>
-                  )}
-                </>
-              )}
-            </>
+                  )
+                ) : (
+                  <>
+                    <ListBox aria-label="Invitation list" className="flex flex-col gap-1">
+                      {collaborators?.map((member: Collaborator) => (
+                        <MemberListItem
+                          key={member.id}
+                          organizationId={organizationId}
+                          member={member}
+                          currentUserAccountId={currentUserAccountId}
+                          currentUserRoleInOrg={currentUserRoleInOrg}
+                          allRoles={allRoles}
+                          isCurrentUserOrganizationOwner={isCurrentUserOrganizationOwner}
+                          orgFeatures={orgFeatures}
+                          permissionRef={permissionRef}
+                          revalidateCurrentUserRoleAndPermissionsInOrg={revalidateCurrentUserRoleAndPermissionsInOrg}
+                          onResetCurrentPage={resetCurrentPage}
+                          onError={setError}
+                          onRemoveMember={() => {
+                            collaboratorsCheckSeatsLoaderLoad({ organizationId });
+                          }}
+                        />
+                      ))}
+                    </ListBox>
+                    <PaginationBar
+                      isPrevDisabled={page === 0}
+                      isNextDisabled={total <= ItemsPerPage || total <= (page + 1) * ItemsPerPage}
+                      isHidden={total <= ItemsPerPage && page === 0}
+                      onPrevPress={() => {
+                        collaboratorsListLoader.load({ organizationId, page: page - 1, per_page: ItemsPerPage });
+                        setSearchParams(getSearchParamsString(searchParams, { page: page - 1 }));
+                      }}
+                      onNextPress={() => {
+                        collaboratorsListLoader.load({ organizationId, page: page + 1, per_page: ItemsPerPage });
+
+                        setSearchParams(getSearchParamsString(searchParams, { page: page + 1 }));
+                      }}
+                    />
+                    {error && (
+                      <div className="mt-[16px] flex justify-center">
+                        <p className="text-[12px] text-(--color-danger)">{error}</p>
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+            </div>
           )}
         </Dialog>
       </Modal>

--- a/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
@@ -246,20 +246,6 @@ const InviteModal: FC<{
                         />
                       ))}
                     </ListBox>
-                    <PaginationBar
-                      isPrevDisabled={page === 0}
-                      isNextDisabled={total <= ItemsPerPage || total <= (page + 1) * ItemsPerPage}
-                      isHidden={total <= ItemsPerPage && page === 0}
-                      onPrevPress={() => {
-                        collaboratorsListLoader.load({ organizationId, page: page - 1, per_page: ItemsPerPage });
-                        setSearchParams(getSearchParamsString(searchParams, { page: page - 1 }));
-                      }}
-                      onNextPress={() => {
-                        collaboratorsListLoader.load({ organizationId, page: page + 1, per_page: ItemsPerPage });
-
-                        setSearchParams(getSearchParamsString(searchParams, { page: page + 1 }));
-                      }}
-                    />
                     {error && (
                       <div className="mt-[16px] flex justify-center">
                         <p className="text-[12px] text-(--color-danger)">{error}</p>
@@ -268,6 +254,20 @@ const InviteModal: FC<{
                   </>
                 )}
               </div>
+              <PaginationBar
+                isPrevDisabled={page === 0}
+                isNextDisabled={total <= ItemsPerPage || total <= (page + 1) * ItemsPerPage}
+                isHidden={total <= ItemsPerPage && page === 0}
+                onPrevPress={() => {
+                  collaboratorsListLoader.load({ organizationId, page: page - 1, per_page: ItemsPerPage });
+                  setSearchParams(getSearchParamsString(searchParams, { page: page - 1 }));
+                }}
+                onNextPress={() => {
+                  collaboratorsListLoader.load({ organizationId, page: page + 1, per_page: ItemsPerPage });
+
+                  setSearchParams(getSearchParamsString(searchParams, { page: page + 1 }));
+                }}
+              />
             </div>
           )}
         </Dialog>

--- a/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
@@ -157,7 +157,7 @@ const InviteModal: FC<{
       onOpenChange={setIsOpen}
       className="theme--transparent-overlay fixed top-0 left-0 z-10 flex h-(--visual-viewport-height) w-full items-start justify-center bg-(--color-bg) pt-[70px]"
     >
-      <Modal className="theme--dialog flex max-h-[calc(var(--visual-viewport-height)-140px)] w-full max-w-[900px] flex-col overflow-hidden rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-[32px] text-(--color-font)">
+      <Modal className="theme--dialog flex max-h-[calc(var(--visual-viewport-height)-140px)] w-full max-w-[900px] flex-col rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-[32px] text-(--color-font)">
         <Dialog className="relative flex h-full flex-1 flex-col overflow-hidden outline-hidden">
           {({ close }) => (
             <div className="flex h-full flex-col overflow-hidden">

--- a/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/invite-modal/invite-modal.tsx
@@ -155,7 +155,7 @@ const InviteModal: FC<{
       isDismissable={false}
       isOpen={true}
       onOpenChange={setIsOpen}
-      className="theme--transparent-overlay fixed top-0 left-0 z-10 flex h-(--visual-viewport-height) w-full items-center justify-center bg-(--color-bg)"
+      className="theme--transparent-overlay fixed top-0 left-0 z-10 flex h-(--visual-viewport-height) w-full items-start justify-center bg-(--color-bg) pt-[70px]"
     >
       <Modal className="theme--dialog flex max-h-[calc(var(--visual-viewport-height)-140px)] w-full max-w-[900px] flex-col overflow-hidden rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) p-[32px] text-(--color-font)">
         <Dialog className="relative flex h-full flex-1 flex-col overflow-hidden outline-hidden">


### PR DESCRIPTION
Note that the diff is likely cleaner with whitespace-only changes ignored.

The "Invite collaborators" modal overflows beyond the fold when the list becomes long enough.

<img width="1912" height="1242" alt="image" src="https://github.com/user-attachments/assets/a19d4fd9-7426-4e94-a427-8d08ac353b2f" />

This PR centers the modal vertically to be consistent with other modals throughout the app and modifies the modal contents to use flexbox for layout throughout, allowing the list of collaborators to scroll vertically.

<img width="1912" height="1242" alt="image" src="https://github.com/user-attachments/assets/a4a10b69-e34e-4ba0-b67c-c14645e115f4" />

No automated tests have been added because testing for such scenarios is likely to just lead to unnecessary tests over time, but changes were manually tested in the following scenarios:
- Project with a single collaborator
- Project with multiple collaborators but not enough to cause overflow
- Project with enough collaborators to cause vertical overflow
- Project with enough collaborators to span multiple pages

I didn't manually test a case where there are _no_ collaborators on a project—I'm not sure if such a case is possible even though such a state is accounted for in the code.
