### PR TITLE
feat: enforce Promise-only service exports in insomnia-data node services

### DIFF
--- a/packages/insomnia/src/insomnia-data/node-src/services/ca-certificate.ts
+++ b/packages/insomnia/src/insomnia-data/node-src/services/ca-certificate.ts
@@ -2,7 +2,7 @@ import { database as db } from '../../src/database';
 import { models } from '../../src/models';
 import { type CaCertificate } from '../../src/models/types';
 
-export const { type } = models.caCertificate;
+const { type } = models.caCertificate;
 
 export function create(patch: Partial<CaCertificate> = {}) {
   if (!patch.parentId) {

--- a/packages/insomnia/src/insomnia-data/node-src/services/index.ts
+++ b/packages/insomnia/src/insomnia-data/node-src/services/index.ts
@@ -3,9 +3,12 @@ import * as mcpPayloadService from './mcp-payload';
 import * as mcpRequestService from './mcp-request';
 import * as mcpResponseService from './mcp-response';
 
+// Services are consumed from renderer via preload -> IPC (`ipcRenderer.invoke`), so this contract
+// must stay async across runtimes even if a main-process implementation could be synchronous.
+// `satisfies` keeps the original inferred type while still producing compile-time errors for sync actions.
 export const servicesNodeImpl = {
   caCertificate: caCertificateService,
   mcpRequest: mcpRequestService,
   mcpResponse: mcpResponseService,
   mcpPayload: mcpPayloadService,
-} as const;
+} satisfies Record<string, Record<string, (...args: never[]) => Promise<unknown>>>;


### PR DESCRIPTION

## Background

Services are shared between inso, renderer, and main, and in the renderer process, it relies on the IPC to work, which means all the service functions are async.

## Changes

* Enforced that all service methods in `servicesNodeImpl` must be asynchronous by using the `satisfies` operator with a stricter type contract in `index.ts`. This ensures compile-time errors for any synchronous service actions, maintaining consistency across runtimes.