### PR TITLE
fix: add line clamp limit for delete workspace model 

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
@@ -300,9 +300,11 @@ export const WorkspaceCardDropdown: FC<Props> = props => {
                   >
                     <input type="hidden" name="workspaceId" value={workspace._id} />
                     <div>
-                      This will permanently delete the{' '}
-                      {<strong style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>{workspace?.name}</strong>}{' '}
-                      {getWorkspaceLabel(workspace).singular}
+                      <p className="line-clamp-5">
+                        This will permanently delete the{' '}
+                        <strong className="break-all whitespace-pre-wrap">{workspace?.name}</strong>{' '}
+                        {getWorkspaceLabel(workspace).singular}
+                      </p>
                       {isRemoteProject(project) && (
                         <RadioGroup name="localOnly" defaultValue="false" className="mb-2 flex flex-col gap-2">
                           <Label className="text-sm text-(--hl)">How do you want to delete it?</Label>

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
@@ -456,13 +456,11 @@ export const WorkspaceDropdown: FC<{}> = () => {
                   >
                     <input type="hidden" name="workspaceId" value={activeWorkspace._id} />
                     <div>
-                      This will permanently delete the{' '}
-                      {
-                        <strong style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
-                          {activeWorkspace?.name}
-                        </strong>
-                      }{' '}
-                      {getWorkspaceLabel(activeWorkspace).singular}
+                      <p className="line-clamp-5">
+                        This will permanently delete the{' '}
+                        <strong className="break-all whitespace-pre-wrap">{activeWorkspace?.name}</strong>{' '}
+                        {getWorkspaceLabel(activeWorkspace).singular}
+                      </p>
                       {isRemoteProject(activeProject) && (
                         <RadioGroup name="localOnly" defaultValue="false" className="mb-2 flex flex-col gap-2">
                           <Label className="text-sm text-(--hl)">How do you want to delete it?</Label>


### PR DESCRIPTION
Add line clamp limit for delete workspace model to avoid very long name to cover the modal content
