### PR TITLE
fix: WebSocket requests inherit auth and headers from parent folders

### DIFF
--- a/packages/insomnia/src/ui/components/websockets/action-bar.tsx
+++ b/packages/insomnia/src/ui/components/websockets/action-bar.tsx
@@ -7,9 +7,12 @@ import {
 } from '~/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.connect';
 import { OneLineEditor, type OneLineEditorHandle } from '~/ui/components/.client/codemirror/one-line-editor';
 
+import { database as db } from '../../../common/database';
 import * as models from '../../../models';
 import type { SocketIORequest } from '../../../models/socket-io-request';
+import { isRequestGroup, type RequestGroup } from '../../../models/request-group';
 import type { WebSocketRequest } from '../../../models/websocket-request';
+import { getOrInheritAuthentication, getOrInheritHeaders } from '../../../network/network';
 import { tryToInterpolateRequestOrShowRenderErrorModal } from '../../../utils/try-interpolate';
 import { buildQueryStringFromParams, joinUrlAndQueryString } from '../../../utils/url/querystring';
 import { useInsomniaTabContext } from '../../context/app/insomnia-tab-context';
@@ -63,14 +66,20 @@ export const WebSocketActionBar = forwardRef<WebSocketActionBarHandle, ActionBar
       // Render any nunjucks tags in the url/headers/authentication settings/cookies
 
       const workspaceCookieJar = await models.cookieJar.getOrCreateForParentId(workspaceId);
+      // Get parent folders for auth/header inheritance
+      const ancestors = await db.withAncestors<WebSocketRequest | SocketIORequest | RequestGroup>(request, [models.requestGroup.type]);
+      const requestGroups = ancestors.filter(isRequestGroup) as RequestGroup[];
+      // Apply auth/header inheritance from parent folders
+      const inheritedAuth = getOrInheritAuthentication({ request, requestGroups });
+      const inheritedHeaders = getOrInheritHeaders({ request, requestGroups });
       // Render any nunjucks tags in the url/headers/authentication settings/cookies
       const rendered = await tryToInterpolateRequestOrShowRenderErrorModal({
         request,
         environmentId,
         payload: {
           url: request.url,
-          headers: request.headers,
-          authentication: request.authentication,
+          headers: inheritedHeaders,
+          authentication: inheritedAuth,
           parameters: request.parameters.filter(p => !p.disabled),
           workspaceCookieJar,
         },

--- a/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
+++ b/packages/insomnia/src/ui/components/websockets/websocket-request-pane.tsx
@@ -10,11 +10,14 @@ import { CodeEditor, type CodeEditorHandle } from '~/ui/components/.client/codem
 import { OneLineEditor } from '~/ui/components/.client/codemirror/one-line-editor';
 
 import { type AuthTypes, CONTENT_TYPE_JSON } from '../../../common/constants';
+import { database as db } from '../../../common/database';
 import * as models from '../../../models';
 import type { Environment } from '../../../models/environment';
 import { getCombinedPathParametersFromUrl, type RequestPathParameter } from '../../../models/request';
+import { isRequestGroup, type RequestGroup } from '../../../models/request-group';
 import type { WebSocketRequest } from '../../../models/websocket-request';
 import { getAuthObjectOrNull } from '../../../network/authentication';
+import { getOrInheritAuthentication, getOrInheritHeaders } from '../../../network/network';
 import {
   useRequestLoaderData,
   type WebSocketRequestLoaderData,
@@ -91,13 +94,19 @@ const WebSocketRequestForm: FC<FormProps> = ({ request, previewMode, environment
       const readyState = await window.main.webSocket.readyState.getCurrent({ requestId: request._id });
       if (!readyState) {
         const workspaceCookieJar = await models.cookieJar.getOrCreateForParentId(workspaceId);
+        // Get parent folders for auth/header inheritance
+        const ancestors = await db.withAncestors<WebSocketRequest | RequestGroup>(request, [models.requestGroup.type]);
+        const requestGroups = ancestors.filter(isRequestGroup) as RequestGroup[];
+        // Apply auth/header inheritance from parent folders
+        const inheritedAuth = getOrInheritAuthentication({ request, requestGroups });
+        const inheritedHeaders = getOrInheritHeaders({ request, requestGroups });
         const rendered = await tryToInterpolateRequestOrShowRenderErrorModal({
           request,
           environmentId,
           payload: {
             url: request.url,
-            headers: request.headers,
-            authentication: request.authentication,
+            headers: inheritedHeaders,
+            authentication: inheritedAuth,
             parameters: request.parameters.filter(p => !p.disabled),
             workspaceCookieJar,
           },


### PR DESCRIPTION
## Summary

Fixes #9666

WebSocket requests were not inheriting authentication and headers from parent folders, while regular HTTP requests did. This PR applies the same inheritance logic used for HTTP requests to WebSocket and Socket.IO requests.

## Changes

- **websocket-request-pane.tsx**: Apply `getOrInheritAuthentication` and `getOrInheritHeaders` before rendering request
- **action-bar.tsx**: Apply inheritance for both WebSocket and Socket.IO requests when establishing connections

Both files now follow the same pattern as `request-url-bar.tsx` for consistency.

## Testing

1. Create a folder with authentication (e.g., Bearer token) and/or headers
2. Create a WebSocket request inside that folder
3. Leave the WebSocket request's auth as "Inherit from parent"
4. Connect to a WebSocket endpoint - the auth/headers should now be inherited from the parent folder

## Checklist

- [x] Code follows project patterns (same approach as request-url-bar.tsx)
- [x] TypeScript compilation passes
- [x] Fixes confirmed bug reported in #9666