### PR TITLE
feat: new deep link import

### DIFF
--- a/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/cloud-sync.test.ts
@@ -70,7 +70,7 @@ test.describe('Cloud Sync', () => {
     // Ensure body is restored
     await page.getByRole('tab', { name: 'Body' }).click();
     await page.getByRole('button', { name: 'Send' }).click();
-    await expect.soft(page.getByText('foo=bar')).toBeHidden();
+    await expect.soft(page.getByTestId('response-pane').getByText('foo=bar')).toBeHidden();
 
     // go back and select mcp project
     await page

--- a/packages/insomnia/src/common/__fixtures__/openapi/smoke-test-with-operationIds.yaml
+++ b/packages/insomnia/src/common/__fixtures__/openapi/smoke-test-with-operationIds.yaml
@@ -1,0 +1,106 @@
+openapi: 3.0.0
+info:
+  description: this is an example description in an OpenAPI Doc
+  title: Smoke Test API server
+  version: 1.0.0
+servers:
+  - url: http://localhost:4010
+tags:
+  - name: Misc
+  - name: Auth
+  - name: File
+paths:
+  /pets/{id}:
+    get:
+      operationId: echoId
+      summary: Echo id
+      parameters:
+        - name: id
+          in: path
+          schema:
+            type: string
+          required: true
+      tags:
+        - Misc
+      responses:
+        "200":
+          description: A JSON object containing the id
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+  /file/dummy.csv:
+    get:
+      operationId: dummyCsvFile
+      summary: Get dummy CSV file
+      tags:
+        - File
+      responses:
+        "200":
+          description: loaded dummy csv file
+          content:
+            application/csv:
+              schema:
+                $ref: "#/components/schemas/File"
+  /file/dummy.pdf:
+    get:
+      operationId: dummyPdfFile
+      summary: Get dummy PDF file
+      tags:
+        - File
+      responses:
+        "200":
+          description: loaded dummy CSV file
+          content:
+            application/pdf:
+              schema:
+                $ref: "#/components/schemas/File"
+  /auth/basic:
+    get:
+      operationId: basicAuth
+      summary: Make basic auth request
+      security:
+        - basicAuth: []
+      tags:
+        - Auth
+      responses:
+        "200":
+          description: successfully authed
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/String"
+  /delay/seconds/{duration}:
+    get:
+      operationId: delayByDuration
+      summary: Delay by seconds
+      parameters:
+        - name: duration
+          in: path
+          schema:
+            type: integer
+          required: true
+      tags:
+        - Misc
+      responses:
+        "200":
+          description: delayed
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/String"
+components:
+  schemas:
+    File:
+      type: string
+      format: binary
+    String:
+      type: string
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+    

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -2,82 +2,114 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
 
 import { environment, project, request, requestGroup, workspace } from '../../models';
 import { EnvironmentKvPairDataType } from '../../models/environment';
 import * as importUtil from '../import';
+import { INSOMNIA_SCHEMA_VERSION } from '../insomnia-schema-migrations/schema-version';
+import { tryImportV5Data } from '../insomnia-v5';
 import { generateId } from '../misc';
-
-function pathPatternMatches(pattern: string, concretePath: string): boolean {
-  if (!pattern || pattern.length > 200) {
-    return false;
-  }
-  if (pattern === concretePath) {
-    return true;
-  }
-  const patternSegments = pattern.split('/').filter(Boolean);
-  const pathSegments = concretePath.split('/').filter(Boolean);
-  if (patternSegments.length > pathSegments.length) {
-    return false;
-  }
-  const offset = pathSegments.length - patternSegments.length;
-  const pathSuffix = pathSegments.slice(offset);
-  return patternSegments.every((segment, i) => {
-    if (segment.startsWith(':')) {
-      return pathSuffix[i].length > 0;
-    }
-    return segment.toLowerCase() === pathSuffix[i].toLowerCase();
-  });
-}
 
 describe('pathPatternMatches', () => {
   it('should match exact paths', () => {
-    expect(pathPatternMatches('/users', '/users')).toBe(true);
-    expect(pathPatternMatches('/users/list', '/users/list')).toBe(true);
+    expect(importUtil.pathPatternMatches('/users', '/users')).toBe(true);
+    expect(importUtil.pathPatternMatches('/users/list', '/users/list')).toBe(true);
   });
 
   it('should not match different paths', () => {
-    expect(pathPatternMatches('/users', '/user')).toBe(false);
-    expect(pathPatternMatches('/users', '/users/123')).toBe(false);
-    expect(pathPatternMatches('/users/list', '/users')).toBe(false);
+    expect(importUtil.pathPatternMatches('/users', '/user')).toBe(false);
+    expect(importUtil.pathPatternMatches('/users', '/users/123')).toBe(false);
+    expect(importUtil.pathPatternMatches('/users/list', '/users')).toBe(false);
   });
 
   it('should match paths with path parameters', () => {
-    expect(pathPatternMatches('/users/:id', '/users/123')).toBe(true);
-    expect(pathPatternMatches('/users/:userId/orders/:orderId', '/users/abc/orders/xyz')).toBe(true);
-    expect(pathPatternMatches('/api/:version/resource', '/api/v1/resource')).toBe(true);
+    expect(importUtil.pathPatternMatches('/users/:id', '/users/123')).toBe(true);
+    expect(importUtil.pathPatternMatches('/users/:userId/orders/:orderId', '/users/abc/orders/xyz')).toBe(true);
+    expect(importUtil.pathPatternMatches('/api/:version/resource', '/api/v1/resource')).toBe(true);
   });
 
   it('should not match when path param is empty', () => {
-    expect(pathPatternMatches('/users/:id', '/users/')).toBe(false);
-    expect(pathPatternMatches('/users/:id', '/users')).toBe(false);
+    expect(importUtil.pathPatternMatches('/users/:id', '/users/')).toBe(false);
+    expect(importUtil.pathPatternMatches('/users/:id', '/users')).toBe(false);
   });
 
   it('should be case insensitive for static segments', () => {
-    expect(pathPatternMatches('/Users', '/users')).toBe(true);
-    expect(pathPatternMatches('/USERS/LIST', '/users/list')).toBe(true);
-    expect(pathPatternMatches('/api/v1', '/API/V1')).toBe(true);
+    expect(importUtil.pathPatternMatches('/Users', '/users')).toBe(true);
+    expect(importUtil.pathPatternMatches('/USERS/LIST', '/users/list')).toBe(true);
+    expect(importUtil.pathPatternMatches('/api/v1', '/API/V1')).toBe(true);
   });
 
   it('should handle empty pattern', () => {
-    expect(pathPatternMatches('', '/users')).toBe(false);
+    expect(importUtil.pathPatternMatches('', '/users')).toBe(false);
   });
 
   it('should reject patterns over 200 characters', () => {
     const longPattern = '/' + 'a'.repeat(200);
-    expect(pathPatternMatches(longPattern, '/aaaa')).toBe(false);
+    expect(importUtil.pathPatternMatches(longPattern, '/aaaa')).toBe(false);
   });
 
   it('should match paths with different segment counts (prefix matching)', () => {
-    expect(pathPatternMatches('/basic', '/v1/basic')).toBe(true);
-    expect(pathPatternMatches('/users', '/api/v1/users')).toBe(true);
-    expect(pathPatternMatches('/key/header', '/v1/key/header')).toBe(true);
+    expect(importUtil.pathPatternMatches('/basic', '/v1/basic')).toBe(true);
+    expect(importUtil.pathPatternMatches('/users', '/api/v1/users')).toBe(true);
+    expect(importUtil.pathPatternMatches('/key/header', '/v1/key/header')).toBe(true);
   });
 
   it('should handle leading slashes consistently', () => {
-    expect(pathPatternMatches('users', 'users')).toBe(true);
-    expect(pathPatternMatches('users', '/users')).toBe(true);
-    expect(pathPatternMatches('/users', 'users')).toBe(true);
+    expect(importUtil.pathPatternMatches('users', 'users')).toBe(true);
+    expect(importUtil.pathPatternMatches('users', '/users')).toBe(true);
+    expect(importUtil.pathPatternMatches('/users', 'users')).toBe(true);
+  });
+});
+
+describe('mcpUrlToInsomniaV5Yaml', () => {
+  it('should produce YAML matching the MCP client export shape (schema_version, mcpRequest)', () => {
+    const yaml = importUtil.mcpUrlToInsomniaV5Yaml('https://example.com/mcp?x=1#y');
+    const doc = parse(yaml) as Record<string, unknown>;
+    expect(doc).toMatchObject({
+      type: 'mcpClient.insomnia/5.0',
+      schema_version: INSOMNIA_SCHEMA_VERSION,
+      name: 'Imported MCP Client',
+      mcpRequest: {
+        name: 'Imported MCP Client',
+        url: 'https://example.com/mcp?x=1#y',
+        transportType: 'streamable-http',
+      },
+    });
+  });
+
+  it.each([
+    ['https://example.com'],
+    ['https://example.com/mcp'],
+    ['https://example.com/mcp?param=value'],
+    ['https://example.com/mcp#fragment'],
+    ['http://examples.com/mcp'],
+  ])('should embed the MCP URL %s in mcpRequest.url', url => {
+    const doc = parse(importUtil.mcpUrlToInsomniaV5Yaml(url)) as { mcpRequest: { url: string } };
+    expect(doc.mcpRequest.url).toBe(url);
+  });
+
+  it('should throw an error if the MCP URL is not a valid HTTP URL', () => {
+    expect(() => importUtil.mcpUrlToInsomniaV5Yaml('ftp://example.com')).toThrow(
+      'MCP server URL must use http or https',
+    );
+    expect(() => importUtil.mcpUrlToInsomniaV5Yaml('not-a-url')).toThrow('Invalid URL: not-a-url');
+  });
+
+  it('escape sequences in the MCP URL are unmodified', () => {
+    const cases = ['https://example.com/foo\\nbar', 'https://example.com/foo\\tbar'] as const;
+    for (const input of cases) {
+      const yaml = importUtil.mcpUrlToInsomniaV5Yaml(input);
+      const doc = parse(yaml) as { mcpRequest: { url: string } };
+      expect(doc.mcpRequest.url).toBe(input);
+    }
+  });
+
+  it('should be accepted by the v5 importer', () => {
+    const yaml = importUtil.mcpUrlToInsomniaV5Yaml('https://example.com/mcp');
+    const { data, error } = tryImportV5Data(yaml);
+    expect(error).toBeUndefined();
+    expect(data.length).toBeGreaterThan(0);
   });
 });
 
@@ -449,77 +481,6 @@ describe('importRaw()', () => {
     expect(newKvPairData.filter(pair => !pair.enabled).length).toBe(2);
     expect(newKvPairData.find(pair => pair.name === 'from' && pair.enabled)?.value).toBe('baseEnv');
     expect(newKvPairData.find(pair => pair.name === 'foo')?.value).toBe('bar');
-  });
-
-  it('should find existing request by method and url matching OpenAPI path params', async () => {
-    const fixturePath = path.join(__dirname, '..', '__fixtures__', 'openapi', 'endpoint-security-input.yaml');
-    const content = fs.readFileSync(fixturePath, 'utf8').toString();
-
-    const projectToImportTo = await project.create();
-
-    const scanResult = await importUtil.scanResources([
-      {
-        contentStr: content,
-      },
-    ]);
-
-    expect(scanResult[0].type?.id).toBe('openapi3');
-    expect(scanResult[0].errors.length).toBe(0);
-
-    await importUtil.importResourcesToProject({
-      projectId: projectToImportTo._id,
-    });
-
-    const workspaces = await workspace.findByParentId(projectToImportTo._id);
-    expect(workspaces).toHaveLength(1);
-    const requests = await request.findByParentId(workspaces[0]._id);
-    expect(requests.length).toBeGreaterThan(0);
-
-    const result = await importUtil.findExistingRequestByMethodAndUrl(
-      projectToImportTo._id,
-      'GET',
-      'https://api.server.test/v1/key/header',
-    );
-    expect(result).toBeDefined();
-    expect(result?.request.url).toContain('/key/header');
-  });
-
-  it('should find existing request by method and url with path parameters', async () => {
-    const fixturePath = path.join(__dirname, '..', '__fixtures__', 'openapi', 'endpoint-security-input.yaml');
-    const content = fs.readFileSync(fixturePath, 'utf8').toString();
-
-    const projectToImportTo = await project.create();
-
-    await importUtil.scanResources([{ contentStr: content }]);
-    await importUtil.importResourcesToProject({ projectId: projectToImportTo._id });
-
-    const workspaces = await workspace.findByParentId(projectToImportTo._id);
-    const requests = await request.findByParentId(workspaces[0]._id);
-
-    const result = await importUtil.findExistingRequestByMethodAndUrl(
-      projectToImportTo._id,
-      'GET',
-      'https://api.server.test/v1/basic',
-    );
-    expect(result).toBeDefined();
-    expect(result?.request.method).toBe('GET');
-  });
-
-  it('should return undefined when no matching request found', async () => {
-    const fixturePath = path.join(__dirname, '..', '__fixtures__', 'openapi', 'endpoint-security-input.yaml');
-    const content = fs.readFileSync(fixturePath, 'utf8').toString();
-
-    const projectToImportTo = await project.create();
-
-    await importUtil.scanResources([{ contentStr: content }]);
-    await importUtil.importResourcesToProject({ projectId: projectToImportTo._id });
-
-    const result = await importUtil.findExistingRequestByMethodAndUrl(
-      projectToImportTo._id,
-      'POST',
-      'https://api.server.test/v1/none',
-    );
-    expect(result).toBeUndefined();
   });
 
   it('should resolve operationId to method and name', async () => {

--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -8,6 +8,79 @@ import { EnvironmentKvPairDataType } from '../../models/environment';
 import * as importUtil from '../import';
 import { generateId } from '../misc';
 
+function pathPatternMatches(pattern: string, concretePath: string): boolean {
+  if (!pattern || pattern.length > 200) {
+    return false;
+  }
+  if (pattern === concretePath) {
+    return true;
+  }
+  const patternSegments = pattern.split('/').filter(Boolean);
+  const pathSegments = concretePath.split('/').filter(Boolean);
+  if (patternSegments.length > pathSegments.length) {
+    return false;
+  }
+  const offset = pathSegments.length - patternSegments.length;
+  const pathSuffix = pathSegments.slice(offset);
+  return patternSegments.every((segment, i) => {
+    if (segment.startsWith(':')) {
+      return pathSuffix[i].length > 0;
+    }
+    return segment.toLowerCase() === pathSuffix[i].toLowerCase();
+  });
+}
+
+describe('pathPatternMatches', () => {
+  it('should match exact paths', () => {
+    expect(pathPatternMatches('/users', '/users')).toBe(true);
+    expect(pathPatternMatches('/users/list', '/users/list')).toBe(true);
+  });
+
+  it('should not match different paths', () => {
+    expect(pathPatternMatches('/users', '/user')).toBe(false);
+    expect(pathPatternMatches('/users', '/users/123')).toBe(false);
+    expect(pathPatternMatches('/users/list', '/users')).toBe(false);
+  });
+
+  it('should match paths with path parameters', () => {
+    expect(pathPatternMatches('/users/:id', '/users/123')).toBe(true);
+    expect(pathPatternMatches('/users/:userId/orders/:orderId', '/users/abc/orders/xyz')).toBe(true);
+    expect(pathPatternMatches('/api/:version/resource', '/api/v1/resource')).toBe(true);
+  });
+
+  it('should not match when path param is empty', () => {
+    expect(pathPatternMatches('/users/:id', '/users/')).toBe(false);
+    expect(pathPatternMatches('/users/:id', '/users')).toBe(false);
+  });
+
+  it('should be case insensitive for static segments', () => {
+    expect(pathPatternMatches('/Users', '/users')).toBe(true);
+    expect(pathPatternMatches('/USERS/LIST', '/users/list')).toBe(true);
+    expect(pathPatternMatches('/api/v1', '/API/V1')).toBe(true);
+  });
+
+  it('should handle empty pattern', () => {
+    expect(pathPatternMatches('', '/users')).toBe(false);
+  });
+
+  it('should reject patterns over 200 characters', () => {
+    const longPattern = '/' + 'a'.repeat(200);
+    expect(pathPatternMatches(longPattern, '/aaaa')).toBe(false);
+  });
+
+  it('should match paths with different segment counts (prefix matching)', () => {
+    expect(pathPatternMatches('/basic', '/v1/basic')).toBe(true);
+    expect(pathPatternMatches('/users', '/api/v1/users')).toBe(true);
+    expect(pathPatternMatches('/key/header', '/v1/key/header')).toBe(true);
+  });
+
+  it('should handle leading slashes consistently', () => {
+    expect(pathPatternMatches('users', 'users')).toBe(true);
+    expect(pathPatternMatches('users', '/users')).toBe(true);
+    expect(pathPatternMatches('/users', 'users')).toBe(true);
+  });
+});
+
 /*
 @vitest-environment jsdom
 */
@@ -376,5 +449,110 @@ describe('importRaw()', () => {
     expect(newKvPairData.filter(pair => !pair.enabled).length).toBe(2);
     expect(newKvPairData.find(pair => pair.name === 'from' && pair.enabled)?.value).toBe('baseEnv');
     expect(newKvPairData.find(pair => pair.name === 'foo')?.value).toBe('bar');
+  });
+
+  it('should find existing request by method and url matching OpenAPI path params', async () => {
+    const fixturePath = path.join(__dirname, '..', '__fixtures__', 'openapi', 'endpoint-security-input.yaml');
+    const content = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    const projectToImportTo = await project.create();
+
+    const scanResult = await importUtil.scanResources([
+      {
+        contentStr: content,
+      },
+    ]);
+
+    expect(scanResult[0].type?.id).toBe('openapi3');
+    expect(scanResult[0].errors.length).toBe(0);
+
+    await importUtil.importResourcesToProject({
+      projectId: projectToImportTo._id,
+    });
+
+    const workspaces = await workspace.findByParentId(projectToImportTo._id);
+    expect(workspaces).toHaveLength(1);
+    const requests = await request.findByParentId(workspaces[0]._id);
+    expect(requests.length).toBeGreaterThan(0);
+
+    const result = await importUtil.findExistingRequestByMethodAndUrl(
+      projectToImportTo._id,
+      'GET',
+      'https://api.server.test/v1/key/header',
+    );
+    expect(result).toBeDefined();
+    expect(result?.request.url).toContain('/key/header');
+  });
+
+  it('should find existing request by method and url with path parameters', async () => {
+    const fixturePath = path.join(__dirname, '..', '__fixtures__', 'openapi', 'endpoint-security-input.yaml');
+    const content = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    const projectToImportTo = await project.create();
+
+    await importUtil.scanResources([{ contentStr: content }]);
+    await importUtil.importResourcesToProject({ projectId: projectToImportTo._id });
+
+    const workspaces = await workspace.findByParentId(projectToImportTo._id);
+    const requests = await request.findByParentId(workspaces[0]._id);
+
+    const result = await importUtil.findExistingRequestByMethodAndUrl(
+      projectToImportTo._id,
+      'GET',
+      'https://api.server.test/v1/basic',
+    );
+    expect(result).toBeDefined();
+    expect(result?.request.method).toBe('GET');
+  });
+
+  it('should return undefined when no matching request found', async () => {
+    const fixturePath = path.join(__dirname, '..', '__fixtures__', 'openapi', 'endpoint-security-input.yaml');
+    const content = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    const projectToImportTo = await project.create();
+
+    await importUtil.scanResources([{ contentStr: content }]);
+    await importUtil.importResourcesToProject({ projectId: projectToImportTo._id });
+
+    const result = await importUtil.findExistingRequestByMethodAndUrl(
+      projectToImportTo._id,
+      'POST',
+      'https://api.server.test/v1/none',
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it('should resolve operationId to method and name', async () => {
+    const fixturePath = path.join(__dirname, '..', '__fixtures__', 'openapi', 'smoke-test-with-operationIds.yaml');
+    const content = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    await importUtil.scanResources([{ contentStr: content }]);
+
+    const result = importUtil.resolveOperationId('echoId');
+    expect(result).toBeDefined();
+    expect(result?.method).toBe('get');
+    expect(result?.name).toBe('Echo id');
+  });
+
+  it('should resolve operationId with path parameters in path', async () => {
+    const fixturePath = path.join(__dirname, '..', '__fixtures__', 'openapi', 'smoke-test-with-operationIds.yaml');
+    const content = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    await importUtil.scanResources([{ contentStr: content }]);
+
+    const result = importUtil.resolveOperationId('delayByDuration');
+    expect(result).toBeDefined();
+    expect(result?.method).toBe('get');
+    expect(result?.name).toBe('Delay by seconds');
+  });
+
+  it('should return undefined for non-existent operationId', async () => {
+    const fixturePath = path.join(__dirname, '..', '__fixtures__', 'openapi', 'smoke-test-with-operationIds.yaml');
+    const content = fs.readFileSync(fixturePath, 'utf8').toString();
+
+    await importUtil.scanResources([{ contentStr: content }]);
+
+    const result = importUtil.resolveOperationId('nonExistentOpId');
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -242,14 +242,11 @@ export async function scanResources(importEntries: ImportEntry[]): Promise<ScanR
           return { ...model, type: MODELS_BY_EXPORT_TYPE[_type] };
         });
 
-      const isDuplicateContent = resourceCacheList.some(c => c.content === contentStr);
-      if (!isDuplicateContent) {
-        resourceCacheList.push({
-          resources,
-          importer: type,
-          content: contentStr,
-        });
-      }
+      resourceCacheList.push({
+        resources,
+        importer: type,
+        content: contentStr,
+      });
 
       const requests = resources.filter(isRequest);
       const requestGroups = resources.filter(isRequestGroup);

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -834,6 +834,9 @@ export async function findRequestInExistingWorkspace(
   const requests = allDocs.filter(isRequest);
   if (endpoint) {
     const [method, path] = endpoint.split(',', 2);
+    if (!method || !path) {
+      return undefined;
+    }
     const normalizedPath = pathWithParamsAsPathParameters(path);
     return requests.find(
       r =>

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -172,6 +172,8 @@ export const MODELS_BY_EXPORT_TYPE: Record<AllExportTypes, AllTypes> = {
   proto_directory: 'ProtoDirectory',
 };
 
+export { mcpUrlToInsomniaV5Yaml } from './insomnia-v5';
+
 export async function scanResources(importEntries: ImportEntry[]): Promise<ScanResult[]> {
   resourceCacheList = [];
   const results = await Promise.allSettled(
@@ -795,34 +797,6 @@ export function pathPatternMatches(pattern: string, concretePath: string): boole
     }
     return segment.toLowerCase() === pathSuffix[i].toLowerCase();
   });
-}
-
-export async function findExistingRequestByMethodAndUrl(
-  projectId: string,
-  method: string,
-  url: string,
-): Promise<{ workspace: Workspace; request: Request } | undefined> {
-  let concretePath: string;
-  try {
-    concretePath = new URL(url).pathname;
-  } catch {
-    return undefined;
-  }
-  const workspaces = await models.workspace.findByParentId(projectId);
-  const workspacesWithRequests = workspaces.filter(w => w.scope === 'collection' || w.scope === 'design');
-  for (const ws of workspacesWithRequests) {
-    const allDocs = await db.getWithDescendants(ws, [models.request.type]);
-    const requests = allDocs.filter(isRequest);
-    const match = requests.find(
-      r =>
-        r.method.toUpperCase() === method.toUpperCase() &&
-        pathPatternMatches(getPathFromRequestUrl(r.url), concretePath),
-    );
-    if (match && isRequest(match)) {
-      return { workspace: ws, request: match };
-    }
-  }
-  return undefined;
 }
 
 export async function findRequestInExistingWorkspace(

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -4,8 +4,9 @@ import { z, type ZodError } from 'zod/v4';
 import { type ApiSpec, type McpRequest, services } from '~/insomnia-data';
 import { insecureReadFile } from '~/main/secure-read-file';
 
-import { type InsomniaImporter } from '../main/importers/convert';
+import type { InsomniaImporter } from '../main/importers/convert';
 import type { ImportEntry } from '../main/importers/entities';
+import { pathWithParamsAsPathParameters } from '../main/importers/importers/openapi-3';
 import { id as postmanEnvImporterId } from '../main/importers/importers/postman-env';
 import { type CookieJar, isCookieJar } from '../models/cookie-jar';
 import {
@@ -15,8 +16,8 @@ import {
   isEnvironment,
 } from '../models/environment';
 import { type GrpcRequest, isGrpcRequest } from '../models/grpc-request';
-import { type AllTypes, type BaseModel, getModel } from '../models/index';
 import * as models from '../models/index';
+import { type AllTypes, type BaseModel, getModel } from '../models/index';
 import { isMockRoute, type MockRoute } from '../models/mock-route';
 import { isGitProject } from '../models/project';
 import { isRequest, type Request } from '../models/request';
@@ -27,12 +28,16 @@ import { isUnitTestSuite, type UnitTestSuite } from '../models/unit-test-suite';
 import { isWebSocketRequest, type WebSocketRequest } from '../models/websocket-request';
 import { isWorkspace, type Workspace } from '../models/workspace';
 import { invariant } from '../utils/invariant';
+import { parseApiSpec, type ParsedApiSpec } from './api-specs';
 import { JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR } from './constants';
 import { database as db } from './database';
 import { tryImportV5Data } from './insomnia-v5';
 import { generateId } from './misc';
 
 const { isApiSpec } = models.apiSpec;
+
+export const IMPORT_SOURCE_TYPES = ['file', 'uri', 'curl', 'clipboard', 'mcp'] as const;
+export type ImportSourceType = (typeof IMPORT_SOURCE_TYPES)[number];
 
 export type AllExportTypes =
   | 'request'
@@ -141,6 +146,10 @@ interface ResourceCacheType {
 
 let resourceCacheList: ResourceCacheType[] = [];
 
+export function clearResourceCache() {
+  resourceCacheList = [];
+}
+
 // All models that can be exported should be listed here
 export const MODELS_BY_EXPORT_TYPE: Record<AllExportTypes, AllTypes> = {
   request: 'Request',
@@ -231,11 +240,14 @@ export async function scanResources(importEntries: ImportEntry[]): Promise<ScanR
           return { ...model, type: MODELS_BY_EXPORT_TYPE[_type] };
         });
 
-      resourceCacheList.push({
-        resources,
-        importer: type,
-        content: contentStr,
-      });
+      const isDuplicateContent = resourceCacheList.some(c => c.content === contentStr);
+      if (!isDuplicateContent) {
+        resourceCacheList.push({
+          resources,
+          importer: type,
+          content: contentStr,
+        });
+      }
 
       const requests = resources.filter(isRequest);
       const requestGroups = resources.filter(isRequestGroup);
@@ -399,6 +411,7 @@ export async function importResourcesToProject({
     importedWorkspaces.push(...newWorkspaces);
     await db.flushChanges(bufferId);
   }
+  clearResourceCache();
   return importedWorkspaces;
 }
 
@@ -553,6 +566,7 @@ export const importResourcesToWorkspace = async ({
 
     await db.flushChanges(bufferId);
   }
+  clearResourceCache();
   return [existingWorkspace];
 };
 
@@ -672,3 +686,170 @@ export const importResourcesToNewWorkspace = async ({
 
   return newWorkspace;
 };
+
+export function resolveOperationId(operationId: string): { method: string; name: string } | undefined {
+  for (const cache of resourceCacheList) {
+    let spec: ParsedApiSpec;
+    try {
+      spec = parseApiSpec(cache.content);
+    } catch {
+      continue;
+    }
+
+    const paths = spec.contents?.paths;
+    if (!paths) {
+      continue;
+    }
+
+    for (const [path, pathItem] of Object.entries(paths)) {
+      if (!pathItem || typeof pathItem !== 'object') {
+        continue;
+      }
+      for (const [method, operation] of Object.entries(pathItem as Record<string, unknown>)) {
+        if (!operation || typeof operation !== 'object') {
+          continue;
+        }
+        if (method.startsWith('x-') || method === 'parameters' || method === '$ref') {
+          continue;
+        }
+        const op = operation as Record<string, unknown>;
+        if (op.operationId === operationId) {
+          const name: string =
+            spec.format === 'swagger'
+              ? (op.summary as string | undefined) || `${method} ${path}`
+              : (op.summary as string | undefined) || path;
+          return { method, name };
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+function getPathFromRequestUrl(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    const m = url.match(/\}\}(\/.*)$/);
+    return m ? m[1] : url;
+  }
+}
+
+function getOasTitleAndVersion(content: string): { title: string; version: string } | undefined {
+  try {
+    const spec = parseApiSpec(content);
+    const info = spec.contents?.info;
+    if (!info || typeof info !== 'object') return undefined;
+    const title = info.title;
+    const version = info.version;
+    if (typeof title !== 'string' || typeof version !== 'string') return undefined;
+    return { title, version };
+  } catch {
+    return undefined;
+  }
+}
+
+export async function findExistingImportedSpec(projectId: string): Promise<
+  | {
+      workspace: Workspace;
+      apiSpec: ApiSpec;
+    }
+  | undefined
+> {
+  for (const cache of resourceCacheList) {
+    if (!isApiSpecImport(cache.importer)) continue;
+    const incoming = getOasTitleAndVersion(cache.content);
+    if (!incoming) continue;
+    const workspaces = await models.workspace.findByParentId(projectId);
+    const designWorkspaces = workspaces.filter(w => w.scope === 'design');
+    for (const ws of designWorkspaces) {
+      const expectedName = `${incoming.title} ${incoming.version}`;
+      if (ws.name !== expectedName) continue;
+      const apiSpec = await services.apiSpec.getByParentId(ws._id);
+      if (!apiSpec) continue;
+      const stored = getOasTitleAndVersion(apiSpec.contents);
+      if (!stored || stored.title !== incoming.title || stored.version !== incoming.version) continue;
+      return { workspace: ws, apiSpec };
+    }
+  }
+  return undefined;
+}
+
+export function pathPatternMatches(pattern: string, concretePath: string): boolean {
+  if (!pattern || pattern.length > 200) {
+    return false;
+  }
+  if (pattern === concretePath) {
+    return true;
+  }
+  const patternSegments = pattern.split('/').filter(Boolean);
+  const pathSegments = concretePath.split('/').filter(Boolean);
+  if (patternSegments.length > pathSegments.length) {
+    return false;
+  }
+  const offset = pathSegments.length - patternSegments.length;
+  const pathSuffix = pathSegments.slice(offset);
+  return patternSegments.every((segment, i) => {
+    if (segment.startsWith(':')) {
+      return pathSuffix[i].length > 0;
+    }
+    return segment.toLowerCase() === pathSuffix[i].toLowerCase();
+  });
+}
+
+export async function findExistingRequestByMethodAndUrl(
+  projectId: string,
+  method: string,
+  url: string,
+): Promise<{ workspace: Workspace; request: Request } | undefined> {
+  let concretePath: string;
+  try {
+    concretePath = new URL(url).pathname;
+  } catch {
+    return undefined;
+  }
+  const workspaces = await models.workspace.findByParentId(projectId);
+  const workspacesWithRequests = workspaces.filter(w => w.scope === 'collection' || w.scope === 'design');
+  for (const ws of workspacesWithRequests) {
+    const allDocs = await db.getWithDescendants(ws, [models.request.type]);
+    const requests = allDocs.filter(isRequest);
+    const match = requests.find(
+      r =>
+        r.method.toUpperCase() === method.toUpperCase() &&
+        pathPatternMatches(getPathFromRequestUrl(r.url), concretePath),
+    );
+    if (match && isRequest(match)) {
+      return { workspace: ws, request: match };
+    }
+  }
+  return undefined;
+}
+
+export async function findRequestInExistingWorkspace(
+  workspace: Workspace,
+  endpoint?: string,
+  operationId?: string,
+): Promise<Request | undefined> {
+  const allDocs = await db.getWithDescendants(workspace, [models.request.type]);
+  const requests = allDocs.filter(isRequest);
+  if (endpoint) {
+    const [method, path] = endpoint.split(',', 2);
+    const normalizedPath = pathWithParamsAsPathParameters(path);
+    return requests.find(
+      r =>
+        r.method.toUpperCase() === method.toUpperCase() &&
+        pathWithParamsAsPathParameters(getPathFromRequestUrl(r.url))
+          .toLowerCase()
+          .endsWith(normalizedPath.toLowerCase()),
+    ) as Request | undefined;
+  }
+  if (operationId) {
+    const opInfo = resolveOperationId(operationId);
+    if (!opInfo) return undefined;
+    return requests.find(
+      r =>
+        r.method.toUpperCase() === opInfo.method.toUpperCase() && r.name?.toLowerCase() === opInfo.name.toLowerCase(),
+    ) as Request | undefined;
+  }
+  return undefined;
+}

--- a/packages/insomnia/src/common/insomnia-v5.ts
+++ b/packages/insomnia/src/common/insomnia-v5.ts
@@ -766,6 +766,24 @@ export function importInsomniaV5Data(rawData: string) {
   }
 }
 
+export function mcpUrlToInsomniaV5Yaml(mcpUrl: string): string {
+  const url = new URL(mcpUrl.trim());
+  const isHttp = url.protocol === 'http:' || url.protocol === 'https:';
+  invariant(isHttp, 'MCP server URL must use http or https');
+  const mcpClient = {
+    type: 'mcpClient.insomnia/5.0' as const,
+    schema_version: INSOMNIA_SCHEMA_VERSION,
+    name: 'Imported MCP Client',
+    mcpRequest: {
+      name: 'Imported MCP Client',
+      url: mcpUrl.trim(),
+      transportType: 'streamable-http' as const,
+    },
+  };
+  const parsed = InsomniaFileSchema.parse(mcpClient);
+  return stringify(removeEmptyFields(parsed));
+}
+
 /**
  * Exports workspace data to Insomnia v5 format
  * This is the main export function that converts internal models to v5 YAML format

--- a/packages/insomnia/src/main/importers/importers/openapi-3.ts
+++ b/packages/insomnia/src/main/importers/importers/openapi-3.ts
@@ -253,7 +253,7 @@ const importFolderItem =
  *
  * I.e. "/foo/{bar}" => "/foo/:bar"
  */
-const pathWithParamsAsPathParameters = (path?: string) => path?.replace(VARIABLE_SEARCH_VALUE, ':$1') ?? '';
+export const pathWithParamsAsPathParameters = (path?: string) => path?.replace(VARIABLE_SEARCH_VALUE, ':$1') ?? '';
 
 /**
  * Return Insomnia request

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -369,9 +369,19 @@ const Root = () => {
           if (organizationId && projectId) {
             try {
               const parseResult = await window.main.parseImport({ contentStr: params.curl }, { importerId: 'curl' });
-              const importedRequest = parseResult.data?.resources?.[0];
+              let importedRequest = parseResult.data?.resources?.[0];
               invariant(parseResult.data?.resources?.length === 1, 'Cannot auto import multiple requests');
               if (importedRequest?.url) {
+                // set defaults
+                importedRequest = {
+                  url: '',
+                  body: '',
+                  parameters: [],
+                  headers: [],
+                  authentication: {},
+                  ...importedRequest,
+                  method: (importedRequest.method || 'GET').toUpperCase(),
+                };
                 // use label to create mcp client, search for existing collection with matching name, or make new collection
                 let importedWorkspace = null;
                 if (params.scope === 'mcp') {
@@ -393,6 +403,9 @@ const Root = () => {
                   }
                 }
                 invariant(importedWorkspace, 'Failed to create workspace for imported request');
+                await models.environment.getOrCreateForParentId(importedWorkspace._id);
+                await models.cookieJar.getOrCreateForParentId(importedWorkspace._id);
+
                 const newRequest = await (params.scope === 'mcp'
                   ? models.mcpRequest.create({
                       parentId: importedWorkspace._id,
@@ -418,14 +431,10 @@ const Root = () => {
                     requests: 1,
                   },
                 });
-                const workspace = importedWorkspace;
-                if (workspace) {
-                  navigate(
-                    `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/debug/request/${newRequest._id}`,
-                  );
-                  return;
-                }
-                throw new Error('Failed to find or create workspace for imported request');
+
+                return navigate(
+                  `/organization/${organizationId}/project/${projectId}/workspace/${importedWorkspace._id}/debug/request/${newRequest._id}`,
+                );
               }
             } catch (err) {
               console.error('[deep-link] Failed to auto-import curl:', err);
@@ -439,40 +448,6 @@ const Root = () => {
             scope: params.scope,
           });
         }
-      }
-      if (urlWithoutParams === 'insomnia://plugins/install') {
-        if (!params.name || params.name.trim() === '') {
-          return showError({
-            title: 'Plugin Install',
-            message: 'Plugin name is required',
-          });
-        }
-
-        return showModal(AskModal, {
-          title: 'Plugin Install',
-          message: (
-            <p className="text-(--hl)">
-              Do you want to install <i className="font-bold text-(--hl)">{params.name}</i>?
-            </p>
-          ),
-          yesText: 'Install',
-          noText: 'Cancel',
-          onDone: async (isYes: boolean) => {
-            if (isYes) {
-              try {
-                // TODO (pavkout): Remove second parameter when we will decide about the @scoped packages name validation
-                await window.main.installPlugin(params.name.trim(), true);
-                showModal(SettingsModal, { tab: 'plugins' });
-              } catch (err) {
-                showError({
-                  title: 'Plugin Install',
-                  message: 'Failed to install plugin',
-                  error: err.message,
-                });
-              }
-            }
-          },
-        });
       }
       if (urlWithoutParams === 'insomnia://plugins/theme') {
         const parsedTheme = JSON.parse(decodeURIComponent(params.theme));

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -22,8 +22,6 @@ import { EXTERNAL_VAULT_PLUGIN_NAME, isDevelopment } from '~/common/constants';
 import type { Settings, UserSession } from '~/insomnia-data';
 import { services } from '~/insomnia-data';
 import * as models from '~/models';
-import * as requestOperations from '~/models/helpers/request-operations';
-import { scopeToActivity } from '~/models/workspace';
 import { executePluginMainAction, reloadPlugins } from '~/plugins';
 import { createPlugin } from '~/plugins/create';
 import { setTheme } from '~/plugins/misc';
@@ -32,8 +30,6 @@ import { useDefaultBrowserRedirectActionFetcher } from '~/routes/auth.default-br
 import { useLogoutFetcher } from '~/routes/auth.logout';
 import { useCreateCloudCredentialActionFetcher } from '~/routes/cloud-credentials.create';
 import { useGitProviderCompleteSignInFetcher } from '~/routes/git-credentials.complete-sign-in';
-import { importScannedResources } from '~/routes/import.resources';
-import { scanImportResources } from '~/routes/import.scan';
 import { SegmentEvent } from '~/ui/analytics';
 import { getLoginUrl } from '~/ui/auth-session-provider.client';
 import { CopyButton } from '~/ui/components/base/copy-button';
@@ -48,6 +44,7 @@ import { Toaster } from '~/ui/components/toast-notification';
 import { AppHooks } from '~/ui/containers/app-hooks';
 import cssHref from '~/ui/css/styles.css?url';
 import Modals from '~/ui/modals';
+import { invariant } from '~/utils/invariant';
 
 import type { Route } from './+types/root';
 
@@ -372,42 +369,65 @@ const Root = () => {
             try {
               const parseResult = await window.main.parseImport({ contentStr: params.curl }, { importerId: 'curl' });
               const importedRequest = parseResult.data?.resources?.[0];
+              invariant(parseResult.data?.resources?.length === 1, 'Cannnot auto import multiple requests');
               if (importedRequest?.url) {
-                const scanResults = await scanImportResources({ source: 'curl', curl: params.curl });
-                const hasErrors = scanResults.some(r => r.errors?.length);
-                if (!hasErrors && scanResults.length > 0) {
-                  const importedWorkspaces = await importScannedResources({
-                    organizationId,
-                    projectId,
-                    options: { label: params.label, scope: params.scope },
+                // use label to set mcp workspace name or search for existing workspace
+                let newWorkspaceId = null;
+                let importedWorkspace = null;
+                if (params.scope === 'mcp') {
+                  importedWorkspace = await models.workspace.create({
+                    parentId: projectId,
+                    name: params.label || 'Imported MCP Client',
+                    scope: 'mcp',
                   });
-                  window.main.trackSegmentEvent({
-                    event: SegmentEvent.importCompleted,
-                    properties: {
-                      workspaces: scanResults.map(r => r.workspaces?.length || 0),
-                      requests: scanResults.map(r => r.requests?.length || 0),
-                    },
-                  });
-                  const workspace =
-                    Array.isArray(importedWorkspaces) && importedWorkspaces.length === 1
-                      ? importedWorkspaces[0]
-                      : undefined;
-                  if (workspace) {
-                    const requests = await requestOperations.findByParentId(workspace._id);
-                    if (Array.isArray(requests) && requests.length === 1) {
-                      navigate(
-                        `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/debug/request/${requests[0]._id}`,
-                      );
-                      return;
-                    }
-                    navigate(
-                      `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/${scopeToActivity(workspace.scope)}`,
-                    );
-                    return;
+                  newWorkspaceId = importedWorkspace._id;
+                } else {
+                  const workspaces = await models.workspace.findByParentId(projectId);
+                  importedWorkspace = workspaces.find(workspace => workspace.name === params.label);
+                  if (importedWorkspace?._id) {
+                    newWorkspaceId = importedWorkspace._id;
+                  } else {
+                    importedWorkspace = await models.workspace.create({
+                      parentId: projectId,
+                      name: params.label || 'Imported Collection',
+                    });
+                    newWorkspaceId = importedWorkspace._id;
                   }
-                  navigate(`/organization/${organizationId}/project/${projectId}`);
+                }
+                invariant(newWorkspaceId, 'Failed to create workspace for imported request');
+                let newRequestId = null;
+                if (params.scope === 'mcp') {
+                  const mcpRequest = await models.mcpRequest.create({
+                    parentId: newWorkspaceId,
+                    name: params.label || 'Imported MCP Request',
+                    url: importedRequest.url,
+                    headers: importedRequest.headers,
+                    authentication: importedRequest.authentication,
+                  });
+                  newRequestId = mcpRequest._id;
+                } else {
+                  const request = await models.request.create({
+                    parentId: newWorkspaceId,
+                    name: importedRequest.name || 'Imported Request',
+                    ...importedRequest,
+                  });
+                  newRequestId = request._id;
+                }
+
+                window.main.trackSegmentEvent({
+                  event: SegmentEvent.importCompleted,
+                  properties: {
+                    requests: 1,
+                  },
+                });
+                const workspace = importedWorkspace;
+                if (workspace) {
+                  navigate(
+                    `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/debug/request/${newRequestId}`,
+                  );
                   return;
                 }
+                throw new Error('Failed to find or create workspace for imported request');
               }
             } catch (err) {
               console.error('[deep-link] Failed to auto-import curl:', err);
@@ -421,40 +441,6 @@ const Root = () => {
             scope: params.scope,
           });
         }
-      }
-      if (urlWithoutParams === 'insomnia://plugins/install') {
-        if (!params.name || params.name.trim() === '') {
-          return showError({
-            title: 'Plugin Install',
-            message: 'Plugin name is required',
-          });
-        }
-
-        return showModal(AskModal, {
-          title: 'Plugin Install',
-          message: (
-            <p className="text-(--hl)">
-              Do you want to install <i className="font-bold text-(--hl)">{params.name}</i>?
-            </p>
-          ),
-          yesText: 'Install',
-          noText: 'Cancel',
-          onDone: async (isYes: boolean) => {
-            if (isYes) {
-              try {
-                // TODO (pavkout): Remove second parameter when we will decide about the @scoped packages name validation
-                await window.main.installPlugin(params.name.trim(), true);
-                showModal(SettingsModal, { tab: 'plugins' });
-              } catch (err) {
-                showError({
-                  title: 'Plugin Install',
-                  message: 'Failed to install plugin',
-                  error: err.message,
-                });
-              }
-            }
-          },
-        });
       }
       if (urlWithoutParams === 'insomnia://plugins/theme') {
         const parsedTheme = JSON.parse(decodeURIComponent(params.theme));

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -371,8 +371,7 @@ const Root = () => {
               const importedRequest = parseResult.data?.resources?.[0];
               invariant(parseResult.data?.resources?.length === 1, 'Cannnot auto import multiple requests');
               if (importedRequest?.url) {
-                // use label to set mcp workspace name or search for existing workspace
-                let newWorkspaceId = null;
+                // use label to create mcp client, search for existing collection with matching name, or make new collection
                 let importedWorkspace = null;
                 if (params.scope === 'mcp') {
                   importedWorkspace = await models.workspace.create({
@@ -380,39 +379,32 @@ const Root = () => {
                     name: params.label || 'Imported MCP Client',
                     scope: 'mcp',
                   });
-                  newWorkspaceId = importedWorkspace._id;
                 } else {
                   const workspaces = await models.workspace.findByParentId(projectId);
-                  importedWorkspace = workspaces.find(workspace => workspace.name === params.label);
-                  if (importedWorkspace?._id) {
-                    newWorkspaceId = importedWorkspace._id;
-                  } else {
+                  importedWorkspace = workspaces.find(
+                    workspace => workspace.name === params.label && workspace.scope === 'collection',
+                  );
+                  if (!importedWorkspace) {
                     importedWorkspace = await models.workspace.create({
                       parentId: projectId,
                       name: params.label || 'Imported Collection',
                     });
-                    newWorkspaceId = importedWorkspace._id;
                   }
                 }
-                invariant(newWorkspaceId, 'Failed to create workspace for imported request');
-                let newRequestId = null;
-                if (params.scope === 'mcp') {
-                  const mcpRequest = await models.mcpRequest.create({
-                    parentId: newWorkspaceId,
-                    name: params.label || 'Imported MCP Request',
-                    url: importedRequest.url,
-                    headers: importedRequest.headers,
-                    authentication: importedRequest.authentication,
-                  });
-                  newRequestId = mcpRequest._id;
-                } else {
-                  const request = await models.request.create({
-                    parentId: newWorkspaceId,
-                    name: importedRequest.name || 'Imported Request',
-                    ...importedRequest,
-                  });
-                  newRequestId = request._id;
-                }
+                invariant(importedWorkspace, 'Failed to create workspace for imported request');
+                const newRequest = await (params.scope === 'mcp'
+                  ? models.mcpRequest.create({
+                      parentId: importedWorkspace._id,
+                      name: params.label || 'Imported MCP Request',
+                      url: importedRequest.url,
+                      headers: importedRequest.headers,
+                      authentication: importedRequest.authentication,
+                    })
+                  : models.request.create({
+                      parentId: importedWorkspace._id,
+                      name: importedRequest.name || 'Imported Request',
+                      ...importedRequest,
+                    }));
 
                 window.main.trackSegmentEvent({
                   event: SegmentEvent.importCompleted,
@@ -423,7 +415,7 @@ const Root = () => {
                 const workspace = importedWorkspace;
                 if (workspace) {
                   navigate(
-                    `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/debug/request/${newRequestId}`,
+                    `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/debug/request/${newRequest._id}`,
                   );
                   return;
                 }

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -440,6 +440,40 @@ const Root = () => {
           });
         }
       }
+      if (urlWithoutParams === 'insomnia://plugins/install') {
+        if (!params.name || params.name.trim() === '') {
+          return showError({
+            title: 'Plugin Install',
+            message: 'Plugin name is required',
+          });
+        }
+
+        return showModal(AskModal, {
+          title: 'Plugin Install',
+          message: (
+            <p className="text-(--hl)">
+              Do you want to install <i className="font-bold text-(--hl)">{params.name}</i>?
+            </p>
+          ),
+          yesText: 'Install',
+          noText: 'Cancel',
+          onDone: async (isYes: boolean) => {
+            if (isYes) {
+              try {
+                // TODO (pavkout): Remove second parameter when we will decide about the @scoped packages name validation
+                await window.main.installPlugin(params.name.trim(), true);
+                showModal(SettingsModal, { tab: 'plugins' });
+              } catch (err) {
+                showError({
+                  title: 'Plugin Install',
+                  message: 'Failed to install plugin',
+                  error: err.message,
+                });
+              }
+            }
+          },
+        });
+      }
       if (urlWithoutParams === 'insomnia://plugins/theme') {
         const parsedTheme = JSON.parse(decodeURIComponent(params.theme));
         showModal(AskModal, {

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -22,6 +22,8 @@ import { EXTERNAL_VAULT_PLUGIN_NAME, isDevelopment } from '~/common/constants';
 import type { Settings, UserSession } from '~/insomnia-data';
 import { services } from '~/insomnia-data';
 import * as models from '~/models';
+import * as requestOperations from '~/models/helpers/request-operations';
+import { scopeToActivity } from '~/models/workspace';
 import { executePluginMainAction, reloadPlugins } from '~/plugins';
 import { createPlugin } from '~/plugins/create';
 import { setTheme } from '~/plugins/misc';
@@ -30,7 +32,8 @@ import { useDefaultBrowserRedirectActionFetcher } from '~/routes/auth.default-br
 import { useLogoutFetcher } from '~/routes/auth.logout';
 import { useCreateCloudCredentialActionFetcher } from '~/routes/cloud-credentials.create';
 import { useGitProviderCompleteSignInFetcher } from '~/routes/git-credentials.complete-sign-in';
-import type { SourceType } from '~/routes/import.scan';
+import { importScannedResources } from '~/routes/import.resources';
+import { scanImportResources, type SourceType } from '~/routes/import.scan';
 import { SegmentEvent } from '~/ui/analytics';
 import { getLoginUrl } from '~/ui/auth-session-provider.client';
 import { CopyButton } from '~/ui/components/base/copy-button';
@@ -368,6 +371,48 @@ const Root = () => {
           });
         }
         if (params.curl) {
+          // Validate and auto-import if curl is valid, skipping the import UI
+          if (organizationId && projectId) {
+            try {
+              const parseResult = await window.main.parseImport({ contentStr: params.curl }, { importerId: 'curl' });
+              const importedRequest = parseResult.data?.resources?.[0];
+              if (importedRequest?.url) {
+                const scanResults = await scanImportResources({ source: 'curl', curl: params.curl });
+                const hasErrors = scanResults.some(r => r.errors?.length);
+                if (!hasErrors && scanResults.length > 0) {
+                  const importedWorkspaces = await importScannedResources({ organizationId, projectId });
+                  window.main.trackSegmentEvent({
+                    event: SegmentEvent.importCompleted,
+                    properties: {
+                      workspaces: scanResults.map(r => r.workspaces?.length || 0),
+                      requests: scanResults.map(r => r.requests?.length || 0),
+                    },
+                  });
+                  const workspace =
+                    Array.isArray(importedWorkspaces) && importedWorkspaces.length === 1
+                      ? importedWorkspaces[0]
+                      : undefined;
+                  if (workspace) {
+                    const requests = await requestOperations.findByParentId(workspace._id);
+                    if (Array.isArray(requests) && requests.length === 1) {
+                      navigate(
+                        `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/debug/request/${requests[0]._id}`,
+                      );
+                      return;
+                    }
+                    navigate(
+                      `/organization/${organizationId}/project/${projectId}/workspace/${workspace._id}/${scopeToActivity(workspace.scope)}`,
+                    );
+                    return;
+                  }
+                  navigate(`/organization/${organizationId}/project/${projectId}`);
+                  return;
+                }
+              }
+            } catch (err) {
+              console.error('[deep-link] Failed to auto-import curl:', err);
+            }
+          }
           return setImportObject({
             type: 'curl',
             defaultValue: params.curl,
@@ -571,6 +616,8 @@ const Root = () => {
     gitProviderCompleteSignInSubmit,
     logoutSubmit,
     navigate,
+    organizationId,
+    projectId,
     redirectToDefaultBrowserSubmit,
   ]);
 

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -449,6 +449,40 @@ const Root = () => {
           });
         }
       }
+      if (urlWithoutParams === 'insomnia://plugins/install') {
+        if (!params.name || params.name.trim() === '') {
+          return showError({
+            title: 'Plugin Install',
+            message: 'Plugin name is required',
+          });
+        }
+
+        return showModal(AskModal, {
+          title: 'Plugin Install',
+          message: (
+            <p className="text-(--hl)">
+              Do you want to install <i className="font-bold text-(--hl)">{params.name}</i>?
+            </p>
+          ),
+          yesText: 'Install',
+          noText: 'Cancel',
+          onDone: async (isYes: boolean) => {
+            if (isYes) {
+              try {
+                // TODO (pavkout): Remove second parameter when we will decide about the @scoped packages name validation
+                await window.main.installPlugin(params.name.trim(), true);
+                showModal(SettingsModal, { tab: 'plugins' });
+              } catch (err) {
+                showError({
+                  title: 'Plugin Install',
+                  message: 'Failed to install plugin',
+                  error: err.message,
+                });
+              }
+            }
+          },
+        });
+      }
       if (urlWithoutParams === 'insomnia://plugins/theme') {
         const parsedTheme = JSON.parse(decodeURIComponent(params.theme));
         showModal(AskModal, {

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -317,6 +317,8 @@ const Root = () => {
     type: SourceType;
     defaultValue: string;
     origin?: string;
+    label?: string;
+    scope?: string;
   });
   const { submit: createCloudCredentials } = useCreateCloudCredentialActionFetcher();
   const { submit: authorizeSubmit } = useAuthorizeActionFetcher();
@@ -421,6 +423,8 @@ const Root = () => {
             type: 'curl',
             defaultValue: params.curl,
             origin: sanitizeUrlAndExtractOrigin(params.origin),
+            label: params.label,
+            scope: params.scope,
           });
         }
       }

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -374,7 +374,7 @@ const Root = () => {
         }
         if (params.curl) {
           // Validate and auto-import if curl is valid, skipping the import UI
-          if (organizationId && projectId && params.skipImport) {
+          if (organizationId && projectId) {
             try {
               const parseResult = await window.main.parseImport({ contentStr: params.curl }, { importerId: 'curl' });
               const importedRequest = parseResult.data?.resources?.[0];

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -22,7 +22,6 @@ import { EXTERNAL_VAULT_PLUGIN_NAME, isDevelopment } from '~/common/constants';
 import type { Settings, UserSession } from '~/insomnia-data';
 import { services } from '~/insomnia-data';
 import * as models from '~/models';
-import type { RequestBody, RequestParameter } from '~/models/request';
 import { executePluginMainAction, reloadPlugins } from '~/plugins';
 import { createPlugin } from '~/plugins/create';
 import { setTheme } from '~/plugins/misc';
@@ -39,13 +38,12 @@ import { Icon } from '~/ui/components/icon';
 import { showError, showModal } from '~/ui/components/modals';
 import { AlertModal } from '~/ui/components/modals/alert-modal';
 import { AskModal } from '~/ui/components/modals/ask-modal';
-import { ImportModal, type ImportSourceType } from '~/ui/components/modals/import-modal/import-modal';
+import { ImportModal, type ImportSource, validateCurl } from '~/ui/components/modals/import-modal/import-modal';
 import { SettingsModal } from '~/ui/components/modals/settings-modal';
 import { Toaster } from '~/ui/components/toast-notification';
 import { AppHooks } from '~/ui/containers/app-hooks';
 import cssHref from '~/ui/css/styles.css?url';
 import Modals from '~/ui/modals';
-import { invariant } from '~/utils/invariant';
 
 import type { Route } from './+types/root';
 
@@ -311,7 +309,7 @@ const Root = () => {
     projectId: string;
   };
 
-  const [importObject, setImportObject] = useState({ type: 'clipboard', defaultValue: '' } as ImportSourceType);
+  const [importObject, setImportObject] = useState<ImportSource>({ type: 'clipboard', defaultValue: '' });
   const { submit: createCloudCredentials } = useCreateCloudCredentialActionFetcher();
   const { submit: authorizeSubmit } = useAuthorizeActionFetcher();
   const { submit: logoutSubmit } = useLogoutFetcher();
@@ -362,126 +360,31 @@ const Root = () => {
             type: 'uri',
             defaultValue: params.uri,
             origin: sanitizeUrlAndExtractOrigin(params.origin),
+            endpoint: params.endpoint,
+            operationId: params.operationId,
+            autoScan: true,
+          });
+        }
+        if (params.mcp) {
+          return setImportObject({
+            type: 'mcp',
+            defaultValue: params.mcp,
+            origin: sanitizeUrlAndExtractOrigin(params.origin),
+            autoScan: true,
           });
         }
         if (params.curl) {
-          // Validate and auto-import if curl is valid, skipping the import UI
-          if (organizationId && projectId) {
-            try {
-              const parseResult = await window.main.parseImport({ contentStr: params.curl }, { importerId: 'curl' });
-              let importedRequest = parseResult.data?.resources?.[0];
-              invariant(parseResult.data?.resources?.length === 1, 'Cannot auto import multiple requests');
-              if (importedRequest?.url) {
-                // set defaults
-                importedRequest = {
-                  url: '',
-                  body: '',
-                  parameters: [],
-                  headers: [],
-                  authentication: {},
-                  ...importedRequest,
-                  method: (importedRequest.method || 'GET').toUpperCase(),
-                };
-                // use label to create mcp client, search for existing collection with matching name, or make new collection
-                let importedWorkspace = null;
-                if (params.scope === 'mcp') {
-                  importedWorkspace = await models.workspace.create({
-                    parentId: projectId,
-                    name: params.label || 'Imported MCP Client',
-                    scope: 'mcp',
-                  });
-                } else {
-                  const workspaces = await models.workspace.findByParentId(projectId);
-                  importedWorkspace = workspaces.find(
-                    workspace => workspace.name === params.label && workspace.scope === 'collection',
-                  );
-                  if (!importedWorkspace) {
-                    importedWorkspace = await models.workspace.create({
-                      parentId: projectId,
-                      name: params.label || 'Imported Collection',
-                    });
-                  }
-                }
-                invariant(importedWorkspace, 'Failed to create workspace for imported request');
-                await models.environment.getOrCreateForParentId(importedWorkspace._id);
-                await models.cookieJar.getOrCreateForParentId(importedWorkspace._id);
-
-                const newRequest = await (params.scope === 'mcp'
-                  ? models.mcpRequest.create({
-                      parentId: importedWorkspace._id,
-                      name: params.label || 'Imported MCP Request',
-                      url: importedRequest.url,
-                      headers: importedRequest.headers,
-                      authentication: importedRequest.authentication,
-                    })
-                  : models.request.create({
-                      parentId: importedWorkspace._id,
-                      name: params.label || 'Imported Request',
-                      url: importedRequest.url,
-                      method: importedRequest.method,
-                      headers: importedRequest.headers,
-                      authentication: importedRequest.authentication,
-                      parameters: importedRequest.parameters as RequestParameter[],
-                      body: importedRequest.body as RequestBody,
-                    }));
-
-                window.main.trackSegmentEvent({
-                  event: SegmentEvent.importCompleted,
-                  properties: {
-                    requests: 1,
-                  },
-                });
-
-                return navigate(
-                  `/organization/${organizationId}/project/${projectId}/workspace/${importedWorkspace._id}/debug/request/${newRequest._id}`,
-                );
-              }
-            } catch (err) {
-              console.error('[deep-link] Failed to auto-import curl:', err);
-            }
-          }
+          const validation = await validateCurl(params.curl);
+          const isValid = validation !== 'Invalid cURL request'; // brittle
           return setImportObject({
             type: 'curl',
             defaultValue: params.curl,
             origin: sanitizeUrlAndExtractOrigin(params.origin),
-            label: params.label,
-            scope: params.scope,
+            endpoint: params.endpoint,
+            operationId: params.operationId,
+            autoScan: isValid,
           });
         }
-      }
-      if (urlWithoutParams === 'insomnia://plugins/install') {
-        if (!params.name || params.name.trim() === '') {
-          return showError({
-            title: 'Plugin Install',
-            message: 'Plugin name is required',
-          });
-        }
-
-        return showModal(AskModal, {
-          title: 'Plugin Install',
-          message: (
-            <p className="text-(--hl)">
-              Do you want to install <i className="font-bold text-(--hl)">{params.name}</i>?
-            </p>
-          ),
-          yesText: 'Install',
-          noText: 'Cancel',
-          onDone: async (isYes: boolean) => {
-            if (isYes) {
-              try {
-                // TODO (pavkout): Remove second parameter when we will decide about the @scoped packages name validation
-                await window.main.installPlugin(params.name.trim(), true);
-                showModal(SettingsModal, { tab: 'plugins' });
-              } catch (err) {
-                showError({
-                  title: 'Plugin Install',
-                  message: 'Failed to install plugin',
-                  error: err.message,
-                });
-              }
-            }
-          },
-        });
       }
       if (urlWithoutParams === 'insomnia://plugins/theme') {
         const parsedTheme = JSON.parse(decodeURIComponent(params.theme));
@@ -662,7 +565,6 @@ const Root = () => {
       {importObject.defaultValue && (
         <ImportModal
           onHide={() => setImportObject({ type: 'clipboard', defaultValue: '' })}
-          projectName="Insomnia"
           defaultProjectId={projectId}
           organizationId={organizationId}
           from={importObject}

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -372,7 +372,7 @@ const Root = () => {
         }
         if (params.curl) {
           // Validate and auto-import if curl is valid, skipping the import UI
-          if (organizationId && projectId) {
+          if (organizationId && projectId && params.skipImport) {
             try {
               const parseResult = await window.main.parseImport({ contentStr: params.curl }, { importerId: 'curl' });
               const importedRequest = parseResult.data?.resources?.[0];
@@ -380,7 +380,11 @@ const Root = () => {
                 const scanResults = await scanImportResources({ source: 'curl', curl: params.curl });
                 const hasErrors = scanResults.some(r => r.errors?.length);
                 if (!hasErrors && scanResults.length > 0) {
-                  const importedWorkspaces = await importScannedResources({ organizationId, projectId });
+                  const importedWorkspaces = await importScannedResources({
+                    organizationId,
+                    projectId,
+                    options: { label: params.label, scope: params.scope },
+                  });
                   window.main.trackSegmentEvent({
                     event: SegmentEvent.importCompleted,
                     properties: {

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -370,7 +370,7 @@ const Root = () => {
             try {
               const parseResult = await window.main.parseImport({ contentStr: params.curl }, { importerId: 'curl' });
               const importedRequest = parseResult.data?.resources?.[0];
-              invariant(parseResult.data?.resources?.length === 1, 'Cannnot auto import multiple requests');
+              invariant(parseResult.data?.resources?.length === 1, 'Cannot auto import multiple requests');
               if (importedRequest?.url) {
                 // use label to create mcp client, search for existing collection with matching name, or make new collection
                 let importedWorkspace = null;

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -33,7 +33,7 @@ import { useLogoutFetcher } from '~/routes/auth.logout';
 import { useCreateCloudCredentialActionFetcher } from '~/routes/cloud-credentials.create';
 import { useGitProviderCompleteSignInFetcher } from '~/routes/git-credentials.complete-sign-in';
 import { importScannedResources } from '~/routes/import.resources';
-import { scanImportResources, type SourceType } from '~/routes/import.scan';
+import { scanImportResources } from '~/routes/import.scan';
 import { SegmentEvent } from '~/ui/analytics';
 import { getLoginUrl } from '~/ui/auth-session-provider.client';
 import { CopyButton } from '~/ui/components/base/copy-button';
@@ -42,7 +42,7 @@ import { Icon } from '~/ui/components/icon';
 import { showError, showModal } from '~/ui/components/modals';
 import { AlertModal } from '~/ui/components/modals/alert-modal';
 import { AskModal } from '~/ui/components/modals/ask-modal';
-import { ImportModal } from '~/ui/components/modals/import-modal/import-modal';
+import { ImportModal, type ImportSourceType } from '~/ui/components/modals/import-modal/import-modal';
 import { SettingsModal } from '~/ui/components/modals/settings-modal';
 import { Toaster } from '~/ui/components/toast-notification';
 import { AppHooks } from '~/ui/containers/app-hooks';
@@ -313,13 +313,7 @@ const Root = () => {
     projectId: string;
   };
 
-  const [importObject, setImportObject] = useState({ type: 'clipboard', defaultValue: '' } as {
-    type: SourceType;
-    defaultValue: string;
-    origin?: string;
-    label?: string;
-    scope?: string;
-  });
+  const [importObject, setImportObject] = useState({ type: 'clipboard', defaultValue: '' } as ImportSourceType);
   const { submit: createCloudCredentials } = useCreateCloudCredentialActionFetcher();
   const { submit: authorizeSubmit } = useAuthorizeActionFetcher();
   const { submit: logoutSubmit } = useLogoutFetcher();

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -22,6 +22,7 @@ import { EXTERNAL_VAULT_PLUGIN_NAME, isDevelopment } from '~/common/constants';
 import type { Settings, UserSession } from '~/insomnia-data';
 import { services } from '~/insomnia-data';
 import * as models from '~/models';
+import type { RequestBody, RequestParameter } from '~/models/request';
 import { executePluginMainAction, reloadPlugins } from '~/plugins';
 import { createPlugin } from '~/plugins/create';
 import { setTheme } from '~/plugins/misc';
@@ -402,8 +403,13 @@ const Root = () => {
                     })
                   : models.request.create({
                       parentId: importedWorkspace._id,
-                      name: importedRequest.name || 'Imported Request',
-                      ...importedRequest,
+                      name: params.label || 'Imported Request',
+                      url: importedRequest.url,
+                      method: importedRequest.method,
+                      headers: importedRequest.headers,
+                      authentication: importedRequest.authentication,
+                      parameters: importedRequest.parameters as RequestParameter[],
+                      body: importedRequest.body as RequestBody,
                     }));
 
                 window.main.trackSegmentEvent({

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -374,8 +374,7 @@ const Root = () => {
           });
         }
         if (params.curl) {
-          const validation = await validateCurl(params.curl);
-          const isValid = validation !== 'Invalid cURL request'; // brittle
+          const { isValid } = await validateCurl(params.curl);
           return setImportObject({
             type: 'curl',
             defaultValue: params.curl,
@@ -385,6 +384,40 @@ const Root = () => {
             autoScan: isValid,
           });
         }
+      }
+      if (urlWithoutParams === 'insomnia://plugins/install') {
+        if (!params.name || params.name.trim() === '') {
+          return showError({
+            title: 'Plugin Install',
+            message: 'Plugin name is required',
+          });
+        }
+
+        return showModal(AskModal, {
+          title: 'Plugin Install',
+          message: (
+            <p className="text-(--hl)">
+              Do you want to install <i className="font-bold text-(--hl)">{params.name}</i>?
+            </p>
+          ),
+          yesText: 'Install',
+          noText: 'Cancel',
+          onDone: async (isYes: boolean) => {
+            if (isYes) {
+              try {
+                // TODO (pavkout): Remove second parameter when we will decide about the @scoped packages name validation
+                await window.main.installPlugin(params.name.trim(), true);
+                showModal(SettingsModal, { tab: 'plugins' });
+              } catch (err) {
+                showError({
+                  title: 'Plugin Install',
+                  message: 'Failed to install plugin',
+                  error: err.message,
+                });
+              }
+            }
+          },
+        });
       }
       if (urlWithoutParams === 'insomnia://plugins/theme') {
         const parsedTheme = JSON.parse(decodeURIComponent(params.theme));

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -1,10 +1,19 @@
 import { href } from 'react-router';
 
-import { importResourcesToProject, importResourcesToWorkspace } from '~/common/import';
+import { database as db } from '~/common/database';
+import {
+  clearResourceCache,
+  findExistingImportedSpec,
+  findRequestInExistingWorkspace,
+  importResourcesToProject,
+  importResourcesToWorkspace,
+  resolveOperationId,
+} from '~/common/import';
 import { services } from '~/insomnia-data';
 import * as models from '~/models';
 import * as requestOperations from '~/models/helpers/request-operations';
 import { isRemoteProject } from '~/models/project';
+import { isRequest, type as requestType } from '~/models/request';
 import type { Workspace } from '~/models/workspace';
 import {
   initializeLocalBackendProjectAndMarkForSync,
@@ -21,6 +30,9 @@ interface ImportScannedResourcesParams {
   organizationId: string;
   projectId: string;
   workspaceId?: string;
+  endpoint?: string;
+  operationId?: string;
+  skipImportIfDuplicate?: boolean;
   options?: {
     overrideBaseEnvironmentData?: boolean;
   };
@@ -61,14 +73,72 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
     invariant(typeof organizationId === 'string', 'OrganizationId is required.');
     invariant(typeof projectId === 'string', 'ProjectId is required.');
 
-    const result = await importScannedResources({
+    const opInfo = data.operationId ? resolveOperationId(data.operationId) : undefined;
+
+    if (!workspaceId && data.skipImportIfDuplicate) {
+      const existing = await findExistingImportedSpec(projectId);
+      if (existing) {
+        const matchedRequest = await findRequestInExistingWorkspace(
+          existing.workspace,
+          data.endpoint,
+          data.operationId,
+        );
+        clearResourceCache();
+        return {
+          done: true,
+          singleImportedWorkspace: existing.workspace,
+          singleImportedRequest: matchedRequest,
+        };
+      }
+    }
+
+    const importedWorkspaces = await importScannedResources({
       organizationId,
       projectId,
       workspaceId,
       options,
     });
+
+    // endpoint here is formatted as {method},{path}
+    // example: GET,https://rest.rodeo/api
+    if (data.endpoint && Array.isArray(importedWorkspaces) && importedWorkspaces.length > 0) {
+      const [method, path] = data.endpoint.split(',', 2);
+      for (const ws of importedWorkspaces) {
+        invariant(ws, 'Workspace not found');
+        if (ws.scope !== 'design') continue;
+        const allDocs = await db.getWithDescendants(ws, [requestType]);
+        const match = allDocs.find(d => {
+          if (!isRequest(d) || d.method.toUpperCase() !== method.toUpperCase()) {
+            return false;
+          }
+          return d.url.toLowerCase().endsWith(path.toLowerCase());
+        });
+        if (match && isRequest(match)) {
+          return { done: true, singleImportedWorkspace: ws, singleImportedRequest: match };
+        }
+      }
+    }
+
+    // operationId is an OAS operationId like "get-users"
+    if (data.operationId && opInfo && Array.isArray(importedWorkspaces) && importedWorkspaces.length > 0) {
+      for (const ws of importedWorkspaces) {
+        invariant(ws, 'Workspace not found');
+        const allDocs = await db.getWithDescendants(ws, [requestType]);
+        const match = allDocs.find(d => {
+          if (!isRequest(d) || d.method.toUpperCase() !== opInfo.method.toUpperCase()) {
+            return false;
+          }
+          return d.name?.toLowerCase() === opInfo.name.toLowerCase();
+        });
+        if (match && isRequest(match)) {
+          return { done: true, singleImportedWorkspace: ws, singleImportedRequest: match };
+        }
+      }
+    }
+
     // When navigating, we are interested in knowing if there was only one workspace and only one request
-    const singleImportedWorkspace = Array.isArray(result) && result.length === 1 && result[0];
+    const singleImportedWorkspace =
+      Array.isArray(importedWorkspaces) && importedWorkspaces.length === 1 && importedWorkspaces[0];
     const requests = singleImportedWorkspace && (await requestOperations.findByParentId(singleImportedWorkspace._id));
     const singleImportedRequest = Array.isArray(requests) && requests.length === 1 && requests.at(0);
     return { done: true, singleImportedWorkspace, singleImportedRequest };

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -23,8 +23,6 @@ interface ImportScannedResourcesParams {
   workspaceId?: string;
   options?: {
     overrideBaseEnvironmentData?: boolean;
-    label?: string;
-    scope?: string;
   };
 }
 
@@ -39,29 +37,6 @@ export const importScannedResources = async ({
 
   const project = await models.project.getById(projectId);
   invariant(project, 'Project not found.');
-  // use label to set mcp workspace name or search for existing workspace
-  if (!workspaceId && options?.label) {
-    if (options.scope === 'mcp') {
-      const newWorkspace = await models.workspace.create({
-        parentId: projectId,
-        name: options.label || 'Imported MCP Client',
-        scope: 'mcp',
-      });
-      workspaceId = newWorkspace._id;
-    } else {
-      const workspaces = await models.workspace.findByParentId(projectId);
-      const matchedWorkspace = workspaces.find(workspace => workspace.name === options.label);
-      if (matchedWorkspace) {
-        workspaceId = matchedWorkspace._id;
-      } else {
-        const newWorkspace = await models.workspace.create({
-          parentId: projectId,
-          name: options.label || 'Imported Collection',
-        });
-        workspaceId = newWorkspace._id;
-      }
-    }
-  }
 
   return await (typeof workspaceId === 'string' && workspaceId
     ? importResourcesToWorkspace({

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -1,19 +1,16 @@
 import { href } from 'react-router';
 
-import { database as db } from '~/common/database';
 import {
   clearResourceCache,
   findExistingImportedSpec,
   findRequestInExistingWorkspace,
   importResourcesToProject,
   importResourcesToWorkspace,
-  resolveOperationId,
 } from '~/common/import';
 import { services } from '~/insomnia-data';
 import * as models from '~/models';
 import * as requestOperations from '~/models/helpers/request-operations';
 import { isRemoteProject } from '~/models/project';
-import { isRequest, type as requestType } from '~/models/request';
 import type { Workspace } from '~/models/workspace';
 import {
   initializeLocalBackendProjectAndMarkForSync,
@@ -73,8 +70,6 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
     invariant(typeof organizationId === 'string', 'OrganizationId is required.');
     invariant(typeof projectId === 'string', 'ProjectId is required.');
 
-    const opInfo = data.operationId ? resolveOperationId(data.operationId) : undefined;
-
     if (!workspaceId && data.skipImportIfDuplicate) {
       const existing = await findExistingImportedSpec(projectId);
       if (existing) {
@@ -83,7 +78,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
           data.endpoint,
           data.operationId,
         );
-        clearResourceCache();
+        clearResourceCache(); // skipping import to navigate to existing, avoid stale resource cache
         return {
           done: true,
           singleImportedWorkspace: existing.workspace,
@@ -99,41 +94,12 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
       options,
     });
 
-    // endpoint here is formatted as {method},{path}
-    // example: GET,https://rest.rodeo/api
-    if (data.endpoint && Array.isArray(importedWorkspaces) && importedWorkspaces.length > 0) {
-      const [method, path] = data.endpoint.split(',', 2);
-      if (method && path) {
-        for (const ws of importedWorkspaces) {
-          invariant(ws, 'Workspace not found');
-          if (ws.scope !== 'design') continue;
-          const allDocs = await db.getWithDescendants(ws, [requestType]);
-          const match = allDocs.find(d => {
-            if (!isRequest(d) || d.method.toUpperCase() !== method.toUpperCase()) {
-              return false;
-            }
-            return d.url.toLowerCase().endsWith(path.toLowerCase());
-          });
-          if (match && isRequest(match)) {
-            return { done: true, singleImportedWorkspace: ws, singleImportedRequest: match };
-          }
-        }
-      }
-    }
-
-    // operationId is an OAS operationId like "get-users"
-    if (data.operationId && opInfo && Array.isArray(importedWorkspaces) && importedWorkspaces.length > 0) {
+    if (data.endpoint || data.operationId) {
       for (const ws of importedWorkspaces) {
-        invariant(ws, 'Workspace not found');
-        const allDocs = await db.getWithDescendants(ws, [requestType]);
-        const match = allDocs.find(d => {
-          if (!isRequest(d) || d.method.toUpperCase() !== opInfo.method.toUpperCase()) {
-            return false;
-          }
-          return d.name?.toLowerCase() === opInfo.name.toLowerCase();
-        });
-        if (match && isRequest(match)) {
-          return { done: true, singleImportedWorkspace: ws, singleImportedRequest: match };
+        if (!ws) continue;
+        const foundDeepLinkedRequest = await findRequestInExistingWorkspace(ws, data.endpoint, data.operationId);
+        if (foundDeepLinkedRequest) {
+          return { done: true, singleImportedWorkspace: ws, singleImportedRequest: foundDeepLinkedRequest };
         }
       }
     }

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -23,6 +23,8 @@ interface ImportScannedResourcesParams {
   workspaceId?: string;
   options?: {
     overrideBaseEnvironmentData?: boolean;
+    label?: string;
+    scope?: string;
   };
 }
 
@@ -37,6 +39,23 @@ export const importScannedResources = async ({
 
   const project = await models.project.getById(projectId);
   invariant(project, 'Project not found.');
+  // use label to set mcp workspace name or search for existing workspace
+  if (!workspaceId && options?.label) {
+    if (options.scope === 'mcp') {
+      const newWorkspace = await models.workspace.create({
+        parentId: projectId,
+        name: options.label,
+        scope: 'mcp',
+      });
+      workspaceId = newWorkspace._id;
+    } else {
+      const workspaces = await models.workspace.findByParentId(projectId);
+      const matchedWorkspace = workspaces.find(workspace => workspace.name === options.label);
+      if (matchedWorkspace) {
+        workspaceId = matchedWorkspace._id;
+      }
+    }
+  }
 
   return await (typeof workspaceId === 'string' && workspaceId
     ? importResourcesToWorkspace({

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -103,21 +103,20 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
     // example: GET,https://rest.rodeo/api
     if (data.endpoint && Array.isArray(importedWorkspaces) && importedWorkspaces.length > 0) {
       const [method, path] = data.endpoint.split(',', 2);
-      if (!method || !path) {
-        return { done: false };
-      }
-      for (const ws of importedWorkspaces) {
-        invariant(ws, 'Workspace not found');
-        if (ws.scope !== 'design') continue;
-        const allDocs = await db.getWithDescendants(ws, [requestType]);
-        const match = allDocs.find(d => {
-          if (!isRequest(d) || d.method.toUpperCase() !== method.toUpperCase()) {
-            return false;
+      if (method && path) {
+        for (const ws of importedWorkspaces) {
+          invariant(ws, 'Workspace not found');
+          if (ws.scope !== 'design') continue;
+          const allDocs = await db.getWithDescendants(ws, [requestType]);
+          const match = allDocs.find(d => {
+            if (!isRequest(d) || d.method.toUpperCase() !== method.toUpperCase()) {
+              return false;
+            }
+            return d.url.toLowerCase().endsWith(path.toLowerCase());
+          });
+          if (match && isRequest(match)) {
+            return { done: true, singleImportedWorkspace: ws, singleImportedRequest: match };
           }
-          return d.url.toLowerCase().endsWith(path.toLowerCase());
-        });
-        if (match && isRequest(match)) {
-          return { done: true, singleImportedWorkspace: ws, singleImportedRequest: match };
         }
       }
     }

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -44,7 +44,7 @@ export const importScannedResources = async ({
     if (options.scope === 'mcp') {
       const newWorkspace = await models.workspace.create({
         parentId: projectId,
-        name: options.label,
+        name: options.label || 'Imported MCP Client',
         scope: 'mcp',
       });
       workspaceId = newWorkspace._id;

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -53,6 +53,12 @@ export const importScannedResources = async ({
       const matchedWorkspace = workspaces.find(workspace => workspace.name === options.label);
       if (matchedWorkspace) {
         workspaceId = matchedWorkspace._id;
+      } else {
+        const newWorkspace = await models.workspace.create({
+          parentId: projectId,
+          name: options.label || 'Imported Collection',
+        });
+        workspaceId = newWorkspace._id;
       }
     }
   }

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -103,6 +103,9 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
     // example: GET,https://rest.rodeo/api
     if (data.endpoint && Array.isArray(importedWorkspaces) && importedWorkspaces.length > 0) {
       const [method, path] = data.endpoint.split(',', 2);
+      if (!method || !path) {
+        return { done: false };
+      }
       for (const ws of importedWorkspaces) {
         invariant(ws, 'Workspace not found');
         if (ws.scope !== 'design') continue;

--- a/packages/insomnia/src/routes/import.scan.tsx
+++ b/packages/insomnia/src/routes/import.scan.tsx
@@ -2,26 +2,30 @@ import path from 'node:path';
 
 import { type ActionFunctionArgs, href } from 'react-router';
 
-import type { ScanResult } from '~/common/import';
-import { fetchImportContentFromURI, getFilesFromPostmanExportedDataDump, scanResources } from '~/common/import';
+import type { ImportSourceType, ScanResult } from '~/common/import';
+import {
+  fetchImportContentFromURI,
+  getFilesFromPostmanExportedDataDump,
+  IMPORT_SOURCE_TYPES,
+  scanResources,
+} from '~/common/import';
 import type { ImportEntry } from '~/main/importers/entities';
 import { SegmentEvent } from '~/ui/analytics';
 import { invariant } from '~/utils/invariant';
 import { createFetcherSubmitHook } from '~/utils/router';
 
-export type SourceType = 'file' | 'uri' | 'curl' | 'clipboard';
-
 export const scanImportResources = async (data: {
-  source: SourceType;
+  source: ImportSourceType;
   uri?: string;
   curl?: string;
+  mcp?: string;
   filePaths?: string | string[];
   postmanArchiveFile?: string | null;
 }): Promise<ScanResult[]> => {
   const { source, postmanArchiveFile } = data;
 
   invariant(typeof source === 'string', 'Source is required.');
-  invariant(['file', 'uri', 'curl', 'clipboard'].includes(source), 'Unsupported import type');
+  invariant(IMPORT_SOURCE_TYPES.includes(source), 'Unsupported import type');
 
   window.main.trackSegmentEvent({
     event: SegmentEvent.importScanned,
@@ -45,6 +49,23 @@ export const scanImportResources = async (data: {
     invariant(typeof curl === 'string' && curl.length, 'cURL command is required');
     contentList.push({
       contentStr: curl,
+    });
+  } else if (source === 'mcp') {
+    const { mcp } = data;
+    invariant(typeof mcp === 'string' && mcp.length, 'MCP server URL is required');
+    const url = mcp.trim();
+    const isHttp = /^https?:\/\//i.test(url);
+    invariant(isHttp, 'MCP server URL must use http or https');
+    const escapedUrl = url.replace(/"/g, '\\"');
+    const yamlStr = `type: mcpClient.insomnia/5.0
+name: Imported MCP Client
+mcpRequest:
+  url: "${escapedUrl}"
+  transportType: streamable-http
+`;
+    contentList.push({
+      contentStr: yamlStr,
+      oriFileName: 'mcp',
     });
   } else if (source === 'file') {
     let filePaths: string[];
@@ -140,8 +161,10 @@ export const scanImportResources = async (data: {
 };
 
 interface ImportScanInputData {
-  source: SourceType;
+  source: ImportSourceType;
   uri?: string;
+  curl?: string;
+  mcp?: string;
   filePaths?: string | string[];
   postmanArchiveFile?: string | null;
 }

--- a/packages/insomnia/src/routes/import.scan.tsx
+++ b/packages/insomnia/src/routes/import.scan.tsx
@@ -7,6 +7,7 @@ import {
   fetchImportContentFromURI,
   getFilesFromPostmanExportedDataDump,
   IMPORT_SOURCE_TYPES,
+  mcpUrlToInsomniaV5Yaml,
   scanResources,
 } from '~/common/import';
 import type { ImportEntry } from '~/main/importers/entities';
@@ -39,7 +40,6 @@ export const scanImportResources = async (data: {
   if (source === 'uri') {
     const { uri } = data;
     invariant(typeof uri === 'string' && uri.length, 'URI is required');
-
     contentList.push({
       contentStr: await fetchImportContentFromURI({ uri }),
       oriFileName: uri,
@@ -53,18 +53,10 @@ export const scanImportResources = async (data: {
   } else if (source === 'mcp') {
     const { mcp } = data;
     invariant(typeof mcp === 'string' && mcp.length, 'MCP server URL is required');
-    const url = mcp.trim();
-    const isHttp = /^https?:\/\//i.test(url);
-    invariant(isHttp, 'MCP server URL must use http or https');
-    const escapedUrl = url.replace(/"/g, '\\"');
-    const yamlStr = `type: mcpClient.insomnia/5.0
-name: Imported MCP Client
-mcpRequest:
-  url: "${escapedUrl}"
-  transportType: streamable-http
-`;
+    const importYaml = mcpUrlToInsomniaV5Yaml(mcp);
+    invariant(importYaml, 'Failed to convert MCP URL to Insomnia v5 YAML');
     contentList.push({
-      contentStr: yamlStr,
+      contentStr: importYaml,
       oriFileName: 'mcp',
     });
   } else if (source === 'file') {

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -340,7 +340,7 @@ export const ImportModal: FC<ImportModalProps> = ({
 };
 const validateCurl = async (value: string) => {
   if (!value) {
-    return 'Invalid cURL request';
+    return '';
   }
   try {
     const { data } = await window.main.parseImport({ contentStr: value }, { importerId: 'curl' });
@@ -437,7 +437,7 @@ const ScanResourcesForm = ({
           {selectedTab === 'uri' && (
             <div className="form-control form-control--outlined">
               <label>
-                Url:
+                Url
                 <input
                   type="text"
                   name="uri"
@@ -450,7 +450,7 @@ const ScanResourcesForm = ({
           {selectedTab === 'curl' && (
             <div className="form-control form-control--outlined">
               <label>
-                cURL:
+                cURL
                 <textarea
                   className="h-[200px] resize-none font-mono"
                   name="curl"

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -5,7 +5,6 @@ import { type DirectoryDropItem, type FileDropItem, OverlayContainer, useDrop } 
 import { Heading, Link } from 'react-aria-components';
 import { useNavigate, useParams } from 'react-router';
 
-import { parseApiSpec } from '~/common/api-specs';
 import { isNotNullOrUndefined } from '~/common/misc';
 import { scopeToActivity } from '~/models/workspace';
 import { useImportResourcesFetcher } from '~/routes/import.resources';
@@ -215,6 +214,7 @@ export const ImportModal: FC<ImportModalProps> = ({
       return;
     }
     modalRef.current?.show();
+    // the only import types that can be auto-scanned are uri (spec), curl, and mcp
     if (autoScan && !scanResourcesFetcherData && scanResourcesFetcher.state === 'idle') {
       const fd: FormData = new FormData();
       fd.append('source', from.type);
@@ -457,7 +457,6 @@ const ScanResourcesForm = ({
   const id = useId();
   const [selectedTab, setSelectedTab] = useState(from?.type || 'uri');
   const [message, setMessage] = useState('');
-  const [mcpUrl, setMcpUrl] = useState(from?.type === 'mcp' ? (from.defaultValue ?? '') : '');
 
   useEffect(() => {
     let isMounted = true;
@@ -470,13 +469,7 @@ const ScanResourcesForm = ({
       isMounted = false;
     };
   }, [from]);
-  useEffect(() => {
-    if (from?.type === 'mcp' && from.defaultValue !== undefined) {
-      setMcpUrl(from.defaultValue);
-    }
-  }, [from?.type, from?.defaultValue]);
   const isValidCurl = (selectedTab === 'curl' && message && message.startsWith('Detected')) || selectedTab !== 'curl';
-  const isValidMcp = selectedTab !== 'mcp' || (mcpUrl && mcpUrl.trim().length > 0);
   return (
     <Fragment>
       <div className="flex flex-col overflow-y-auto">
@@ -565,8 +558,7 @@ const ScanResourcesForm = ({
                 <input
                   type="text"
                   name="mcp"
-                  value={mcpUrl}
-                  onChange={e => setMcpUrl(e.target.value)}
+                  defaultValue={from?.type === 'mcp' && from.defaultValue ? from.defaultValue : ''}
                   placeholder="https://mcp.example.com/mcp"
                 />
               </label>
@@ -604,7 +596,7 @@ const ScanResourcesForm = ({
       <div className="flex items-end justify-between gap-(--padding-sm)">
         <SupportedFormats />
         <Button
-          isDisabled={!isValidCurl || !isValidMcp}
+          isDisabled={!isValidCurl}
           variant="contained"
           bg="surprise"
           type="submit"
@@ -618,6 +610,8 @@ const ScanResourcesForm = ({
     </Fragment>
   );
 };
+
+const DEFAULT_NEW_PROJECT_NAME = 'New Project';
 
 const ImportResourcesForm = ({
   onImport,
@@ -649,26 +643,14 @@ const ImportResourcesForm = ({
   const workspacesFetcher = useProjectListWorkspacesLoaderFetcher();
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(workspaceId || '');
   const [selectedProjectId, setSelectedProjectId] = useState(projectId || '');
-  const defaultProjectName = useMemo(() => {
+  const [newProjectName, setNewProjectName] = useState(() => {
     for (const result of scanResults) {
-      if (result.apiSpecs?.length) {
-        const spec = result.apiSpecs[0];
-        try {
-          const parsed = parseApiSpec(spec.contents);
-          const info = parsed.contents?.info;
-          if (info && typeof info === 'object' && typeof info.title === 'string') {
-            return info.title;
-          }
-        } catch {}
-        return spec.fileName;
+      if (isApiSpecScanResult(result)) {
+        return result.workspaces?.[0]?.name || result.apiSpecs?.[0]?.name || DEFAULT_NEW_PROJECT_NAME;
       }
     }
-    return '';
-  }, [scanResults]);
-  const [newProjectName, setNewProjectName] = useState(defaultProjectName);
-  useEffect(() => {
-    setNewProjectName(defaultProjectName);
-  }, [defaultProjectName]);
+    return DEFAULT_NEW_PROJECT_NAME;
+  });
   useEffect(() => {
     const isIdle = workspacesFetcher.state === 'idle';
     const hasFetchedSelectedProject = selectedProjectId === workspacesFetcher?.data?.activeProject._id;
@@ -758,11 +740,9 @@ const ImportResourcesForm = ({
               </div>
             </div>
           )}
-          {origin && (
-            <div className="mt-4 w-full items-center gap-4 text-wrap outline-hidden">
-              ⚠️ Make sure that you trust the import source before continuing.
-            </div>
-          )}
+          <div className="mt-4 w-full items-center gap-4 text-wrap outline-hidden">
+            ⚠️ Make sure that you trust the import source before continuing.
+          </div>
           {isImportingBaseEnvironmentToWorkspace && (
             <Checkbox
               isSelected={overrideBaseEnvironmentData}

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -309,8 +309,6 @@ export const ImportModal: FC<ImportModalProps> = ({
                 workspaceId: selectedWorkspaceId || (shouldImportToWorkspace ? defaultWorkspaceId : undefined),
                 options: {
                   overrideBaseEnvironmentData,
-                  label: from.type === 'curl' ? from.label : undefined,
-                  scope: from.type === 'curl' ? from.scope : undefined,
                 },
               });
               scanResourcesFetcherData

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -21,7 +21,7 @@ import { ModalHeader } from '../../base/modal-header';
 import { HelpTooltip } from '../../help-tooltip';
 import { Icon } from '../../icon';
 import { Button } from '../../themed-button';
-import { CurlIcon, disclaimer, ScanResultsTable, SupportedFormats, validImportExtensions } from './shared';
+import { CurlIcon, ScanResultsTable, SupportedFormats, validImportExtensions } from './shared';
 
 export const Radio: FC<{
   name: string;

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -388,9 +388,6 @@ const ScanResourcesForm = ({
   return (
     <Fragment>
       <div className="flex flex-col overflow-y-auto">
-        <div className="mb-4 w-full items-center gap-4 rounded-lg border border-solid border-[rgba(var(--color-warning-rgb),1)] bg-(--color-bg) px-3 py-2 text-sm text-wrap text-[rgba(var(--color-warning-rgb),1)] shadow-lg outline-hidden">
-          ⚠️ Make sure that you trust the import source before continuing.
-        </div>
         <form
           aria-label="Import from"
           id={id}
@@ -471,11 +468,12 @@ const ScanResourcesForm = ({
             <ScanResultsTable scanResults={scanResults} />
           </div>
         )}
-        {selectedTab === 'curl' && message && <div className="truncate">{message}</div>}
-        {from?.type === 'curl' && from.origin && (
-          <div className="flex w-full justify-start py-1">
-            <CurlIcon />
-            cURL from{' '}
+        {selectedTab === 'curl' && message && (
+          <div className={`truncate ${isValidCurl ? '' : 'text-(--color-danger)'}`}>{message}</div>
+        )}
+        {from?.origin && (
+          <div className="flex w-full justify-start py-2">
+            from{' '}
             <Link
               className="px-2 font-bold underline"
               onClick={() => {
@@ -488,6 +486,9 @@ const ScanResourcesForm = ({
             ⚠️
           </div>
         )}
+        <div className="mt-4 w-full items-center gap-4 text-wrap outline-hidden">
+          ⚠️ Make sure that you trust the import source before continuing.
+        </div>
       </div>
 
       <div className="flex items-end justify-between gap-(--padding-sm)">
@@ -627,10 +628,7 @@ const ImportResourcesForm = ({
         </div>
       </div>
 
-      <div className="flex w-full items-end justify-between gap-(--padding-sm)">
-        <div>
-          <div className="pb-(--padding-sm)">{disclaimer}</div>
-        </div>
+      <div className="flex w-full items-end justify-end gap-(--padding-sm)">
         <Button
           variant="contained"
           bg="surprise"

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -165,7 +165,29 @@ const FileField: FC = () => {
     </div>
   );
 };
-
+export type ImportSourceType =
+  | {
+      type: 'file';
+      origin?: string;
+      defaultValue?: string;
+    }
+  | {
+      type: 'uri';
+      defaultValue?: string;
+      origin?: string;
+    }
+  | {
+      type: 'curl';
+      defaultValue?: string;
+      origin?: string;
+      label?: string;
+      scope?: string;
+    }
+  | {
+      type: 'clipboard';
+      origin?: string;
+      defaultValue?: string;
+    };
 interface ImportModalProps extends ModalProps {
   organizationId: string;
   projectName: string;
@@ -175,25 +197,7 @@ interface ImportModalProps extends ModalProps {
   defaultProjectId: string;
   // undefined when in workspace selection page
   defaultWorkspaceId?: string;
-  from:
-    | {
-        type: 'file';
-        origin?: string;
-      }
-    | {
-        type: 'uri';
-        defaultValue?: string;
-        origin?: string;
-      }
-    | {
-        type: 'curl';
-        defaultValue?: string;
-        origin?: string;
-      }
-    | {
-        type: 'clipboard';
-        origin?: string;
-      };
+  from: ImportSourceType;
 }
 
 export const ImportModal: FC<ImportModalProps> = ({
@@ -305,6 +309,8 @@ export const ImportModal: FC<ImportModalProps> = ({
                 workspaceId: selectedWorkspaceId || (shouldImportToWorkspace ? defaultWorkspaceId : undefined),
                 options: {
                   overrideBaseEnvironmentData,
+                  label: from.type === 'curl' ? from.label : undefined,
+                  scope: from.type === 'curl' ? from.scope : undefined,
                 },
               });
               scanResourcesFetcherData
@@ -497,7 +503,7 @@ const ScanResourcesForm = ({
           className="btn h-10 gap-(--padding-sm)"
         >
           <i className="fa fa-file-import" /> Scan
-          {loading && <Icon icon="spinner" className="ml-[4px] animate-spin" />}
+          {loading && <Icon icon="spinner" className="ml-1 animate-spin" />}
         </Button>
       </div>
     </Fragment>

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -5,14 +5,22 @@ import { type DirectoryDropItem, type FileDropItem, OverlayContainer, useDrop } 
 import { Heading, Link } from 'react-aria-components';
 import { useNavigate, useParams } from 'react-router';
 
+import { parseApiSpec } from '~/common/api-specs';
 import { isNotNullOrUndefined } from '~/common/misc';
 import { scopeToActivity } from '~/models/workspace';
 import { useImportResourcesFetcher } from '~/routes/import.resources';
 import { useScanResourcesFetcher } from '~/routes/import.scan';
 import { useProjectListWorkspacesLoaderFetcher } from '~/routes/organization.$organizationId.project.$projectId.list-workspaces';
+import { createProject } from '~/routes/organization.$organizationId.project.new';
 import { Checkbox } from '~/ui/components/base/checkbox';
 
-import type { ScanResult } from '../../../../common/import';
+import {
+  clearResourceCache,
+  findExistingImportedSpec,
+  findRequestInExistingWorkspace,
+  type ImportSourceType,
+  type ScanResult,
+} from '../../../../common/import';
 import { isScratchpadProject } from '../../../../models/project';
 import { invariant } from '../../../../utils/invariant';
 import { SegmentEvent } from '../../../analytics';
@@ -21,7 +29,7 @@ import { ModalHeader } from '../../base/modal-header';
 import { HelpTooltip } from '../../help-tooltip';
 import { Icon } from '../../icon';
 import { Button } from '../../themed-button';
-import { CurlIcon, ScanResultsTable, SupportedFormats, validImportExtensions } from './shared';
+import { CurlIcon, isApiSpecScanResult, ScanResultsTable, SupportedFormats, validImportExtensions } from './shared';
 
 export const Radio: FC<{
   name: string;
@@ -165,39 +173,26 @@ const FileField: FC = () => {
     </div>
   );
 };
-export type ImportSourceType =
-  | {
-      type: 'file';
-      origin?: string;
-      defaultValue?: string;
-    }
-  | {
-      type: 'uri';
-      defaultValue?: string;
-      origin?: string;
-    }
-  | {
-      type: 'curl';
-      defaultValue?: string;
-      origin?: string;
-      label?: string;
-      scope?: string;
-    }
-  | {
-      type: 'clipboard';
-      origin?: string;
-      defaultValue?: string;
-    };
+
+export interface ImportSource {
+  type: ImportSourceType;
+  origin?: string;
+  defaultValue?: string;
+  endpoint?: string;
+  operationId?: string;
+  autoScan?: boolean;
+}
+
 interface ImportModalProps extends ModalProps {
   organizationId: string;
-  projectName: string;
+  projectName?: string;
   // undefined when not using preferences
   workspaceName?: string;
   // undefined when logged out, should not happen
   defaultProjectId: string;
   // undefined when in workspace selection page
   defaultWorkspaceId?: string;
-  from: ImportSourceType;
+  from: ImportSource;
 }
 
 export const ImportModal: FC<ImportModalProps> = ({
@@ -214,9 +209,61 @@ export const ImportModal: FC<ImportModalProps> = ({
   const scanResourcesFetcherData = scanResourcesFetcher.data;
   const importFetcher = useImportResourcesFetcher();
   const navigate = useNavigate();
+  const autoScan = from.autoScan ?? false;
   useEffect(() => {
+    if (modalRef?.current?.isOpen()) {
+      return;
+    }
     modalRef.current?.show();
-  }, []);
+    if (autoScan && !scanResourcesFetcherData && scanResourcesFetcher.state === 'idle') {
+      const fd: FormData = new FormData();
+      fd.append('source', from.type);
+      if (from.type === 'uri') {
+        fd.append('uri', from.defaultValue || '');
+      } else if (from.type === 'curl') {
+        fd.append('curl', from.defaultValue || '');
+      } else if (from.type === 'mcp') {
+        fd.append('mcp', from.defaultValue || '');
+      }
+      scanResourcesFetcher.submit(fd);
+    }
+  }, [autoScan, from.type, from.defaultValue, scanResourcesFetcher, scanResourcesFetcherData]);
+
+  const hasApiSpecScanResult = scanResourcesFetcherData?.some(isApiSpecScanResult);
+  const [showForm, setShowForm] = useState(!autoScan);
+  const [createdProjectId, setCreatedProjectId] = useState<string | null>(null);
+  const dupCheckRef = useRef(false);
+  useEffect(() => {
+    if (!autoScan || !hasApiSpecScanResult || !organizationId) return;
+    if (!defaultProjectId) {
+      setShowForm(true);
+      return;
+    }
+    if (dupCheckRef.current) return;
+    const valid = scanResourcesFetcherData?.some(({ errors }) => !errors.length);
+    if (!valid) return;
+    dupCheckRef.current = true;
+    findExistingImportedSpec(defaultProjectId).then(existing => {
+      if (!existing) return setShowForm(true);
+      findRequestInExistingWorkspace(existing.workspace, from.endpoint, from.operationId).then(req => {
+        const path = req
+          ? `/organization/${organizationId}/project/${defaultProjectId}/workspace/${existing.workspace._id}/debug/request/${req._id}`
+          : `/organization/${organizationId}/project/${defaultProjectId}/workspace/${existing.workspace._id}/${scopeToActivity(existing.workspace.scope)}`;
+        clearResourceCache();
+        navigate(path);
+        modalRef.current?.hide();
+      });
+    });
+  }, [
+    autoScan,
+    defaultProjectId,
+    from.endpoint,
+    from.operationId,
+    hasApiSpecScanResult,
+    navigate,
+    organizationId,
+    scanResourcesFetcherData,
+  ]);
 
   // Track the import completion event, redirect to the new workspace and close the modal
   useEffect(() => {
@@ -230,22 +277,31 @@ export const ImportModal: FC<ImportModalProps> = ({
       });
       const workspace = importFetcher?.data?.singleImportedWorkspace;
       const request = importFetcher?.data?.singleImportedRequest;
+      const targetProjectId = createdProjectId || defaultProjectId;
       if (workspace && request) {
         navigate(
-          `/organization/${organizationId}/project/${defaultProjectId}/workspace/${workspace._id}/debug/request/${request._id}`,
+          `/organization/${organizationId}/project/${targetProjectId}/workspace/${workspace._id}/debug/request/${request._id}`,
         );
         return modalRef.current?.hide();
       }
       if (workspace) {
         navigate(
-          `/organization/${organizationId}/project/${defaultProjectId}/workspace/${workspace._id}/${scopeToActivity(workspace.scope)}`,
+          `/organization/${organizationId}/project/${targetProjectId}/workspace/${workspace._id}/${scopeToActivity(workspace.scope)}`,
         );
         return modalRef.current?.hide();
       }
-      navigate(`/organization/${organizationId}/project/${defaultProjectId}`);
+      navigate(`/organization/${organizationId}/project/${targetProjectId}`);
       modalRef.current?.hide();
     }
-  }, [defaultProjectId, defaultWorkspaceId, importFetcher?.data, navigate, organizationId, scanResourcesFetcherData]);
+  }, [
+    createdProjectId,
+    defaultProjectId,
+    defaultWorkspaceId,
+    importFetcher?.data,
+    navigate,
+    organizationId,
+    scanResourcesFetcherData,
+  ]);
   // allow workspace import if there is only one workspace
   const totalWorkspacesCount = useMemo(() => {
     return (
@@ -255,7 +311,7 @@ export const ImportModal: FC<ImportModalProps> = ({
       ) || 0
     );
   }, [scanResourcesFetcherData]);
-  const shouldImportToWorkspace = !!defaultWorkspaceId && totalWorkspacesCount <= 1;
+  const shouldImportToWorkspace = !!defaultWorkspaceId && totalWorkspacesCount <= 1 && !hasApiSpecScanResult;
   // Check if base environment is being imported to existing workspace
   const isImportingBaseEnvironmentToWorkspace =
     shouldImportToWorkspace &&
@@ -265,7 +321,9 @@ export const ImportModal: FC<ImportModalProps> = ({
   // TODO: need to add a more strong way to inform users that resources will be imported into project rather than current workspace
   const header = shouldImportToWorkspace
     ? `Import to "${workspaceName}" Workspace`
-    : `Import to "${projectName}" Project`;
+    : projectName
+      ? `Import to "${projectName}" Project`
+      : 'Import';
   const isScratchPad =
     defaultProjectId &&
     isScratchpadProject({
@@ -289,24 +347,47 @@ export const ImportModal: FC<ImportModalProps> = ({
     <OverlayContainer onClick={e => e.stopPropagation()}>
       <Modal ref={modalRef} onHide={onHide}>
         <ModalHeader>{header}</ModalHeader>
-        {hasAnyDataToImport ? (
+        {autoScan && hasApiSpecScanResult && hasAnyDataToImport && !showForm ? (
+          <div className="flex items-center justify-center p-8">
+            <i className="fa fa-spinner fa-spin fa-2x" />
+          </div>
+        ) : hasAnyDataToImport ? (
           <ImportResourcesForm
             scanResults={scanResourcesFetcherData as ScanResult[]}
             errors={importErrors}
             loading={importFetcher.state !== 'idle'}
             disabled={importErrors.length > 0}
             isImportingBaseEnvironmentToWorkspace={!!isImportingBaseEnvironmentToWorkspace}
-            onImport={(
+            onImport={async (
               overrideBaseEnvironmentData: boolean,
               selectedProjectId?: string,
               selectedWorkspaceId?: string,
+              newProjectName?: string,
             ) => {
               invariant(Array.isArray(scanResourcesFetcherData));
 
+              let targetProjectId = selectedProjectId || defaultProjectId || '';
+
+              if (newProjectName) {
+                const createdProjectId = await createProject(organizationId, {
+                  storageType: 'local',
+                  name: newProjectName,
+                });
+                if (createdProjectId) {
+                  targetProjectId = createdProjectId;
+                  setCreatedProjectId(createdProjectId);
+                }
+              }
+
               importFetcher.submit({
                 organizationId,
-                projectId: selectedProjectId || defaultProjectId || '',
-                workspaceId: selectedWorkspaceId || (shouldImportToWorkspace ? defaultWorkspaceId : undefined),
+                projectId: targetProjectId,
+                workspaceId: hasApiSpecScanResult
+                  ? undefined
+                  : selectedWorkspaceId || (shouldImportToWorkspace ? defaultWorkspaceId : undefined),
+                endpoint: from.endpoint,
+                operationId: from.operationId,
+                skipImportIfDuplicate: autoScan,
                 options: {
                   overrideBaseEnvironmentData,
                 },
@@ -322,6 +403,10 @@ export const ImportModal: FC<ImportModalProps> = ({
                 });
             }}
           />
+        ) : autoScan && scanResourcesFetcher.state === 'loading' ? (
+          <div className="flex items-center justify-center p-8">
+            <i className="fa fa-spinner fa-spin fa-2x" />
+          </div>
         ) : (
           <ScanResourcesForm
             from={from}
@@ -338,7 +423,7 @@ export const ImportModal: FC<ImportModalProps> = ({
     </OverlayContainer>
   );
 };
-const validateCurl = async (value: string) => {
+export const validateCurl = async (value: string) => {
   if (!value) {
     return '';
   }
@@ -372,6 +457,7 @@ const ScanResourcesForm = ({
   const id = useId();
   const [selectedTab, setSelectedTab] = useState(from?.type || 'uri');
   const [message, setMessage] = useState('');
+  const [mcpUrl, setMcpUrl] = useState(from?.type === 'mcp' ? (from.defaultValue ?? '') : '');
 
   useEffect(() => {
     let isMounted = true;
@@ -384,7 +470,13 @@ const ScanResourcesForm = ({
       isMounted = false;
     };
   }, [from]);
+  useEffect(() => {
+    if (from?.type === 'mcp' && from.defaultValue !== undefined) {
+      setMcpUrl(from.defaultValue);
+    }
+  }, [from?.type, from?.defaultValue]);
   const isValidCurl = (selectedTab === 'curl' && message && message.startsWith('Detected')) || selectedTab !== 'curl';
+  const isValidMcp = selectedTab !== 'mcp' || (mcpUrl && mcpUrl.trim().length > 0);
   return (
     <Fragment>
       <div className="flex flex-col overflow-y-auto">
@@ -428,6 +520,10 @@ const ScanResourcesForm = ({
                 <i className="fa fa-clipboard" />
                 Clipboard
               </Radio>
+              <Radio onChange={() => setSelectedTab('mcp')} name="source" value="mcp" checked={selectedTab === 'mcp'}>
+                <i className="fa fa-plug" />
+                MCP
+              </Radio>
             </div>
           </fieldset>
           {selectedTab === 'file' && <FileField />}
@@ -458,6 +554,20 @@ const ScanResourcesForm = ({
                     const msg = await validateCurl(value);
                     setMessage(msg);
                   }}
+                />
+              </label>
+            </div>
+          )}
+          {selectedTab === 'mcp' && (
+            <div className="form-control form-control--outlined">
+              <label>
+                MCP Server URL
+                <input
+                  type="text"
+                  name="mcp"
+                  value={mcpUrl}
+                  onChange={e => setMcpUrl(e.target.value)}
+                  placeholder="https://mcp.example.com/mcp"
                 />
               </label>
             </div>
@@ -494,7 +604,7 @@ const ScanResourcesForm = ({
       <div className="flex items-end justify-between gap-(--padding-sm)">
         <SupportedFormats />
         <Button
-          isDisabled={!isValidCurl}
+          isDisabled={!isValidCurl || !isValidMcp}
           variant="contained"
           bg="surprise"
           type="submit"
@@ -519,7 +629,12 @@ const ImportResourcesForm = ({
 }: {
   scanResults: ScanResult[];
   errors?: string[];
-  onImport: (overrideBaseEnvironmentData: boolean, selectedProjectId?: string, selectedWorkspaceId?: string) => void;
+  onImport: (
+    overrideBaseEnvironmentData: boolean,
+    selectedProjectId?: string,
+    selectedWorkspaceId?: string,
+    newProjectName?: string,
+  ) => void;
   disabled: boolean;
   loading: boolean;
   isImportingBaseEnvironmentToWorkspace: boolean;
@@ -534,6 +649,26 @@ const ImportResourcesForm = ({
   const workspacesFetcher = useProjectListWorkspacesLoaderFetcher();
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState(workspaceId || '');
   const [selectedProjectId, setSelectedProjectId] = useState(projectId || '');
+  const defaultProjectName = useMemo(() => {
+    for (const result of scanResults) {
+      if (result.apiSpecs?.length) {
+        const spec = result.apiSpecs[0];
+        try {
+          const parsed = parseApiSpec(spec.contents);
+          const info = parsed.contents?.info;
+          if (info && typeof info === 'object' && typeof info.title === 'string') {
+            return info.title;
+          }
+        } catch {}
+        return spec.fileName;
+      }
+    }
+    return '';
+  }, [scanResults]);
+  const [newProjectName, setNewProjectName] = useState(defaultProjectName);
+  useEffect(() => {
+    setNewProjectName(defaultProjectName);
+  }, [defaultProjectName]);
   useEffect(() => {
     const isIdle = workspacesFetcher.state === 'idle';
     const hasFetchedSelectedProject = selectedProjectId === workspacesFetcher?.data?.activeProject._id;
@@ -582,6 +717,25 @@ const ImportResourcesForm = ({
               </label>
             </div>
           </div>
+          {selectedNewProject && (
+            <div className="mt-2">
+              <div className="form-control form-control--outlined">
+                <label>
+                  New Project Name:
+                  <input
+                    type="text"
+                    name="newProjectName"
+                    value={newProjectName}
+                    onChange={e => setNewProjectName(e.target.value)}
+                    placeholder="Enter project name"
+                  />
+                </label>
+              </div>
+              <p className="mt-1 text-xs text-[--color-help]">
+                New project will be created as Local. You can change the type later in project settings.
+              </p>
+            </div>
+          )}
           {shouldShowWorkspaceSelect && (
             <div className="form-row mt-2">
               <div className="form-control form-control--outlined">
@@ -602,6 +756,11 @@ const ImportResourcesForm = ({
                   </select>
                 </label>
               </div>
+            </div>
+          )}
+          {origin && (
+            <div className="mt-4 w-full items-center gap-4 text-wrap outline-hidden">
+              ⚠️ Make sure that you trust the import source before continuing.
             </div>
           )}
           {isImportingBaseEnvironmentToWorkspace && (
@@ -632,8 +791,15 @@ const ImportResourcesForm = ({
         <Button
           variant="contained"
           bg="surprise"
-          disabled={disabled}
-          onClick={() => onImport(overrideBaseEnvironmentData, selectedProjectId, selectedWorkspaceId)}
+          disabled={disabled || loading}
+          onClick={() =>
+            onImport(
+              overrideBaseEnvironmentData,
+              selectedProjectId,
+              selectedWorkspaceId,
+              selectedNewProject ? newProjectName || 'New Project' : undefined,
+            )
+          }
           className="btn h-10 gap-(--padding-sm)"
         >
           {loading ? (

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -423,24 +423,24 @@ export const ImportModal: FC<ImportModalProps> = ({
     </OverlayContainer>
   );
 };
-export const validateCurl = async (value: string) => {
+export const validateCurl = async (value: string): Promise<{ isValid: boolean; message: string }> => {
   if (!value) {
-    return '';
+    return { isValid: false, message: 'Invalid cURL request' };
   }
   try {
     const { data } = await window.main.parseImport({ contentStr: value }, { importerId: 'curl' });
     const importedRequest = data?.resources?.[0];
     return importedRequest.url
-      ? `Detected ${importedRequest.method} request to ${importedRequest.url}`
-      : 'Invalid cURL request';
+      ? { isValid: true, message: `Detected ${importedRequest.method} request to ${importedRequest.url}` }
+      : { isValid: false, message: 'Invalid cURL request' };
   } catch (error) {
     const rawMessage = error instanceof Error ? error.message : String(error);
     const cleanedMessage = rawMessage.replace("Error invoking remote method 'parseImport': Error: ", '');
     const finalMessage = rawMessage.includes('No importers found for file') ? 'Invalid cURL request' : cleanedMessage;
     console.log('[importer] error', finalMessage);
     return finalMessage.includes('No importers found for file')
-      ? 'Invalid cURL request'
-      : finalMessage.replace("Error invoking remote method 'parseImport': Error: ", '');
+      ? { isValid: false, message: 'Invalid cURL request' }
+      : { isValid: false, message: finalMessage.replace("Error invoking remote method 'parseImport': Error: ", '') };
   }
 };
 const ScanResourcesForm = ({
@@ -462,7 +462,7 @@ const ScanResourcesForm = ({
   useEffect(() => {
     let isMounted = true;
     const fn = async () => {
-      const msg = await validateCurl(from?.type === 'curl' && from.defaultValue ? from.defaultValue : '');
+      const { message: msg } = await validateCurl(from?.type === 'curl' && from.defaultValue ? from.defaultValue : '');
       isMounted && setMessage(msg);
     };
     fn();
@@ -551,7 +551,7 @@ const ScanResourcesForm = ({
                   placeholder="curl --request GET --url http://insomnia.rest/"
                   onChange={async event => {
                     const { value } = event.target;
-                    const msg = await validateCurl(value);
+                    const { message: msg } = await validateCurl(value);
                     setMessage(msg);
                   }}
                 />

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -366,7 +366,7 @@ const ScanResourcesForm = ({
   loading: boolean;
 }) => {
   const id = useId();
-  const [importFrom, setImportFrom] = useState(from?.type || 'uri');
+  const [selectedTab, setSelectedTab] = useState(from?.type || 'uri');
   const [message, setMessage] = useState('');
 
   useEffect(() => {
@@ -380,7 +380,7 @@ const ScanResourcesForm = ({
       isMounted = false;
     };
   }, [from]);
-  const isValidCurl = (importFrom === 'curl' && message && message.startsWith('Detected')) || importFrom !== 'curl';
+  const isValidCurl = (selectedTab === 'curl' && message && message.startsWith('Detected')) || selectedTab !== 'curl';
   return (
     <Fragment>
       <div className="flex flex-col overflow-y-auto">
@@ -396,31 +396,41 @@ const ScanResourcesForm = ({
         >
           <fieldset className="flex flex-col gap-(--padding-md)">
             <div className="flex rounded-md border border-solid border-(--hl-md) bg-(--hl-xs) p-(--padding-xs)">
-              <Radio onChange={() => setImportFrom('file')} name="source" value="file" checked={importFrom === 'file'}>
+              <Radio
+                onChange={() => setSelectedTab('file')}
+                name="source"
+                value="file"
+                checked={selectedTab === 'file'}
+              >
                 <i className="fa fa-plus" />
                 File
               </Radio>
-              <Radio onChange={() => setImportFrom('uri')} name="source" value="uri" checked={importFrom === 'uri'}>
+              <Radio onChange={() => setSelectedTab('uri')} name="source" value="uri" checked={selectedTab === 'uri'}>
                 <i className="fa fa-link" />
                 Url
               </Radio>
-              <Radio onChange={() => setImportFrom('curl')} name="source" value="curl" checked={importFrom === 'curl'}>
+              <Radio
+                onChange={() => setSelectedTab('curl')}
+                name="source"
+                value="curl"
+                checked={selectedTab === 'curl'}
+              >
                 <CurlIcon />
                 cURL
               </Radio>
               <Radio
-                onChange={() => setImportFrom('clipboard')}
+                onChange={() => setSelectedTab('clipboard')}
                 name="source"
                 value="clipboard"
-                checked={importFrom === 'clipboard'}
+                checked={selectedTab === 'clipboard'}
               >
                 <i className="fa fa-clipboard" />
                 Clipboard
               </Radio>
             </div>
           </fieldset>
-          {importFrom === 'file' && <FileField />}
-          {importFrom === 'uri' && (
+          {selectedTab === 'file' && <FileField />}
+          {selectedTab === 'uri' && (
             <div className="form-control form-control--outlined">
               <label>
                 Url:
@@ -433,7 +443,7 @@ const ScanResourcesForm = ({
               </label>
             </div>
           )}
-          {importFrom === 'curl' && (
+          {selectedTab === 'curl' && (
             <div className="form-control form-control--outlined">
               <label>
                 cURL:
@@ -457,7 +467,7 @@ const ScanResourcesForm = ({
             <ScanResultsTable scanResults={scanResults} />
           </div>
         )}
-        {importFrom === 'curl' && message && <div className="truncate">{message}</div>}
+        {selectedTab === 'curl' && message && <div className="truncate">{message}</div>}
         {from?.type === 'curl' && from.origin && (
           <div className="flex w-full justify-start py-1">
             <CurlIcon />

--- a/packages/insomnia/src/ui/components/modals/import-modal/shared.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/shared.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, { type FC, Fragment, type PropsWithChildren, useMemo } from 'react';
 
+import { type ProjectScopeKeys, scopeToLabelMap } from '~/common/get-workspace-label';
 import type { ScanResult } from '~/common/import';
 
 export const validImportExtensions = [
@@ -181,14 +182,6 @@ export const SupportedFormats = () => {
   );
 };
 
-const WORKSPACE_SCOPE_LABELS: Record<string, { singular: string; plural: string }> = {
-  'mcp': { singular: 'MCP Client', plural: 'MCP Clients' },
-  'design': { singular: 'Document', plural: 'Documents' },
-  'collection': { singular: 'Collection', plural: 'Collections' },
-  'environment': { singular: 'Environment', plural: 'Environments' },
-  'mock-server': { singular: 'Mock Server', plural: 'Mock Servers' },
-};
-
 export function isApiSpecScanResult(scanResult: ScanResult) {
   return (
     (scanResult.apiSpecs?.length ?? 0) > 0 || scanResult.type?.id === 'openapi3' || scanResult.type?.id === 'swagger2'
@@ -271,10 +264,8 @@ export const ScanResultsTable = ({ scanResults }: { scanResults: ScanResult[] })
                     getWorkspaceCountsByScope(scanResult.workspaces, scanResult).map(({ scope, count }) => (
                       <tr key={scope} className="table--no-outline-row">
                         <td>
-                          {count}{' '}
-                          {count === 1
-                            ? (WORKSPACE_SCOPE_LABELS[scope]?.singular ?? 'Workspace')
-                            : (WORKSPACE_SCOPE_LABELS[scope]?.plural ?? 'Workspaces')}
+                          {count} {scopeToLabelMap[scope as ProjectScopeKeys] ?? 'Workspace'}
+                          {count > 1 ? 's' : ''}
                         </td>
                       </tr>
                     ))}

--- a/packages/insomnia/src/ui/components/modals/import-modal/shared.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/shared.tsx
@@ -181,6 +181,30 @@ export const SupportedFormats = () => {
   );
 };
 
+const WORKSPACE_SCOPE_LABELS: Record<string, { singular: string; plural: string }> = {
+  'mcp': { singular: 'MCP Client', plural: 'MCP Clients' },
+  'design': { singular: 'Document', plural: 'Documents' },
+  'collection': { singular: 'Collection', plural: 'Collections' },
+  'environment': { singular: 'Environment', plural: 'Environments' },
+  'mock-server': { singular: 'Mock Server', plural: 'Mock Servers' },
+};
+
+export function isApiSpecScanResult(scanResult: ScanResult) {
+  return (
+    (scanResult.apiSpecs?.length ?? 0) > 0 || scanResult.type?.id === 'openapi3' || scanResult.type?.id === 'swagger2'
+  );
+}
+
+function getWorkspaceCountsByScope(workspaces: { scope?: string }[], scanResult: ScanResult) {
+  const defaultScope = isApiSpecScanResult(scanResult) ? 'design' : 'collection';
+  const counts = new Map<string, number>();
+  for (const w of workspaces) {
+    const scope = w.scope ?? defaultScope;
+    counts.set(scope, (counts.get(scope) ?? 0) + 1);
+  }
+  return Array.from(counts.entries(), ([scope, count]) => ({ scope, count }));
+}
+
 export const ScanResultsTable = ({ scanResults }: { scanResults: ScanResult[] }) => {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const keyRandom = useMemo(() => Math.random(), [scanResults]);
@@ -242,13 +266,18 @@ export const ScanResultsTable = ({ scanResults }: { scanResults: ScanResult[] })
                 </tr>
               ) : (
                 <Fragment>
-                  {scanResult.workspaces && scanResult.workspaces?.length > 0 && (
-                    <tr key={scanResult.workspaces[0]._id} className="table--no-outline-row">
-                      <td>
-                        {scanResult.workspaces.length} {scanResult.workspaces.length === 1 ? 'Workspace' : 'Workspaces'}
-                      </td>
-                    </tr>
-                  )}
+                  {scanResult.workspaces &&
+                    scanResult.workspaces.length > 0 &&
+                    getWorkspaceCountsByScope(scanResult.workspaces, scanResult).map(({ scope, count }) => (
+                      <tr key={scope} className="table--no-outline-row">
+                        <td>
+                          {count}{' '}
+                          {count === 1
+                            ? (WORKSPACE_SCOPE_LABELS[scope]?.singular ?? 'Workspace')
+                            : (WORKSPACE_SCOPE_LABELS[scope]?.plural ?? 'Workspaces')}
+                        </td>
+                      </tr>
+                    ))}
                   {scanResult.requests && scanResult.requests?.length > 0 && (
                     <tr key={scanResult.requests[0]._id} className="table--no-outline-row">
                       <td>


### PR DESCRIPTION
Adds support for skipping certain aspects of app-uri imports `insomnia://app/import?...`:

- cURL imports:
  - When valid, skip/auto-scan to the project/collection selection step
  - When invalid, offer corrections by opening regular project-scoped import dialog
- OpenAPI spec imports:
  - If existing Document matching title+version exists in any project
    - If `endpoint` or `operationId` specified, navigates to specific request
    - Otherwise, navigates to the existing Document
  - If non-existing, skip/auto-scan to the project selection
- All other imports:
  - Auto-scans prompting project/collection selection
