### PR TITLE
feat(Git Sync): Add support for canonical repository output

### DIFF
--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -37,6 +37,7 @@ import { migrateToLatestYaml } from '../common/insomnia-schema-migrations';
 import { insomniaSchemaTypeToScope } from '../common/insomnia-v5';
 import * as models from '../models';
 import { fsClient } from '../sync/git/fs-client';
+import { migrateRepoStructureIfNeeded } from '../sync/git/git-repo-migration';
 import GitVCS, {
   fetchRemoteBranches,
   GIT_CLONE_DIR,
@@ -53,6 +54,7 @@ import { MemClient } from '../sync/git/mem-client';
 import { NeDBClient } from '../sync/git/ne-db-client';
 import { GitProjectNeDBClient } from '../sync/git/project-ne-db-client';
 import { projectRoutableFSClient } from '../sync/git/project-routable-fs-client';
+import { startWatcher, stopWatcher } from '../sync/git/repo-file-watcher';
 import { routableFSClient } from '../sync/git/routable-fs-client';
 import { shallowClone } from '../sync/git/shallow-clone';
 import type { MergeConflict } from '../sync/types';
@@ -224,11 +226,12 @@ async function getGitFSClient({
   // All app data is stored within a namespaced GIT_INSOMNIA_DIR directory at the root of the repository and is read/written from the local NeDB database
   const neDbClient = GitProjectNeDBClient.createClient(projectId);
 
-  // All git metadata in the GIT_INTERNAL_DIR directory is stored in a git/ directory on the filesystem
+  // All git metadata in the GIT_INTERNAL_DIR directory is stored in a .git/ directory on the filesystem
   const gitDataClient = fsClient(baseDir);
 
-  // All data outside the directories listed below will be stored in an 'other' directory. This is so we can support files that exist outside the ones the app is specifically in charge of.
-  const otherDataClient = fsClient(path.join(baseDir, 'other'));
+  // All non-YAML files are stored at the repository root (no separate 'other' subfolder)
+  // so that native Git tools can operate directly on the repository directory.
+  const otherDataClient = fsClient(baseDir);
 
   // The routable FS client directs isomorphic-git to read/write from the database or from the correct directory on the file system while performing git operations.
   const routableFS = projectRoutableFSClient(otherDataClient, neDbClient, {
@@ -242,6 +245,17 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
   try {
     const gitRepository = await getGitRepository({ workspaceId, projectId });
 
+    const baseDir = path.join(
+      process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'),
+      `version-control/git/${gitRepository._id}`,
+    );
+
+    // Migrate old directory structure (git/ → .git/, other/ → root) if needed.
+    // Only runs for the modern project-scoped flow (no workspaceId).
+    if (!workspaceId) {
+      await migrateRepoStructureIfNeeded(baseDir, projectId, gitRepository._id);
+    }
+
     const bufferId = await database.bufferChanges();
     const fsClient = await getGitFSClient({ gitRepositoryId: gitRepository._id, projectId, workspaceId });
 
@@ -249,6 +263,8 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
       let legacyInsomniaWorkspace;
       if (!workspaceId) {
         legacyInsomniaWorkspace = await containsLegacyInsomniaDir({ fsClient });
+        // Ensure watcher is running (idempotent)
+        startWatcher(gitRepository._id, baseDir, projectId);
       }
 
       return {
@@ -289,6 +305,12 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
     // Configure basic info
     await GitVCS.setAuthor();
     await GitVCS.addRemote(uri);
+
+    // Start file watcher for project-scoped repos so external YAML edits
+    // (native git CLI, VS Code, etc.) flow back into the database.
+    if (!workspaceId) {
+      startWatcher(gitRepository._id, baseDir, projectId);
+    }
 
     let legacyInsomniaWorkspace;
     if (!workspaceId) {
@@ -1259,6 +1281,9 @@ export const resetGitRepoAction = async ({ projectId, workspaceId }: { projectId
   }
 
   await services.gitRepository.remove(repo);
+  // Stop the file watcher for this repository (project-scoped flow only).
+  stopWatcher(repo._id);
+
   await database.flushChanges(flushId);
 
   return null;

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.generate-request-collection.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.generate-request-collection.tsx
@@ -32,7 +32,7 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
   const gitRepositoryId = models.project.isGitProject(project) ? project.gitRepositoryId : workspaceMeta?.gitRepositoryId;
 
   const rulesetPath = gitRepositoryId
-    ? path.join(window.app.getPath('userData'), `version-control/git/${gitRepositoryId}/other/.spectral.yaml`)
+    ? path.join(window.app.getPath('userData'), `version-control/git/${gitRepositoryId}/.spectral.yaml`)
     : '';
 
   const { diagnostics, error } = await window.main.lintSpec({ documentContent: apiSpec.contents, rulesetPath });

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
@@ -90,7 +90,7 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
   // we don't run the lint here because it is expensive and slows first render too much
   // TODO: add this in once we run this loader outside the renderer
   const rulesetPath = gitRepositoryId
-    ? path.join(window.app.getPath('userData'), `version-control/git/${gitRepositoryId}/other/.spectral.yaml`)
+    ? path.join(window.app.getPath('userData'), `version-control/git/${gitRepositoryId}/.spectral.yaml`)
     : '';
 
   let parsedSpec: OpenAPIV3.Document | undefined;

--- a/packages/insomnia/src/sync/git/git-repo-migration.ts
+++ b/packages/insomnia/src/sync/git/git-repo-migration.ts
@@ -1,0 +1,208 @@
+/**
+ * Git Repository Structure Migration
+ *
+ * Migrates existing on-disk git repositories from the old layout to the new
+ * layout that lets users run native Git CLI commands directly against the repo.
+ *
+ * Old layout:
+ *   {baseDir}/git/          ← git internals (isomorphic-git used 'git' as gitdir)
+ *   {baseDir}/other/        ← non-YAML files
+ *   (Insomnia YAML was virtual / DB-only)
+ *
+ * New layout:
+ *   {baseDir}/.git/         ← standard git internals
+ *   {baseDir}/<file>        ← non-YAML files at root
+ *   {baseDir}/insomnia.{id}.yaml  ← Insomnia YAML on disk AND in DB
+ *
+ * The migration is:
+ *  1. Idempotent – guarded by an ElectronStorage flag per repository.
+ *  2. Best-effort – errors are logged but never fatal; the app still loads.
+ *  3. Run once at repository load time (before VCS initialisation).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { database as db } from '../../common/database';
+import { getInsomniaV5DataExport } from '../../common/insomnia-v5';
+import { initElectronStorage } from '../../main/window-utils';
+import * as models from '../../models';
+import type { Workspace } from '../../models/workspace';
+import type { WorkspaceMeta } from '../../models/workspace-meta';
+
+const MIGRATION_KEY_PREFIX = 'GIT_STRUCTURE_V2_';
+
+function getMigrationKey(gitRepositoryId: string): string {
+  return `${MIGRATION_KEY_PREFIX}${gitRepositoryId}`;
+}
+
+function hasMigrated(gitRepositoryId: string): boolean {
+  const storage = initElectronStorage();
+  return Boolean(storage.getItem<number>(getMigrationKey(gitRepositoryId)));
+}
+
+function markMigrated(gitRepositoryId: string): void {
+  const storage = initElectronStorage();
+  storage.setItem(getMigrationKey(gitRepositoryId), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively move everything inside `srcDir` into `destDir`, then remove
+ * `srcDir`. Files that already exist at the destination are overwritten.
+ */
+async function moveDirectoryContents(srcDir: string, destDir: string): Promise<void> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(srcDir, { withFileTypes: true });
+  } catch {
+    return; // srcDir doesn't exist or isn't readable
+  }
+
+  for (const entry of entries) {
+    const srcPath = path.join(srcDir, entry.name);
+    const destPath = path.join(destDir, entry.name);
+
+    if (entry.isDirectory()) {
+      await fs.promises.mkdir(destPath, { recursive: true });
+      await moveDirectoryContents(srcPath, destPath);
+      try {
+        await fs.promises.rmdir(srcPath);
+      } catch {
+        // Ignore if dir not empty (shouldn't happen after recursive move)
+      }
+    } else {
+      await fs.promises.rename(srcPath, destPath).catch(async () => {
+        // Cross-device rename falls back to copy + delete
+        await fs.promises.copyFile(srcPath, destPath);
+        await fs.promises.unlink(srcPath);
+      });
+    }
+  }
+
+  try {
+    await fs.promises.rmdir(srcDir);
+  } catch {
+    // Not empty or already gone — ignore
+  }
+}
+
+/**
+ * Check whether a directory exists.
+ */
+async function dirExists(dirPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.promises.stat(dirPath);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exported migration entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Migrate the on-disk structure of a git repository to the new layout.
+ * Safe to call on every app load — it is a no-op if already done.
+ *
+ * @param baseDir          Absolute path to the repository root
+ *                         (e.g. `{userData}/version-control/git/{gitRepositoryId}`)
+ * @param projectId        The project that owns this repository
+ * @param gitRepositoryId  Used for the idempotency guard key
+ */
+export async function migrateRepoStructureIfNeeded(
+  baseDir: string,
+  projectId: string,
+  gitRepositoryId: string,
+): Promise<void> {
+  if (hasMigrated(gitRepositoryId)) {
+    return;
+  }
+
+  console.log(`[git-migration] Starting structure migration for repo ${gitRepositoryId}`);
+
+  try {
+    // Step 1: Rename git/ → .git/
+    const oldGitDir = path.join(baseDir, 'git');
+    const newGitDir = path.join(baseDir, '.git');
+
+    if ((await dirExists(oldGitDir)) && !(await dirExists(newGitDir))) {
+      console.log('[git-migration] Renaming git/ → .git/');
+      await fs.promises.rename(oldGitDir, newGitDir).catch(async () => {
+        // Fallback for cross-device issues (unlikely since same volume, but safe)
+        await fs.promises.mkdir(newGitDir, { recursive: true });
+        await moveDirectoryContents(oldGitDir, newGitDir);
+      });
+    }
+
+    // Step 2: Collapse other/ → repo root
+    const otherDir = path.join(baseDir, 'other');
+    if (await dirExists(otherDir)) {
+      console.log('[git-migration] Moving other/ contents to repo root');
+      await moveDirectoryContents(otherDir, baseDir);
+    }
+
+    // Step 3: Flush all Insomnia YAML workspaces to disk so they become real files.
+    // This is a best-effort bootstrap; the routable FS client will keep disk in sync
+    // for all subsequent Git operations.
+    await _flushWorkspacesToDisk(baseDir, projectId);
+
+    markMigrated(gitRepositoryId);
+    console.log(`[git-migration] Migration complete for repo ${gitRepositoryId}`);
+  } catch (err) {
+    console.error('[git-migration] Migration failed (non-fatal):', err);
+  }
+}
+
+/**
+ * Write any workspace in `projectId` that doesn't yet have an on-disk YAML
+ * file to `baseDir`. This bootstraps the dual-sync state for existing repos.
+ */
+async function _flushWorkspacesToDisk(baseDir: string, projectId: string): Promise<void> {
+  const workspaces = await db.find<Workspace>(models.workspace.type, { parentId: projectId });
+
+  for (const workspace of workspaces) {
+    const workspaceMeta = await db.findOne<WorkspaceMeta>(models.workspaceMeta.type, {
+      parentId: workspace._id,
+    });
+
+    // Determine the target file name
+    const gitFilePath: string = workspaceMeta?.gitFilePath || `insomnia.${workspace._id}.yaml`;
+
+    const absPath = path.join(baseDir, gitFilePath);
+
+    // Don't overwrite an existing file — trust disk as the primary store
+    try {
+      await fs.promises.access(absPath);
+      continue; // file already exists
+    } catch {
+      // file does not exist — write it
+    }
+
+    try {
+      const yamlContent = await getInsomniaV5DataExport({
+        workspaceId: workspace._id,
+        includePrivateEnvironments: false,
+      });
+
+      await fs.promises.mkdir(path.dirname(absPath), { recursive: true });
+      await fs.promises.writeFile(absPath, yamlContent, 'utf8');
+      console.log('[git-migration] Flushed workspace to disk:', absPath);
+
+      // Ensure workspaceMeta records the correct gitFilePath
+      if (workspaceMeta && !workspaceMeta.gitFilePath) {
+        await models.workspaceMeta.update(workspaceMeta, { gitFilePath });
+      } else if (!workspaceMeta) {
+        const meta = await models.workspaceMeta.getOrCreateByParentId(workspace._id);
+        await models.workspaceMeta.update(meta, { gitFilePath });
+      }
+    } catch (err) {
+      console.warn('[git-migration] Could not flush workspace', workspace._id, err);
+    }
+  }
+}

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -98,7 +98,7 @@ interface FileStatus {
  * We should set this explicitly (even if set to an empty string), because we have other code (such as fs clients and unit tests) that depend on the clone directory.
  */
 export const GIT_CLONE_DIR = '.';
-const gitInternalDirName = 'git';
+const gitInternalDirName = '.git';
 export const GIT_INSOMNIA_DIR_NAME = '.insomnia';
 export const GIT_INTERNAL_DIR = path.join(GIT_CLONE_DIR, gitInternalDirName); // .git
 export const GIT_INSOMNIA_DIR = path.join(GIT_CLONE_DIR, GIT_INSOMNIA_DIR_NAME); // .insomnia

--- a/packages/insomnia/src/sync/git/project-routable-fs-client.ts
+++ b/packages/insomnia/src/sync/git/project-routable-fs-client.ts
@@ -69,19 +69,49 @@ export function projectRoutableFSClient(
       return [...new Set([...insomniaFiles, ...defaultFiles])];
     }
 
-    // 3) YAML-first writes/reads: prefer insomniaFS (DB). If it throws, fall back to disk.
-    // Also, when writing, collect attempted content into writeFileMap to assist conflict UIs.
+    // 3) YAML files: dual-sync between disk (defaultFS) and DB (insomniaFS).
+    //
+    // - writeFile: write to disk first, then import into DB. Suppressed paths
+    //   (those being written by the watcher itself) skip the DB re-import to
+    //   prevent write loops. Collect content in writeFileMap for conflict UI.
+    // - readFile / stat / lstat: prefer disk; fall back to DB-export.
+    // - unlink: remove from both disk and DB.
     if (filePath.endsWith('.yaml')) {
-      try {
-        const result = await insomniaFS.promises[method]!(filePath, ...args);
-        if (method === 'writeFile' && writeFileMap) {
+      if (method === 'writeFile') {
+        // Write to disk first so the file is real and Git-accessible.
+        await defaultFS.promises.writeFile!(filePath, ...args);
+        // Then import into DB (insomniaFS.writeFile triggers tryImportV5Data).
+        try {
+          await insomniaFS.promises.writeFile!(filePath, ...args);
+        } catch {
+          // Non-fatal: disk write succeeded; DB import failure is logged inside insomniaFS.
+        }
+        if (writeFileMap) {
           writeFileMap[filePath.split(path.win32.sep).join(path.posix.sep)] = args[0].toString();
         }
-        return result;
-      } catch {
-        const result = await defaultFS.promises[method]!(filePath, ...args);
+        return;
+      }
 
-        return result;
+      if (method === 'unlink') {
+        // Best-effort removal from both stores.
+        await Promise.allSettled([defaultFS.promises.unlink!(filePath), insomniaFS.promises.unlink!(filePath)]);
+        return;
+      }
+
+      if (method === 'readFile' || method === 'stat' || method === 'lstat') {
+        // Prefer the real on-disk file; fall back to DB-generated content.
+        try {
+          return await defaultFS.promises[method]!(filePath, ...args);
+        } catch {
+          return await insomniaFS.promises[method]!(filePath, ...args);
+        }
+      }
+
+      // readlink and symlink: delegate to disk.
+      try {
+        return await defaultFS.promises[method]!(filePath, ...args);
+      } catch {
+        return await insomniaFS.promises[method]!(filePath, ...args);
       }
     }
 

--- a/packages/insomnia/src/sync/git/repo-file-watcher.ts
+++ b/packages/insomnia/src/sync/git/repo-file-watcher.ts
@@ -1,0 +1,440 @@
+/**
+ * RepoFileWatcher
+ *
+ * Watches an on-disk git repository directory for changes to Insomnia YAML
+ * files made by external tools (native git CLI, VS Code, etc.) and imports
+ * them back into the NeDB database so the Insomnia UI stays in sync.
+ *
+ * Strategy:
+ *  - Primary:  `fs.watch` with `recursive: true` (Windows + macOS).
+ *              On Linux, individual subdirectories are watched manually because
+ *              Node's `fs.watch` does not support `recursive` there.
+ *  - Fallback: Periodic polling (default 10 s) compares mtime against the last
+ *              known sync time so no change is ever permanently missed.
+ *
+ * Write-loop prevention:
+ *  When Insomnia itself writes a YAML file (e.g. via git pull / merge), it
+ *  calls `suppressPath` before the write and `unsuppressPath` after. Events
+ *  for suppressed paths are silently dropped.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { database as db } from '../../common/database';
+import { InsomniaFileTypeValues } from '../../common/import-v5-parser';
+import { getInsomniaV5DataExport, tryImportV5Data } from '../../common/insomnia-v5';
+import { canSync } from '../../models';
+import * as models from '../../models';
+import { isWorkspace } from '../../models/workspace';
+import type { WorkspaceMeta } from '../../models/workspace-meta';
+
+const POLL_INTERVAL_MS = 10_000;
+const DEBOUNCE_MS = 300;
+const GIT_DIR = '.git';
+
+class RepoFileWatcher {
+  private readonly repoDir: string;
+  private readonly projectId: string;
+
+  private fsWatchers: fs.FSWatcher[] = [];
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  /** mtime (ms) of the last successful import for each absolute file path */
+  private lastSyncMtime = new Map<string, number>();
+  /** Paths currently being written by Insomnia – watcher events are dropped for these */
+  private suppressedPaths = new Set<string>();
+  private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /** True while Insomnia is writing YAML to disk – prevents the onChange flush from looping */
+  private isFlushing = false;
+  /** Debounce timer for the DB→disk outbound flush */
+  private flushDebounce: ReturnType<typeof setTimeout> | null = null;
+  /** Set to true by stop() so async callbacks can bail out cleanly */
+  private stopped = false;
+
+  constructor(repoDir: string, projectId: string) {
+    this.repoDir = repoDir;
+    this.projectId = projectId;
+
+    this.startFsWatch();
+    this.startPolling();
+    this.registerDbChangeListener();
+    // Populate initial mtimes so that future external changes (e.g. git restore)
+    // can be detected by comparing disk mtime against this baseline.
+    this.initSyncMtimes().catch(err => {
+      console.warn('[repo-file-watcher] init mtime scan error:', err);
+    });
+  }
+
+  stop(): void {
+    this.stopped = true;
+
+    for (const w of this.fsWatchers) {
+      try {
+        w.close();
+      } catch {
+        // ignore
+      }
+    }
+
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+    }
+
+    for (const t of this.debounceTimers.values()) {
+      clearTimeout(t);
+    }
+
+    if (this.flushDebounce) {
+      clearTimeout(this.flushDebounce);
+    }
+  }
+
+  /**
+   * Suppress watcher events for `filePath` to prevent write loops when Insomnia
+   * itself is writing the file. Call `unsuppress` once the write is done.
+   */
+  suppress(filePath: string): void {
+    this.suppressedPaths.add(path.normalize(filePath));
+  }
+
+  /** Resume watching a previously suppressed path. */
+  unsuppress(filePath: string): void {
+    this.suppressedPaths.delete(path.normalize(filePath));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private methods
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Register a database onChange listener that flushes workspace YAML to disk
+   * whenever synced documents change (DB → disk direction).
+   *
+   * This is the counterpart to the fs.watch flow (disk → DB). Without this,
+   * changes made through the Insomnia UI would update the DB but leave stale
+   * files on disk, so isomorphic-git would see no diff.
+   */
+  private registerDbChangeListener(): void {
+    db.onChange(changes => {
+      // Drop if watcher was stopped or if we're in the middle of a flush (loop guard)
+      if (this.stopped || this.isFlushing) {
+        return;
+      }
+
+      // Only react to changes for syncable documents
+      const hasSyncableChange = changes.some(([, doc]) => canSync(doc));
+      if (!hasSyncableChange) {
+        return;
+      }
+
+      // Debounce: coalesce rapid bursts (e.g. importing a large collection) into one flush
+      if (this.flushDebounce) {
+        clearTimeout(this.flushDebounce);
+      }
+      this.flushDebounce = setTimeout(() => {
+        this.flushDebounce = null;
+        this.flushProjectWorkspacesToDisk().catch(err => {
+          console.warn('[repo-file-watcher] DB→disk flush error:', err);
+        });
+      }, DEBOUNCE_MS);
+    });
+  }
+
+  /**
+   * Re-export every workspace in the project to its on-disk YAML file.
+   * Called after DB changes so that `git status` / `git diff` reflect the
+   * current database state.
+   */
+  private async flushProjectWorkspacesToDisk(): Promise<void> {
+    // Guard: skip if the watcher was stopped or a previous flush is still running
+    if (this.stopped || this.isFlushing) {
+      return;
+    }
+
+    this.isFlushing = true;
+    try {
+      const workspaces = await db.find(models.workspace.type, { parentId: this.projectId });
+
+      for (const workspace of workspaces) {
+        const workspaceMeta = await db.findOne<WorkspaceMeta>(models.workspaceMeta.type, {
+          parentId: workspace._id,
+        });
+
+        const gitFilePath: string = workspaceMeta?.gitFilePath || `insomnia.${workspace._id}.yaml`;
+        const absPath = path.normalize(path.join(this.repoDir, gitFilePath));
+
+        // Before overwriting, check whether the file was externally modified
+        // (e.g. via `git restore`) since we last tracked it. If the disk mtime is
+        // newer than our baseline, defer to the disk version by importing it into
+        // the DB and skipping the write — this respects the user's git operation.
+        const lastKnownMtime = this.lastSyncMtime.get(absPath);
+        if (lastKnownMtime !== undefined) {
+          try {
+            const diskStat = await fs.promises.stat(absPath);
+            if (diskStat.mtimeMs > lastKnownMtime) {
+              await this.importFile(absPath);
+              continue;
+            }
+          } catch {
+            // File doesn't exist on disk yet — proceed to write it.
+          }
+        }
+
+        // Suppress the path so the fs.watch event triggered by our own write
+        // does not reimport the file we just wrote.
+        this.suppressedPaths.add(absPath);
+        try {
+          const yamlContent = await getInsomniaV5DataExport({
+            workspaceId: workspace._id,
+            includePrivateEnvironments: false,
+          });
+
+          await fs.promises.mkdir(path.dirname(absPath), { recursive: true });
+          await fs.promises.writeFile(absPath, yamlContent, 'utf8');
+
+          // Update the tracked mtime so the polling loop doesn't re-import the file
+          const stat = await fs.promises.stat(absPath);
+          this.lastSyncMtime.set(absPath, stat.mtimeMs);
+        } catch (err) {
+          console.warn('[repo-file-watcher] Could not flush workspace to disk:', workspace._id, err);
+        } finally {
+          // Unsuppress after a short delay to let the fs.watch event fire and be dropped
+          setTimeout(() => this.suppressedPaths.delete(absPath), DEBOUNCE_MS * 2);
+        }
+      }
+    } finally {
+      this.isFlushing = false;
+    }
+  }
+
+  /**
+   * Scan all YAML files in the repo directory and record their current mtimes as
+   * the initial baseline. This lets `flushProjectWorkspacesToDisk` detect files
+   * that are subsequently modified externally (e.g. via `git restore`) by
+   * comparing against this snapshot.
+   */
+  private async initSyncMtimes(): Promise<void> {
+    await this.scanMtimes(this.repoDir);
+  }
+
+  private async scanMtimes(dir: string): Promise<void> {
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const absPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === GIT_DIR) {
+          continue;
+        }
+        await this.scanMtimes(absPath);
+      } else if (entry.isFile() && entry.name.endsWith('.yaml')) {
+        try {
+          const stat = await fs.promises.stat(absPath);
+          this.lastSyncMtime.set(path.normalize(absPath), stat.mtimeMs);
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }
+
+  private startFsWatch(): void {
+    try {
+      // On Windows and macOS, `recursive: true` covers the whole tree in one call.
+      // On Linux this option is silently ignored, so we fall back to watching the
+      // root directory only and rely on polling to catch deep changes.
+      const watcher = fs.watch(this.repoDir, { recursive: true }, (_eventType, filename) => {
+        if (!filename) {
+          return;
+        }
+        const absPath = path.join(this.repoDir, filename);
+        this.scheduleImport(absPath);
+      });
+
+      watcher.on('error', err => {
+        console.warn('[repo-file-watcher] fs.watch error:', err);
+      });
+
+      this.fsWatchers.push(watcher);
+    } catch (err) {
+      console.warn('[repo-file-watcher] Could not start fs.watch, relying on polling only:', err);
+    }
+  }
+
+  private startPolling(): void {
+    this.pollTimer = setInterval(() => {
+      this.pollDirectory(this.repoDir).catch(err => {
+        console.warn('[repo-file-watcher] poll error:', err);
+      });
+    }, POLL_INTERVAL_MS);
+  }
+
+  private async pollDirectory(dir: string): Promise<void> {
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const absPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        // Skip .git internals
+        if (entry.name === GIT_DIR) {
+          continue;
+        }
+        await this.pollDirectory(absPath);
+      } else if (entry.isFile() && entry.name.endsWith('.yaml')) {
+        try {
+          const stat = await fs.promises.stat(absPath);
+          const lastMtime = this.lastSyncMtime.get(absPath) ?? 0;
+          if (stat.mtimeMs > lastMtime) {
+            await this.importFile(absPath);
+          }
+        } catch {
+          // File may have been removed between readdir and stat; ignore.
+        }
+      }
+    }
+  }
+
+  private scheduleImport(absPath: string): void {
+    // Only process YAML files outside .git
+    if (!absPath.endsWith('.yaml')) {
+      return;
+    }
+    if (this.isInGitDir(absPath)) {
+      return;
+    }
+
+    // Debounce: discard previous timer for this path
+    const existing = this.debounceTimers.get(absPath);
+    if (existing) {
+      clearTimeout(existing);
+    }
+
+    const timer = setTimeout(() => {
+      this.debounceTimers.delete(absPath);
+      this.importFile(absPath).catch(err => {
+        console.warn('[repo-file-watcher] import error for', absPath, err);
+      });
+    }, DEBOUNCE_MS);
+
+    this.debounceTimers.set(absPath, timer);
+  }
+
+  private isInGitDir(absPath: string): boolean {
+    const rel = path.relative(this.repoDir, absPath);
+    return rel.startsWith(GIT_DIR + path.sep) || rel === GIT_DIR;
+  }
+
+  private async importFile(absPath: string): Promise<void> {
+    const normalised = path.normalize(absPath);
+
+    // Drop events for paths Insomnia is currently writing
+    if (this.suppressedPaths.has(normalised)) {
+      return;
+    }
+
+    let content: string;
+    try {
+      content = await fs.promises.readFile(absPath, 'utf8');
+    } catch {
+      // File deleted or not readable; ignore
+      return;
+    }
+
+    // Skip files that don't look like Insomnia V5 YAML
+    const firstLine = content.split('\n')[0].trim();
+    const isInsomniaFile = InsomniaFileTypeValues.some(t => firstLine.includes(t));
+    if (!isInsomniaFile) {
+      return;
+    }
+
+    // Skip files that contain Git conflict markers — they are not importable yet
+    const lines = content.split('\n');
+    if (lines.some(l => l.startsWith('<<<<<<<') || l.startsWith('>>>>>>>'))) {
+      console.warn('[repo-file-watcher] Skipping conflicted file:', absPath);
+      return;
+    }
+
+    const { data: docs, error } = tryImportV5Data(content);
+    if (error || !docs) {
+      console.warn('[repo-file-watcher] Failed to parse', absPath, error);
+      return;
+    }
+
+    const bufferId = await db.bufferChanges();
+    try {
+      for (const doc of docs) {
+        if (isWorkspace(doc)) {
+          doc.parentId = this.projectId;
+          // Update workspaceMeta with the relative file path so routing still works
+          const relPath = path.relative(this.repoDir, absPath);
+          const workspaceMeta = await models.workspaceMeta.getOrCreateByParentId(doc._id);
+          await models.workspaceMeta.update(workspaceMeta, {
+            gitFilePath: relPath.split(path.sep).join(path.posix.sep),
+          });
+        }
+        await db.update(doc);
+      }
+
+      // Record the mtime so polling doesn't re-import the same version
+      try {
+        const stat = await fs.promises.stat(absPath);
+        this.lastSyncMtime.set(normalised, stat.mtimeMs);
+      } catch {
+        // ignore stat failure
+      }
+    } finally {
+      await db.flushChanges(bufferId);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level registry & public API
+// ---------------------------------------------------------------------------
+
+/** Per-repo-id watcher instances */
+const watchers = new Map<string, RepoFileWatcher>();
+
+/**
+ * Start watching `repoDir` for external YAML changes.
+ * Safe to call multiple times for the same repoId; subsequent calls are no-ops.
+ */
+export function startWatcher(repoId: string, repoDir: string, projectId: string): void {
+  if (watchers.has(repoId)) {
+    return;
+  }
+  watchers.set(repoId, new RepoFileWatcher(repoDir, projectId));
+}
+
+/** Stop watching and clean up resources for a given repoId. */
+export function stopWatcher(repoId: string): void {
+  const watcher = watchers.get(repoId);
+  if (!watcher) {
+    return;
+  }
+  watcher.stop();
+  watchers.delete(repoId);
+}
+
+/**
+ * Suppress watcher events for `filePath` to prevent write loops when Insomnia
+ * itself is writing the file. Call `unsuppressPath` once the write is done.
+ */
+export function suppressPath(repoId: string, filePath: string): void {
+  watchers.get(repoId)?.suppress(filePath);
+}
+
+/** Resume watching a previously suppressed path. */
+export function unsuppressPath(repoId: string, filePath: string): void {
+  watchers.get(repoId)?.unsuppress(filePath);
+}

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -155,6 +155,16 @@ export const ProjectSettingsForm: FC<Props> = ({
     gitRepository?.credentialsId &&
     selectedProvider;
 
+  const showRepoPath =
+    storageType === 'git' &&
+    !isSwitchingStorageType(project!, storageType) &&
+    project?.gitRepositoryId !== EMPTY_GIT_PROJECT_ID &&
+    Boolean(gitRepository?._id);
+
+  const repoPath = showRepoPath
+    ? window.path.join(window.app.getPath('userData'), 'version-control', 'git', gitRepository!._id)
+    : '';
+
   const showGitRepoForm =
     storageType === 'git' &&
     ((isGitSyncEnabled && isSwitchingStorageType(project!, storageType)) ||
@@ -183,6 +193,7 @@ export const ProjectSettingsForm: FC<Props> = ({
 
   const showEmailSelector = showGitConnectionInfo && canFetchEmails;
   const [isEmailSelectOpen, setIsEmailSelectOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   useEffect(() => {
     if (canFetchEmails && selectedCredential && emailsFetcher.state === 'idle' && !emailsFetcher.data) {
@@ -402,6 +413,34 @@ export const ProjectSettingsForm: FC<Props> = ({
                   </div>
                 </div>
               ) : null}
+            </>
+          )}
+          {showRepoPath && (
+            <>
+              <Divider />
+              <div className="flex flex-col gap-2">
+                <div className="text-sm font-semibold">Local repository path</div>
+                <div className="flex items-center gap-2">
+                  <span className="min-w-0 flex-1 truncate rounded-xs border border-solid border-(--hl-sm) bg-(--hl-xs) px-2 py-1 font-mono text-xs text-(--color-font)">
+                    {repoPath}
+                  </span>
+                  <Button
+                    onPress={() => {
+                      window.clipboard.writeText(repoPath);
+                      setCopied(true);
+                      setTimeout(() => setCopied(false), 2000);
+                    }}
+                    className="flex shrink-0 items-center gap-1.5 rounded-xs border border-solid border-(--hl-sm) px-2 py-1 text-xs text-(--color-font) transition-colors hover:bg-(--hl-xs)"
+                    aria-label="Copy repository path"
+                  >
+                    <Icon icon={copied ? 'check' : 'copy'} />
+                    <span>{copied ? 'Copied!' : 'Copy'}</span>
+                  </Button>
+                </div>
+                <div className="text-xs text-(--hl-lg)">
+                  Open this path in your terminal to use native Git commands.
+                </div>
+              </div>
             </>
           )}
           {showGitRepoForm && (


### PR DESCRIPTION
# Overview

Prior to this work, Insomnia stored its git repositories with a layout that was internal to the app and invisible to standard Git tooling:

```
{userData}/version-control/git/{repoId}/
  git/          ← git internals (non-standard folder name)
  other/        ← all non-Insomnia files
  (Insomnia YAML files existed only in the NeDB database — never on disk)
```

This prevented users from running any native Git command (git log, git diff, git rebase, VSCode source-control, etc.) against a cloned repository, even though the data was conceptually a real Git repo. It also made it impossible to integrate Insomnia repositories into broader developer workflows.

## Goals

- Native Git compatibility — The repository on disk must be a first-class Git repository that any Git client can operate against without any knowledge of Insomnia internals.

- Bidirectional sync — Changes made inside Insomnia (new requests, environment edits, etc.) must appear as real file changes on disk. Changes made on disk (native git pull, merge, rebase, VSCode edits) must be reflected in the Insomnia UI and database.

- Zero data loss migration — Existing cloned repositories must be migrated silently and safely, without any action from the user.

- Correctness under concurrency — The sync loop must not produce duplicate writes, import loops, or data corruption when both Insomnia and native Git are operating near-simultaneously.

- Scope — The modern project-scoped code path (GitProjectNeDBClient) is the target. The legacy workspace-scoped path (NeDBClient / .insomnia/ directory) is left unchanged for backward compatibility.