### PR TITLE
fix: Execute bundle plugin actions with correct execution environment

### DIFF
--- a/packages/insomnia-smoke-test/server/index.ts
+++ b/packages/insomnia-smoke-test/server/index.ts
@@ -144,6 +144,13 @@ app.get('/updates/win', (request, response) => {
     name: '11.6.1',
   });
 });
+// mock endpoint for azure oauth config, used in external vault integration test
+app.get('/v1/oauth/azure/config', (_req, res) => {
+  res.status(200).send({
+    clientID: 'test_client_id',
+    clientRedirectURI: 'https://login.microsoftonline.com',
+  });
+});
 
 startWebSocketServer(
   app.listen(port, () => {

--- a/packages/insomnia-smoke-test/tests/smoke/external-vault-integration.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/external-vault-integration.test.ts
@@ -46,6 +46,24 @@ test('Setup external vault and used in request', async ({ app, page }) => {
   await page.getByRole('textbox', { name: 'Secret Id:' }).fill('secret-id');
   await page.getByRole('dialog').getByRole('button', { name: 'Create', exact: true }).click();
   await expect.soft(page.getByRole('cell', { name: hashicorpCredentialName })).toBeVisible();
+  // test azure credential should open new browser window with correct url
+  // Replace shell.openExternal
+  await app.evaluate(({ shell }) => {
+    shell.openExternal = async url => {
+      // @ts-expect-error -- add url to globalThis to verify the url in test
+      globalThis.__lastOpenedExternalUrl = url;
+      return;
+    };
+  });
+  await page.getByRole('button', { name: 'Create Cloud Credential' }).click();
+  await page.getByRole('menuitemradio', { name: 'Azure' }).click();
+  await page.getByText('Authenticate With Azure').first().click();
+  // @ts-expect-error -- add url to globalThis to verify the url in test
+  const azureAuthUrl = await app.evaluate(() => globalThis.__lastOpenedExternalUrl);
+  console.log('azureAuthUrl', azureAuthUrl);
+  expect.soft(azureAuthUrl).toContain('https://login.microsoftonline.com/');
+  await page.locator('#close-add-cloud-credential-modal').click();
+
   // close the settings
   await page.locator('.app').press('Escape');
 

--- a/packages/insomnia-smoke-test/tests/smoke/external-vault-integration.test.ts
+++ b/packages/insomnia-smoke-test/tests/smoke/external-vault-integration.test.ts
@@ -60,7 +60,6 @@ test('Setup external vault and used in request', async ({ app, page }) => {
   await page.getByText('Authenticate With Azure').first().click();
   // @ts-expect-error -- add url to globalThis to verify the url in test
   const azureAuthUrl = await app.evaluate(() => globalThis.__lastOpenedExternalUrl);
-  console.log('azureAuthUrl', azureAuthUrl);
   expect.soft(azureAuthUrl).toContain('https://login.microsoftonline.com/');
   await page.locator('#close-add-cloud-credential-modal').click();
 

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -308,6 +308,6 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
         return targetAction.action({ ...commonContext, ...context }, params);
       }
     }
-    throw new Error(`Unsupported tag ${actionName} for plugin ${pluginName}`);
+    throw new Error(`Unsupported action named ${actionName} for plugin ${pluginName}`);
   },
 };

--- a/packages/insomnia/src/main/templating-worker-database.ts
+++ b/packages/insomnia/src/main/templating-worker-database.ts
@@ -290,4 +290,24 @@ const pluginToMainAPI: Record<PluginToMainAPIPaths, (...args: any[]) => Promise<
     }
     throw new Error(`Unsupported tag ${tagName} for plugin ${pluginName}`);
   },
+  // execute the plugin exported main action with the given parameters
+  'plugin.executeBundlePluginMainAction': async (body: {
+    pluginName: string;
+    actionName: string;
+    context?: Record<string, any>;
+    params?: Record<string, any>;
+  }) => {
+    const { pluginName, actionName, context, params } = body;
+    const appBundlePluginNames = getAppBundlePlugins().map(p => p.name);
+    if (appBundlePluginNames.includes(pluginName)) {
+      const module = getBundlePluginModule(pluginName);
+      const pluginActions = module?.unsafePluginMainActions || [];
+      const targetAction = pluginActions.find(action => action.name === actionName);
+      if (targetAction) {
+        const commonContext = getPluginCommonContext({ plugin: { name: pluginName } });
+        return targetAction.action({ ...commonContext, ...context }, params);
+      }
+    }
+    throw new Error(`Unsupported tag ${actionName} for plugin ${pluginName}`);
+  },
 };

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -384,11 +384,10 @@ export function getPluginCommonContext({
     ...pluginStore.init(plugin),
     ...pluginNetwork.init(),
     util: {
-      openInBrowser: async (url: string) => {
+      openInBrowser: async (url: string) =>
         process.type === 'renderer' || process.type === 'worker'
           ? window.main.openInBrowser(url)
-          : (await import('electron')).shell.openExternal(url);
-      },
+          : electron.shell.openExternal(url),
       models: {
         request: {
           getById: models.request.getById,
@@ -427,8 +426,8 @@ export function getPluginCommonContext({
   };
 }
 
-// This is for insomnia UI to reach out to bundled plugin functions and executed under render process or main process(by default)
-// It should only be available to bundled plugins, not for public plugins
+// Allows Insomnia UI to invoke bundled plugin actions from either the renderer process or the main process (default).
+// This entry point is only exposed to bundled plugins, not to public/third‑party plugins.
 export async function executePluginMainAction({
   pluginName,
   actionName,

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -5,6 +5,7 @@ import electron from 'electron';
 
 import { services } from '~/insomnia-data';
 import { getBodyBuffer } from '~/models/helpers/response-operations';
+import { fetchFromTemplateWorkerDatabase } from '~/templating/base-extension-worker';
 
 import type { ParsedApiSpec } from '../common/api-specs';
 import { getAppBundlePlugins, isDevelopment } from '../common/constants';
@@ -383,7 +384,11 @@ export function getPluginCommonContext({
     ...pluginStore.init(plugin),
     ...pluginNetwork.init(),
     util: {
-      openInBrowser: (url: string) => window.main.openInBrowser(url),
+      openInBrowser: async (url: string) => {
+        process.type === 'renderer' || process.type === 'worker'
+          ? window.main.openInBrowser(url)
+          : (await import('electron')).shell.openExternal(url);
+      },
       models: {
         request: {
           getById: models.request.getById,
@@ -422,7 +427,7 @@ export function getPluginCommonContext({
   };
 }
 
-// This is for insomnia UI to reach out to bundled plugin functions and executed under main process(node integration) context
+// This is for insomnia UI to reach out to bundled plugin functions and executed under render process(by default) or main process
 // It should only be available to bundled plugins, not for public plugins
 export async function executePluginMainAction({
   pluginName,
@@ -435,17 +440,27 @@ export async function executePluginMainAction({
   context?: Record<string, any>;
   params?: Record<string, any>;
 }): Promise<any> {
-  const bundlePlugins = await getBundlePlugins();
-  const plugin = bundlePlugins.find(p => p.name === pluginName);
-  if (!plugin) {
-    throw new Error(`Plugin ${pluginName} not found`);
+  const settings = await services.settings.get();
+  if (settings.pluginsAllowElevatedAccess) {
+    const bundlePlugins = await getBundlePlugins();
+    const plugin = bundlePlugins.find(p => p.name === pluginName);
+    if (!plugin) {
+      throw new Error(`Plugin ${pluginName} not found`);
+    }
+    const action = plugin.module.unsafePluginMainActions?.find(p => p.name === actionName);
+    if (!action) {
+      throw new Error(`Action ${actionName} not found in plugin ${pluginName}`);
+    }
+    const commonContext = getPluginCommonContext({ plugin });
+    return action.action({ ...commonContext, ...context }, params);
   }
-  const action = plugin.module.unsafePluginMainActions?.find(p => p.name === actionName);
-  if (!action) {
-    throw new Error(`Action ${actionName} not found in plugin ${pluginName}`);
-  }
-  const commonContext = getPluginCommonContext({ plugin });
-  return action.action({ ...commonContext, ...context }, params);
+  const result = await fetchFromTemplateWorkerDatabase('plugin.executeBundlePluginMainAction', {
+    pluginName,
+    actionName,
+    context,
+    params,
+  });
+  return result;
 }
 
 export async function getRequestHooks(): Promise<RequestHook[]> {

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -441,6 +441,7 @@ export async function executePluginMainAction({
   params?: Record<string, any>;
 }): Promise<any> {
   const settings = await services.settings.get();
+  // Execute the plugin action directly in the renderer process, to keep to same execution context as plugin tags
   if (settings.pluginsAllowElevatedAccess) {
     const bundlePlugins = await getBundlePlugins();
     const plugin = bundlePlugins.find(p => p.name === pluginName);
@@ -454,6 +455,7 @@ export async function executePluginMainAction({
     const commonContext = getPluginCommonContext({ plugin });
     return action.action({ ...commonContext, ...context }, params);
   }
+  // Use the template worker database to execute the plugin action in main process
   const result = await fetchFromTemplateWorkerDatabase('plugin.executeBundlePluginMainAction', {
     pluginName,
     actionName,

--- a/packages/insomnia/src/plugins/index.ts
+++ b/packages/insomnia/src/plugins/index.ts
@@ -427,7 +427,7 @@ export function getPluginCommonContext({
   };
 }
 
-// This is for insomnia UI to reach out to bundled plugin functions and executed under render process(by default) or main process
+// This is for insomnia UI to reach out to bundled plugin functions and executed under render process or main process(by default)
 // It should only be available to bundled plugins, not for public plugins
 export async function executePluginMainAction({
   pluginName,
@@ -441,7 +441,7 @@ export async function executePluginMainAction({
   params?: Record<string, any>;
 }): Promise<any> {
   const settings = await services.settings.get();
-  // Execute the plugin action directly in the renderer process, to keep to same execution context as plugin tags
+  // Execute the plugin action directly in renderer process when allow elevated access.
   if (settings.pluginsAllowElevatedAccess) {
     const bundlePlugins = await getBundlePlugins();
     const plugin = bundlePlugins.find(p => p.name === pluginName);

--- a/packages/insomnia/src/templating/types.ts
+++ b/packages/insomnia/src/templating/types.ts
@@ -46,7 +46,8 @@ export type PluginToMainAPIPaths =
   | 'network.sendRequest'
   | 'network.sendRequestWithoutSideEffects'
   | 'plugin.getBundlePluginTemplateTags'
-  | 'plugin.executeBundlePluginTag';
+  | 'plugin.executeBundlePluginTag'
+  | 'plugin.executeBundlePluginMainAction';
 
 export type RenderedRequest = Request & {
   cookies: {


### PR DESCRIPTION
## Background
Currently, the `executePluginMainAction` will execute bundle plugin exported actions in renderer process,  regardless of the  `Allow elevated access for plugins` setting. 
This causes issues because Nujuck tag related bundle plugins are imported in either the main or renderer process depending on that setting. Running actions in the wrong context means they may fail to read or modify shared global state, since they execute in a different process than where the plugin was loaded.

## Changes
- Execute `executePluginMainAction` based on `Allow elevated access for plugins` option.


[INS-2279](https://konghq.atlassian.net/browse/INS-2279)

[INS-2279]: https://konghq.atlassian.net/browse/INS-2279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ