### PR TITLE
Validate credentials

### DIFF
--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -112,6 +112,7 @@ const git: GitServiceAPI = {
   getGitBranches: options => ipcRenderer.invoke('git.getGitBranches', options),
   fetchGitRemoteBranches: options => ipcRenderer.invoke('git.fetchGitRemoteBranches', options),
   validateGitRepositoryCredentials: options => ipcRenderer.invoke('git.validateGitRepositoryCredentials', options),
+  validateGitCredentialById: options => ipcRenderer.invoke('git.validateGitCredentialById', options),
   gitFetchAction: options => ipcRenderer.invoke('git.gitFetchAction', options),
   gitLogLoader: options => ipcRenderer.invoke('git.gitLogLoader', options),
   gitChangesLoader: options => ipcRenderer.invoke('git.gitChangesLoader', options),

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -111,6 +111,7 @@ const git: GitServiceAPI = {
   loadGitRepository: options => ipcRenderer.invoke('git.loadGitRepository', options),
   getGitBranches: options => ipcRenderer.invoke('git.getGitBranches', options),
   fetchGitRemoteBranches: options => ipcRenderer.invoke('git.fetchGitRemoteBranches', options),
+  validateGitRepositoryCredentials: options => ipcRenderer.invoke('git.validateGitRepositoryCredentials', options),
   gitFetchAction: options => ipcRenderer.invoke('git.gitFetchAction', options),
   gitLogLoader: options => ipcRenderer.invoke('git.gitLogLoader', options),
   gitChangesLoader: options => ipcRenderer.invoke('git.gitChangesLoader', options),

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -291,6 +291,32 @@ export async function validateGitRepositoryCredentials({
   }
 }
 
+/**
+ * Validates a credential by its ID without requiring a repo URI.
+ * Works for OAuth providers (GitHub, GitLab) which have a dedicated validate endpoint.
+ * PAT/custom credentials are skipped since they require a repo URI to validate.
+ */
+export async function validateGitCredentialById({
+  credentialsId,
+}: {
+  credentialsId: string;
+}): Promise<{ errors?: string[] }> {
+  try {
+    const credentials = await services.gitCredentials.getById(credentialsId);
+    if (!credentials) {
+      return { errors: ['Credential not found.'] };
+    }
+    const provider = gitRemoteProviderRegistry.get(credentials.provider as GitRemoteProviderType);
+    if (provider?.validateCredentials) {
+      await provider.validateCredentials(credentials);
+    }
+    return {};
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : 'Error validating git credentials.';
+    return { errors: [errorMessage] };
+  }
+}
+
 export async function loadGitRepository({ projectId, workspaceId }: { projectId: string; workspaceId?: string }) {
   try {
     const gitRepository = await getGitRepository({ workspaceId, projectId });
@@ -2566,6 +2592,7 @@ export interface GitServiceAPI {
   migrateLegacyInsomniaFolderToFile: typeof migrateLegacyInsomniaFolderToFile;
   fetchGitRemoteBranches: typeof fetchGitRemoteBranches;
   validateGitRepositoryCredentials: typeof validateGitRepositoryCredentials;
+  validateGitCredentialById: typeof validateGitCredentialById;
 
   initSignInToGitProvider: typeof initSignInToGitProvider;
   completeSignInToGitProvider: typeof completeSignInToGitProvider;
@@ -2588,6 +2615,10 @@ export const registerGitServiceAPI = () => {
     'git.validateGitRepositoryCredentials',
     (_, options: Parameters<typeof validateGitRepositoryCredentials>[0]) =>
       validateGitRepositoryCredentials(options),
+  );
+  ipcMainHandle(
+    'git.validateGitCredentialById',
+    (_, options: Parameters<typeof validateGitCredentialById>[0]) => validateGitCredentialById(options),
   );
   ipcMainHandle('git.gitFetchAction', (_, options: Parameters<typeof gitFetchAction>[0]) => gitFetchAction(options));
   ipcMainHandle('git.gitLogLoader', (_, options: Parameters<typeof gitLogLoader>[0]) => gitLogLoader(options));

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -442,6 +442,14 @@ export const gitFetchAction = async ({ projectId, workspaceId }: { projectId: st
     };
   } catch (e) {
     console.error(e);
+    if (
+      e instanceof Errors.UserCanceledError ||
+      (e instanceof Errors.HttpError && (e.data.statusCode === 401 || e.data.statusCode === 403))
+    ) {
+      return {
+        errors: [GitVCSOperationErrors.AuthenticationRequiredError],
+      };
+    }
     return {
       errors: ['Failed to fetch from remote'],
     };
@@ -1864,15 +1872,17 @@ export const pushToGitRemoteAction = async ({
   try {
     canPush = await GitVCS.canPush(gitRepository.credentialsId);
   } catch (err) {
-    if (err instanceof Errors.HttpError) {
-      if (err.data.statusCode === 401 || err.data.statusCode === 403) {
-        // If we get a 401 or 403, it means that the user does not have permissions to push to this repository
-        return {
-          errors: [`${err.data.statusMessage}, it seems that you do not have permissions to push to this repository.`],
-          gitRepository,
-        };
-      }
+    if (
+      err instanceof Errors.UserCanceledError ||
+      (err instanceof Errors.HttpError && (err.data.statusCode === 401 || err.data.statusCode === 403))
+    ) {
+      return {
+        errors: [GitVCSOperationErrors.AuthenticationRequiredError],
+        gitRepository,
+      };
+    }
 
+    if (err instanceof Errors.HttpError) {
       return {
         errors: [`${err.message}, ${err.data.response}`],
         gitRepository,
@@ -1924,6 +1934,16 @@ export const pushToGitRemoteAction = async ({
         errors: [
           'Push Rejected. It seems that the tag you are trying to push already exists in the remote repository.',
         ],
+      };
+    }
+
+    if (
+      err instanceof Errors.UserCanceledError ||
+      (err instanceof Errors.HttpError && (err.data.statusCode === 401 || err.data.statusCode === 403))
+    ) {
+      return {
+        errors: [GitVCSOperationErrors.AuthenticationRequiredError],
+        gitRepository,
       };
     }
 
@@ -2018,6 +2038,16 @@ export async function pullFromGitRemote({ projectId, workspaceId }: { projectId:
   } catch (err: unknown) {
     if (err instanceof MergeConflictError) {
       return err.data;
+    }
+
+    if (
+      err instanceof Errors.UserCanceledError ||
+      (err instanceof Errors.HttpError && (err.data.statusCode === 401 || err.data.statusCode === 403))
+    ) {
+      return {
+        success: false,
+        errors: [GitVCSOperationErrors.AuthenticationRequiredError],
+      };
     }
 
     let errorMessage = getErrorMessage(err);

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -238,6 +238,59 @@ async function getGitFSClient({
   return routableFS;
 }
 
+/**
+ * Validate that the stored Git credential is currently accepted by the remote.
+ *
+ * For GitHub credentials the GitHub REST API (`GET /user`) is used because the
+ * git wire protocol (`listServerRefs`) can succeed anonymously on public repos
+ * even after a token has been revoked or a GitHub App has been uninstalled.
+ * The REST endpoint reliably returns HTTP 401 in those cases.
+ *
+ * For all other providers we fall back to `fetchRemoteBranches` which uses the
+ * git wire protocol and is sufficient for PAT / GitLab credentials.
+ *
+ * Throws an error starting with `HTTP Error: 4xx` on auth failures so the
+ * existing `shouldShowHttp40OAuthReauthHint` banner logic is triggered.
+ */
+async function validateGitCredentials({
+  credentialsId,
+  uri,
+}: {
+  credentialsId?: string | null;
+  uri: string;
+}): Promise<void> {
+  if (!credentialsId) return;
+
+  const credentials = await services.gitCredentials.getById(credentialsId);
+  if (!credentials) return;
+
+  const provider = gitRemoteProviderRegistry.get(credentials.provider as GitRemoteProviderType);
+
+  await (provider?.validateCredentials
+    ? provider.validateCredentials(credentials)
+    : fetchRemoteBranches({ uri: parseGitToHttpsURL(uri), credentialsId }));
+}
+
+export async function validateGitRepositoryCredentials({
+  projectId,
+  workspaceId,
+}: {
+  projectId: string;
+  workspaceId?: string;
+}): Promise<{ errors?: string[] }> {
+  try {
+    const gitRepository = await getGitRepository({ projectId, workspaceId });
+    await validateGitCredentials({
+      credentialsId: gitRepository.credentialsId,
+      uri: gitRepository.uri,
+    });
+    return {};
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : 'Error validating git credentials.';
+    return { errors: [errorMessage] };
+  }
+}
+
 export async function loadGitRepository({ projectId, workspaceId }: { projectId: string; workspaceId?: string }) {
   try {
     const gitRepository = await getGitRepository({ workspaceId, projectId });
@@ -284,6 +337,10 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
         credentialsId,
         legacyDiff: Boolean(workspaceId),
       });
+
+      // GitVCS.init() opens the local repo without a network call, so explicitly
+      // verify credentials here to surface revoked tokens as HTTP 4xx errors.
+      await validateGitCredentials({ credentialsId, uri });
     }
 
     // Configure basic info
@@ -2508,6 +2565,7 @@ export interface GitServiceAPI {
   getRepositoryDirectoryTree: typeof getRepositoryDirectoryTree;
   migrateLegacyInsomniaFolderToFile: typeof migrateLegacyInsomniaFolderToFile;
   fetchGitRemoteBranches: typeof fetchGitRemoteBranches;
+  validateGitRepositoryCredentials: typeof validateGitRepositoryCredentials;
 
   initSignInToGitProvider: typeof initSignInToGitProvider;
   completeSignInToGitProvider: typeof completeSignInToGitProvider;
@@ -2525,6 +2583,11 @@ export const registerGitServiceAPI = () => {
   ipcMainHandle('git.getGitBranches', (_, options: Parameters<typeof getGitBranches>[0]) => getGitBranches(options));
   ipcMainHandle('git.fetchGitRemoteBranches', (_, options: Parameters<typeof fetchGitRemoteBranches>[0]) =>
     fetchGitRemoteBranches(options),
+  );
+  ipcMainHandle(
+    'git.validateGitRepositoryCredentials',
+    (_, options: Parameters<typeof validateGitRepositoryCredentials>[0]) =>
+      validateGitRepositoryCredentials(options),
   );
   ipcMainHandle('git.gitFetchAction', (_, options: Parameters<typeof gitFetchAction>[0]) => gitFetchAction(options));
   ipcMainHandle('git.gitLogLoader', (_, options: Parameters<typeof gitLogLoader>[0]) => gitLogLoader(options));

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -246,8 +246,9 @@ async function getGitFSClient({
  * even after a token has been revoked or a GitHub App has been uninstalled.
  * The REST endpoint reliably returns HTTP 401 in those cases.
  *
- * For all other providers we fall back to `fetchRemoteBranches` which uses the
- * git wire protocol and is sufficient for PAT / GitLab credentials.
+ * For providers that do not implement `validateCredentials` we fall back to
+ * `fetchRemoteBranches`, which uses the git wire protocol and performs a
+ * basic authentication check against the remote.
  *
  * Throws an error starting with `HTTP Error: 4xx` on auth failures so the
  * existing `shouldShowHttp40OAuthReauthHint` banner logic is triggered.

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -483,6 +483,7 @@ export interface GitChangesLoaderData {
     }[];
   };
   branch: string;
+  gitRepository?: GitRepository | null;
   errors?: string[];
 }
 
@@ -506,6 +507,7 @@ export const gitChangesLoader = async ({
     return {
       branch,
       changes,
+      gitRepository,
     };
   } catch {
     return {
@@ -1475,6 +1477,16 @@ export const commitAndPushToGitRepoAction = async ({
   message: string;
 }): Promise<CommitToGitRepoResult> => {
   const repo = await getGitRepository({ workspaceId, projectId });
+
+  // Validate credentials before committing to prevent orphaned local commits
+  // when the subsequent push would fail due to authentication issues.
+  try {
+    await validateGitCredentials({ credentialsId: repo.credentialsId, uri: repo.uri });
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : 'Authentication failed';
+    return { errors: [errorMessage] };
+  }
+
   try {
     await GitVCS.setAuthor();
     await GitVCS.commit(message);

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -265,7 +265,14 @@ async function validateGitCredentials({
   const credentials = await services.gitCredentials.getById(credentialsId);
   if (!credentials) return;
 
-  const provider = gitRemoteProviderRegistry.get(credentials.provider as GitRemoteProviderType);
+  if (!models.gitCredentials.isGitCredentialsV2(credentials)) {
+    // V1 (legacy) credentials may have provider 'githubapp', which is no longer
+    // registered. Falling back to fetchRemoteBranches would silently "pass" on
+    // public repos even when the token has been revoked, so we bail with a clear error.
+    throw new Error('Legacy git credentials are no longer supported. Please re-authenticate.');
+  }
+
+  const provider = gitRemoteProviderRegistry.get(credentials.provider);
 
   await (provider?.validateCredentials
     ? provider.validateCredentials(credentials)
@@ -307,7 +314,10 @@ export async function validateGitCredentialById({
     if (!credentials) {
       return { errors: ['Credential not found.'] };
     }
-    const provider = gitRemoteProviderRegistry.get(credentials.provider as GitRemoteProviderType);
+    if (!models.gitCredentials.isGitCredentialsV2(credentials)) {
+      return { errors: ['Legacy git credentials are no longer supported. Please re-authenticate.'] };
+    }
+    const provider = gitRemoteProviderRegistry.get(credentials.provider);
     if (provider?.validateCredentials) {
       await provider.validateCredentials(credentials);
     }

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -51,6 +51,7 @@ export type HandleChannels =
   | 'git.diffFileLoader'
   | 'git.discardChanges'
   | 'git.fetchGitRemoteBranches'
+  | 'git.validateGitRepositoryCredentials'
   | 'git.getGitBranches'
   | 'git.getRepositoryDirectoryTree'
   | 'git.gitChangesLoader'

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -52,6 +52,7 @@ export type HandleChannels =
   | 'git.discardChanges'
   | 'git.fetchGitRemoteBranches'
   | 'git.validateGitRepositoryCredentials'
+  | 'git.validateGitCredentialById'
   | 'git.getGitBranches'
   | 'git.getRepositoryDirectoryTree'
   | 'git.gitChangesLoader'

--- a/packages/insomnia/src/routes/git.commits.tsx
+++ b/packages/insomnia/src/routes/git.commits.tsx
@@ -17,6 +17,18 @@ interface CommitGitRepoData {
 export async function clientAction({ request }: Route.ClientActionArgs) {
   const data = (await request.json()) as CommitGitRepoData;
 
+  if (data.push) {
+    // Validate credentials before committing to prevent orphaned local commits
+    // when the subsequent push would fail due to authentication issues.
+    const validationResult = await window.main.git.validateGitRepositoryCredentials({
+      projectId: data.projectId,
+      workspaceId: data.workspaceId,
+    });
+    if (validationResult.errors && validationResult.errors.length > 0) {
+      return validationResult;
+    }
+  }
+
   await window.main.git.multipleCommitToGitRepo({
     projectId: data.projectId,
     workspaceId: data.workspaceId,

--- a/packages/insomnia/src/routes/git.validate-credential.tsx
+++ b/packages/insomnia/src/routes/git.validate-credential.tsx
@@ -1,0 +1,23 @@
+import { href } from 'react-router';
+
+import { createFetcherLoadHook } from '~/utils/router';
+
+import type { validateGitCredentialById } from '../main/git-service';
+
+export async function clientLoader({ request }: { request: Request }) {
+  const url = new URL(request.url);
+  const params = Object.fromEntries(url.searchParams.entries());
+
+  return window.main.git.validateGitCredentialById({
+    credentialsId: params.credentialsId,
+  });
+}
+
+export const useGitValidateCredentialFetcher = createFetcherLoadHook(
+  load =>
+    ({ credentialsId }: { credentialsId: string }) => {
+      const searchParams = new URLSearchParams({ credentialsId });
+      return load(`${href('/git/validate-credential')}?${searchParams.toString()}`);
+    },
+  clientLoader as unknown as typeof validateGitCredentialById,
+);

--- a/packages/insomnia/src/routes/git.validate-credentials.tsx
+++ b/packages/insomnia/src/routes/git.validate-credentials.tsx
@@ -1,0 +1,27 @@
+import { href } from 'react-router';
+
+import { createFetcherLoadHook } from '~/utils/router';
+
+import type { Route } from './+types/git.validate-credentials';
+
+export async function clientLoader({ request }: Route.ClientLoaderArgs) {
+  const url = new URL(request.url);
+  const params = Object.fromEntries(url.searchParams.entries());
+
+  return window.main.git.validateGitRepositoryCredentials({
+    projectId: params.projectId,
+    workspaceId: params.workspaceId || undefined,
+  });
+}
+
+export const useGitValidateCredentialsFetcher = createFetcherLoadHook(
+  load =>
+    ({ projectId, workspaceId }: { projectId: string; workspaceId?: string }) => {
+      const searchParams = new URLSearchParams({ projectId });
+      if (workspaceId) {
+        searchParams.set('workspaceId', workspaceId);
+      }
+      return load(`${href('/git/validate-credentials')}?${searchParams.toString()}`);
+    },
+  clientLoader,
+);

--- a/packages/insomnia/src/sync/git/git-vcs-operation-errors.ts
+++ b/packages/insomnia/src/sync/git/git-vcs-operation-errors.ts
@@ -1,4 +1,5 @@
 export const GitVCSOperationErrors = {
   UncommittedChangesError: 'UncommittedChangesError',
   RequiredPullRemoteChangesError: 'RequiredPullRemoteChangesError',
+  AuthenticationRequiredError: 'AuthenticationRequiredError',
 };

--- a/packages/insomnia/src/sync/git/providers/github.ts
+++ b/packages/insomnia/src/sync/git/providers/github.ts
@@ -112,6 +112,27 @@ export class GitHubProvider implements GitRemoteProvider<GitHubProviderConfig> {
   }
 
   /**
+   * Validate credentials against the GitHub API.
+   * Hits `GET /user` — lightweight and authoritative: returns 401 when the
+   * token is revoked or the GitHub App has been uninstalled.
+   */
+  async validateCredentials(credential: GitCredentials): Promise<void> {
+    if (!isGitCredentialsV2(credential) || credential.provider !== 'github') {
+      throw new Error('Invalid credential type for GitHub provider');
+    }
+
+    const response = await net.fetch(`${this.config.apiUrl}/user`, {
+      headers: {
+        Authorization: `token ${credential.credentials.token}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP Error: ${response.status} ${response.statusText}`);
+    }
+  }
+
+  /**
    * Fetch repositories accessible by the credential
    */
   async fetchRepositories(credentials: GitCredentials, refresh?: boolean): Promise<ProviderRepository[]> {

--- a/packages/insomnia/src/sync/git/providers/gitlab.ts
+++ b/packages/insomnia/src/sync/git/providers/gitlab.ts
@@ -171,6 +171,27 @@ export class GitLabProvider implements GitRemoteProvider<GitLabProviderConfig> {
   }
 
   /**
+   * Validate credentials against the GitLab API.
+   * Hits `GET /user` — lightweight and authoritative: returns 401 when the
+   * token is revoked or has expired (and auto-renewal is not possible).
+   */
+  async validateCredentials(credential: GitCredentials): Promise<void> {
+    if (!isGitCredentialsV2(credential) || credential.provider !== 'gitlab') {
+      throw new Error('Invalid credential type for GitLab provider');
+    }
+
+    const response = await net.fetch(`${this.config.apiUrl}/user`, {
+      headers: {
+        Authorization: `Bearer ${credential.credentials?.token}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP Error: ${response.status} ${response.statusText}`);
+    }
+  }
+
+  /**
    * Fetch projects (repositories) accessible by the credential
    */
   async fetchRepositories(credential: GitCredentials): Promise<ProviderRepository[]> {

--- a/packages/insomnia/src/sync/git/providers/types.ts
+++ b/packages/insomnia/src/sync/git/providers/types.ts
@@ -132,6 +132,14 @@ export interface GitRemoteProvider<TConfig extends BaseProviderConfig = BaseProv
   validateUrl(url: string): Promise<ValidationResult>;
 
   /**
+   * Validate that a credential is currently accepted by the remote provider.
+   * Should throw an error starting with `HTTP Error: 4xx` on auth failures so
+   * the re-auth banner can detect it.  Falls back to `fetchRemoteBranches` for
+   * providers that don't implement this method.
+   */
+  validateCredentials?(credential: GitCredentials): Promise<void>;
+
+  /**
    * Fetch repositories accessible by the credential
    * Only for providers that support it (GitHub, GitLab)
    */

--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -174,7 +174,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
             title: 'Push failed',
             description: (
               <span>
-                Authentication is required.{' '}
+                Connection has expired.{' '}
                 <button
                   className="underline hover:opacity-70"
                   onClick={() => {
@@ -182,7 +182,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
                     showSettingsModal({ tab: 'credentials' });
                   }}
                 >
-                  Fix credentials
+                  Re-authenticate
                 </button>
               </span>
             ),
@@ -251,7 +251,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
             title: 'Fetch failed',
             description: (
               <span>
-                Authentication is required.{' '}
+                Connection has expired.{' '}
                 <button
                   className="underline hover:opacity-70"
                   onClick={() => {
@@ -259,7 +259,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
                     showSettingsModal({ tab: 'credentials' });
                   }}
                 >
-                  Fix credentials
+                  Re-authenticate
                 </button>
               </span>
             ),
@@ -365,7 +365,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
               title: 'Pull failed',
               description: (
                 <span>
-                  Authentication is required.{' '}
+                  Connection has expired.{' '}
                   <button
                     className="underline hover:opacity-70"
                     onClick={() => {
@@ -373,7 +373,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
                       showSettingsModal({ tab: 'credentials' });
                     }}
                   >
-                    Fix credentials
+                    Re-authenticate
                   </button>
                 </span>
               ),

--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -26,6 +26,7 @@ import { useStorageRulesLoaderFetcher } from '~/routes/organization.$organizatio
 import { GitVCSOperationErrors } from '~/sync/git/git-vcs-operation-errors';
 import { SegmentEvent } from '~/ui/analytics';
 import { ProjectModal } from '~/ui/components/modals/project-modal';
+import { showSettingsModal } from '~/ui/components/modals/settings-modal';
 import { useGitCredentials } from '~/ui/hooks/use-git-credentials';
 import { useLoaderDeferData } from '~/ui/hooks/use-loader-defer-data';
 import { DEFAULT_STORAGE_RULES } from '~/ui/organization-utils';
@@ -43,7 +44,7 @@ import {
 } from '../modals/git-project-staging-modal';
 import { GitPullRequiredModal } from '../modals/git-pull-required-modal';
 import { SyncMergeModal } from '../modals/sync-merge-modal';
-import { showToast } from '../toast-notification';
+import { queue, showToast } from '../toast-notification';
 interface Props {
   gitRepository?: GitRepository;
   activeProject: GitProject;
@@ -165,6 +166,33 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
 
       prevHadPullError.current = false;
 
+      if (errors.includes(GitVCSOperationErrors.AuthenticationRequiredError)) {
+        let toastKey = '';
+        toastKey = showToast(
+          {
+            icon,
+            title: 'Push failed',
+            description: (
+              <span>
+                Authentication is required.{' '}
+                <button
+                  className="underline hover:opacity-70"
+                  onClick={() => {
+                    queue.close(toastKey);
+                    showSettingsModal({ tab: 'credentials' });
+                  }}
+                >
+                  Fix credentials
+                </button>
+              </span>
+            ),
+            status: 'error',
+          },
+          { timeout: null },
+        );
+        return;
+      }
+
       // Other errors
       showToast({
         icon,
@@ -215,6 +243,32 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
   useEffect(() => {
     const errors = [...(gitFetchFetcher.data?.errors ?? [])];
     if (errors.length > 0) {
+      if (errors.includes(GitVCSOperationErrors.AuthenticationRequiredError)) {
+        let toastKey = '';
+        toastKey = showToast(
+          {
+            icon,
+            title: 'Fetch failed',
+            description: (
+              <span>
+                Authentication is required.{' '}
+                <button
+                  className="underline hover:opacity-70"
+                  onClick={() => {
+                    queue.close(toastKey);
+                    showSettingsModal({ tab: 'credentials' });
+                  }}
+                >
+                  Fix credentials
+                </button>
+              </span>
+            ),
+            status: 'error',
+          },
+          { timeout: null },
+        );
+        return;
+      }
       setOperationError(errors.join('\n'));
       showToast({
         icon,
@@ -303,12 +357,38 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
           callbackRef: gitProjectStagingModalCallbackPropsRef,
         });
       } else if ('errors' in pullResult && pullResult.errors) {
-        showToast({
-          icon,
-          title: `Pull failed`,
-          status: 'error',
-        });
-        setOperationError(pullResult.errors.join('\n'));
+        if (pullResult.errors.includes(GitVCSOperationErrors.AuthenticationRequiredError)) {
+          let toastKey = '';
+          toastKey = showToast(
+            {
+              icon,
+              title: 'Pull failed',
+              description: (
+                <span>
+                  Authentication is required.{' '}
+                  <button
+                    className="underline hover:opacity-70"
+                    onClick={() => {
+                      queue.close(toastKey);
+                      showSettingsModal({ tab: 'credentials' });
+                    }}
+                  >
+                    Fix credentials
+                  </button>
+                </span>
+              ),
+              status: 'error',
+            },
+            { timeout: null },
+          );
+        } else {
+          showToast({
+            icon,
+            title: `Pull failed`,
+            status: 'error',
+          });
+          setOperationError(pullResult.errors.join('\n'));
+        }
         setIsPulling(false);
 
         return {

--- a/packages/insomnia/src/ui/components/git/git-oauth-auth-banner.tsx
+++ b/packages/insomnia/src/ui/components/git/git-oauth-auth-banner.tsx
@@ -89,7 +89,7 @@ export const GitOauthAuthBanner: FC<{
                 initSignInFetcher.submit({ provider: provider.type });
               }}
             >
-              Reauthenticate with {provider.displayName}
+              Re-authenticate with {provider.displayName}
             </Button>{' '}
             to continue.
           </span>
@@ -111,7 +111,7 @@ export const GitOauthAuthBanner: FC<{
             {({ close }) => (
               <div className="flex flex-col gap-4">
                 <div className="flex items-center justify-between gap-2">
-                  <Heading className="text-2xl">Reauthenticate {provider.displayName} Credential</Heading>
+                  <Heading className="text-2xl">Re-authenticate {provider.displayName} Credential</Heading>
                   <Button
                     className="flex aspect-square h-6 shrink-0 items-center justify-center rounded-xs text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
                     onPress={close}

--- a/packages/insomnia/src/ui/components/git/git-oauth-auth-banner.tsx
+++ b/packages/insomnia/src/ui/components/git/git-oauth-auth-banner.tsx
@@ -1,12 +1,15 @@
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import type { FC } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button, Dialog, Heading, Modal, ModalOverlay } from 'react-aria-components';
 
 import { Banner } from '~/basic-components/banner';
 import { Icon } from '~/basic-components/icon';
 import type { GitCredentials, GitRepository } from '~/insomnia-data';
-import { useGitProviderCompleteSignInFetcher } from '~/routes/git-credentials.complete-sign-in';
+import {
+  GIT_PROVIDER_COMPLETE_SIGN_IN_FETCHER_KEY,
+  useGitProviderCompleteSignInFetcher,
+} from '~/routes/git-credentials.complete-sign-in';
 import { useInitSignInToGitProviderFetcher } from '~/routes/git-credentials.init-sign-in';
 
 import { isOAuthAccessTokenExpired, shouldShowHttp40OAuthReauthHint } from './git-oauth-auth-utils';
@@ -35,17 +38,26 @@ export const GitOauthAuthBanner: FC<{
   const [isReauthModalOpen, setIsReauthModalOpen] = useState(false);
   const [error, setError] = useState('');
   const initSignInFetcher = useInitSignInToGitProviderFetcher();
-  const completeSignInFetcher = useGitProviderCompleteSignInFetcher();
+  const completeSignInFetcher = useGitProviderCompleteSignInFetcher({ key: GIT_PROVIDER_COMPLETE_SIGN_IN_FETCHER_KEY });
 
   const initSignInError = getErrorResult(initSignInFetcher.data);
   const completeSignInError = getErrorResult(completeSignInFetcher.data);
 
+  const prevCompleteSignInStateRef = useRef(completeSignInFetcher.state);
   useEffect(() => {
-    if (completeSignInFetcher.data && !completeSignInError) {
+    const prevState = prevCompleteSignInStateRef.current;
+    prevCompleteSignInStateRef.current = completeSignInFetcher.state;
+
+    if (
+      (prevState === 'submitting' || prevState === 'loading') &&
+      completeSignInFetcher.state === 'idle' &&
+      completeSignInFetcher.data &&
+      !completeSignInError
+    ) {
       setIsReauthModalOpen(false);
       setError('');
     }
-  }, [completeSignInFetcher.data, completeSignInError]);
+  }, [completeSignInFetcher.state, completeSignInFetcher.data, completeSignInError]);
 
   const expiredByExpiresAt = isOAuthAccessTokenExpired(selectedCredential);
   const http40Fallback =

--- a/packages/insomnia/src/ui/components/git/git-oauth-auth-banner.tsx
+++ b/packages/insomnia/src/ui/components/git/git-oauth-auth-banner.tsx
@@ -76,13 +76,13 @@ export const GitOauthAuthBanner: FC<{
     <div className="flex flex-col gap-2">
       <Banner
         type="warning"
-        className="bg-[rgba(var(--color-danger-rgb),0.5)] p-2 text-(--color-font-danger)"
+        className="gap-2 bg-[rgba(var(--color-danger-rgb),0.5)] p-2 text-(--color-font-danger)"
         message={
           <span>
             This connection has expired.{' '}
             <Button
               type="button"
-              className="inline cursor-pointer border-0 bg-transparent p-0 text-(--color-surprise) underline"
+              className="inline cursor-pointer border-0 bg-transparent p-0 underline"
               onPress={() => {
                 setIsReauthModalOpen(true);
                 setError('');

--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -33,18 +33,18 @@ import { LearnMoreLink } from '~/basic-components/link';
 import { scopeToBgColorMap, scopeToIconMap, scopeToTextColorMap } from '~/common/get-workspace-label';
 import type { GitCredentials, GitRepository } from '~/insomnia-data';
 import { useAIGenerateActionFetcher } from '~/routes/ai.generate-commit-messages';
-import { useGitCredentialsLoaderFetcher } from '~/routes/git-credentials';
 import { useGitProjectChangesFetcher } from '~/routes/git.changes';
 import { useGitProjectCommitActionFetcher } from '~/routes/git.commit';
 import { useGitProjectCommitsActionFetcher } from '~/routes/git.commits';
-import {
-  GIT_PROVIDER_COMPLETE_SIGN_IN_FETCHER_KEY,
-  useGitProviderCompleteSignInFetcher,
-} from '~/routes/git-credentials.complete-sign-in';
 import { useGitProjectDiffLoaderFetcher } from '~/routes/git.diff';
 import { useGitProjectDiscardActionFetcher } from '~/routes/git.discard';
 import { useGitProjectStageActionFetcher } from '~/routes/git.stage';
 import { useGitProjectUnstageActionFetcher } from '~/routes/git.unstage';
+import { useGitCredentialsLoaderFetcher } from '~/routes/git-credentials';
+import {
+  GIT_PROVIDER_COMPLETE_SIGN_IN_FETCHER_KEY,
+  useGitProviderCompleteSignInFetcher,
+} from '~/routes/git-credentials.complete-sign-in';
 import type { GitFileType } from '~/sync/git/git-vcs';
 import { GitVCSOperationErrors } from '~/sync/git/git-vcs-operation-errors';
 import type { GitProviderOption } from '~/sync/git/providers/types';

--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -27,21 +27,31 @@ import {
 import { useParams } from 'react-router';
 import { type TreeData, useTreeData } from 'react-stately';
 
+import { Banner } from '~/basic-components/banner';
 import { Button as BasicButton } from '~/basic-components/button';
 import { LearnMoreLink } from '~/basic-components/link';
 import { scopeToBgColorMap, scopeToIconMap, scopeToTextColorMap } from '~/common/get-workspace-label';
+import type { GitCredentials, GitRepository } from '~/insomnia-data';
 import { useAIGenerateActionFetcher } from '~/routes/ai.generate-commit-messages';
+import { useGitCredentialsLoaderFetcher } from '~/routes/git-credentials';
 import { useGitProjectChangesFetcher } from '~/routes/git.changes';
 import { useGitProjectCommitActionFetcher } from '~/routes/git.commit';
 import { useGitProjectCommitsActionFetcher } from '~/routes/git.commits';
+import {
+  GIT_PROVIDER_COMPLETE_SIGN_IN_FETCHER_KEY,
+  useGitProviderCompleteSignInFetcher,
+} from '~/routes/git-credentials.complete-sign-in';
 import { useGitProjectDiffLoaderFetcher } from '~/routes/git.diff';
 import { useGitProjectDiscardActionFetcher } from '~/routes/git.discard';
 import { useGitProjectStageActionFetcher } from '~/routes/git.stage';
 import { useGitProjectUnstageActionFetcher } from '~/routes/git.unstage';
 import type { GitFileType } from '~/sync/git/git-vcs';
 import { GitVCSOperationErrors } from '~/sync/git/git-vcs-operation-errors';
+import type { GitProviderOption } from '~/sync/git/providers/types';
 import { SegmentEvent } from '~/ui/analytics';
 import { Badge } from '~/ui/components/base/badge';
+import { GitOauthAuthBanner } from '~/ui/components/git/git-oauth-auth-banner';
+import { isGitRepoLoadAuthHttp40Error } from '~/ui/components/git/git-oauth-auth-utils';
 import { showSettingsModal } from '~/ui/components/modals/settings-modal';
 import { SvgIcon } from '~/ui/components/svg-icon';
 import { useAIFeatureStatus } from '~/ui/hooks/use-organization-features';
@@ -111,6 +121,9 @@ interface GeneratedCommitsFormProps {
   setShowConfirmDiscardAndPullModal: (show: boolean) => void;
   onCommitSuccess: (options: { push: boolean }) => void;
   diffChanges: (params: { path: string; staged: boolean }) => void;
+  gitRepository?: GitRepository | null;
+  selectedCredential?: GitCredentials | null;
+  selectedProvider?: GitProviderOption | null;
 }
 
 interface FileItem {
@@ -272,10 +285,34 @@ const GeneratedCommitsForm: FC<GeneratedCommitsFormProps> = ({
   setShowConfirmDiscardAndPullModal,
   onCommitSuccess,
   diffChanges,
+  gitRepository,
+  selectedCredential,
+  selectedProvider,
 }) => {
   const commitsFetcher = useGitProjectCommitsActionFetcher();
   const committingActionRef = useRef<'commit' | 'commit-push' | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
+  const [operationError, setOperationError] = useState<string | null>(null);
+  const completeSignInFetcher = useGitProviderCompleteSignInFetcher({ key: GIT_PROVIDER_COMPLETE_SIGN_IN_FETCHER_KEY });
+  const prevCompleteSignInStateRef = useRef(completeSignInFetcher.state);
+  useEffect(() => {
+    const prevState = prevCompleteSignInStateRef.current;
+    prevCompleteSignInStateRef.current = completeSignInFetcher.state;
+    const hasError =
+      completeSignInFetcher.data &&
+      typeof completeSignInFetcher.data === 'object' &&
+      'errors' in completeSignInFetcher.data &&
+      Array.isArray((completeSignInFetcher.data as { errors: unknown }).errors) &&
+      (completeSignInFetcher.data as { errors: string[] }).errors.length > 0;
+    if (
+      (prevState === 'submitting' || prevState === 'loading') &&
+      completeSignInFetcher.state === 'idle' &&
+      completeSignInFetcher.data &&
+      !hasError
+    ) {
+      setOperationError(null);
+    }
+  }, [completeSignInFetcher.state, completeSignInFetcher.data]);
   const isCommitting = commitsFetcher.state !== 'idle';
   const canCommitAndPull = changes.staged.length > 0 && changes.unstaged.length === 0;
 
@@ -290,7 +327,12 @@ const GeneratedCommitsForm: FC<GeneratedCommitsFormProps> = ({
     const isSuccess =
       ('success' in commitsFetcher.data && commitsFetcher.data.success) ||
       ('errors' in commitsFetcher.data && commitsFetcher.data.errors?.length === 0);
+    if (hasErrors && 'errors' in commitsFetcher.data) {
+      setOperationError((commitsFetcher.data.errors as string[]).join('\n'));
+      return;
+    }
     if (isSuccess && !hasErrors) {
+      setOperationError(null);
       onCommitSuccess({ push: action === 'commit-push' });
     }
   }, [commitsFetcher.data, onCommitSuccess, isCommitting]);
@@ -494,6 +536,36 @@ const GeneratedCommitsForm: FC<GeneratedCommitsFormProps> = ({
           </Button>
         </div>
       )}
+      {operationError && selectedProvider && isGitRepoLoadAuthHttp40Error([operationError]) ? (
+        <GitOauthAuthBanner
+          selectedCredential={selectedCredential}
+          gitRepository={gitRepository}
+          repoLoadErrors={[operationError]}
+          provider={selectedProvider}
+        />
+      ) : operationError && selectedCredential?.provider === 'custom' ? (
+        <Banner
+          type="warning"
+          className="bg-[rgba(var(--color-danger-rgb),0.5)] p-2 text-(--color-font-danger)"
+          message={
+            <span>
+              Remote connection is unavailable. Ensure your{' '}
+              <Button
+                type="button"
+                className="inline cursor-pointer border-0 bg-transparent p-0 text-(--color-surprise) underline"
+                onPress={() => showSettingsModal({ tab: 'credentials' })}
+              >
+                PAT Credential
+              </Button>{' '}
+              is valid, then try again.
+            </span>
+          }
+        />
+      ) : operationError ? (
+        <p className="rounded-xs bg-(--color-danger)/20 p-2 text-sm text-(--color-font-danger)">
+          <Icon icon="exclamation-triangle" /> {operationError}
+        </p>
+      ) : null}
     </form>
   );
 };
@@ -509,6 +581,9 @@ interface ManualCommitFormProps {
   setDiscardData: (data: { paths: string[]; filesCount: number }) => void;
   stageChanges: (paths: string[]) => void;
   unstageChanges: (paths: string[]) => void;
+  gitRepository?: GitRepository | null;
+  selectedCredential?: GitCredentials | null;
+  selectedProvider?: GitProviderOption | null;
 }
 
 const ManualCommitForm: FC<ManualCommitFormProps> = ({
@@ -522,6 +597,9 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
   setDiscardData,
   stageChanges,
   unstageChanges,
+  gitRepository,
+  selectedCredential,
+  selectedProvider,
 }) => {
   const commitFetcher = useGitProjectCommitActionFetcher();
 
@@ -530,6 +608,26 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
   const [message, setMessage] = useState('');
   const committingActionRef = useRef<'commit' | 'commit-push' | null>(null);
   const [operationError, setOperationError] = useState<string | null>(null);
+  const completeSignInFetcher = useGitProviderCompleteSignInFetcher({ key: GIT_PROVIDER_COMPLETE_SIGN_IN_FETCHER_KEY });
+  const prevCompleteSignInStateRef = useRef(completeSignInFetcher.state);
+  useEffect(() => {
+    const prevState = prevCompleteSignInStateRef.current;
+    prevCompleteSignInStateRef.current = completeSignInFetcher.state;
+    const hasError =
+      completeSignInFetcher.data &&
+      typeof completeSignInFetcher.data === 'object' &&
+      'errors' in completeSignInFetcher.data &&
+      Array.isArray((completeSignInFetcher.data as { errors: unknown }).errors) &&
+      (completeSignInFetcher.data as { errors: string[] }).errors.length > 0;
+    if (
+      (prevState === 'submitting' || prevState === 'loading') &&
+      completeSignInFetcher.state === 'idle' &&
+      completeSignInFetcher.data &&
+      !hasError
+    ) {
+      setOperationError(null);
+    }
+  }, [completeSignInFetcher.state, completeSignInFetcher.data]);
 
   const isCommitting = commitFetcher.state !== 'idle';
   const canCommitAndPull = stagedCount > 0 && unstagedCount === 0;
@@ -662,11 +760,29 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
             </Button>
           </div>
         )}
-        {operationError && (
+        {operationError && selectedProvider && isGitRepoLoadAuthHttp40Error([operationError]) ? (
+          <GitOauthAuthBanner
+            selectedCredential={selectedCredential}
+            gitRepository={gitRepository}
+            repoLoadErrors={[operationError]}
+            provider={selectedProvider}
+          />
+        ) : operationError && selectedCredential?.provider === 'custom' ? (
+          <p className="rounded-xs bg-(--color-danger)/20 p-2 text-sm text-(--color-font-danger)">
+            <Icon icon="exclamation-triangle" /> Remote connection is unavailable. Ensure your{' '}
+            <Button
+              className="inline cursor-pointer border-0 bg-transparent p-0 text-(--color-font-danger) underline"
+              onPress={() => showSettingsModal({ tab: 'credentials' })}
+            >
+              PAT Credential
+            </Button>{' '}
+            is valid, then try again.
+          </p>
+        ) : operationError ? (
           <p className="rounded-xs bg-(--color-danger)/20 p-2 text-sm text-(--color-font-danger)">
             <Icon icon="exclamation-triangle" /> {operationError}
           </p>
-        )}
+        ) : null}
       </form>
 
       <div className="grid auto-rows-auto gap-2 overflow-y-auto">
@@ -989,6 +1105,7 @@ const OriginalGitProjectStagingModal: FC<
   const [discardData, setDiscardData] = React.useState<DiscardData | null>(null);
 
   const gitChangesFetcher = useGitProjectChangesFetcher();
+  const gitCredentialsFetcher = useGitCredentialsLoaderFetcher();
 
   const undoUnstagedChangesFetcher = useGitProjectDiscardActionFetcher();
   const diffChangesFetcher = useGitProjectDiffLoaderFetcher();
@@ -1020,6 +1137,12 @@ const OriginalGitProjectStagingModal: FC<
     }
   }, [projectId, gitChangesFetcher]);
 
+  useEffect(() => {
+    if (gitCredentialsFetcher.state === 'idle' && !gitCredentialsFetcher.data) {
+      gitCredentialsFetcher.load();
+    }
+  }, [gitCredentialsFetcher]);
+
   const { changes } = gitChangesFetcher.data || {
     changes: {
       staged: [],
@@ -1028,6 +1151,12 @@ const OriginalGitProjectStagingModal: FC<
     branch: '',
     statusNames: {},
   };
+
+  const gitRepository = gitChangesFetcher.data?.gitRepository ?? null;
+  const credentials = gitCredentialsFetcher.data?.credentials ?? [];
+  const providers = gitCredentialsFetcher.data?.providers ?? [];
+  const selectedCredential = credentials.find(c => c._id === gitRepository?.credentialsId) ?? null;
+  const selectedProvider = providers.find(p => p.type === selectedCredential?.provider) ?? null;
 
   const previewDiffItem = diffChangesFetcher.data && 'diff' in diffChangesFetcher.data ? diffChangesFetcher.data : null;
 
@@ -1241,6 +1370,9 @@ const OriginalGitProjectStagingModal: FC<
                         setShowConfirmDiscardAndPullModal={setShowConfirmDiscardAndPullModal}
                         onCommitSuccess={handleCommitSuccess}
                         diffChanges={diffChanges}
+                        gitRepository={gitRepository}
+                        selectedCredential={selectedCredential}
+                        selectedProvider={selectedProvider}
                       />
                     )}
 
@@ -1256,6 +1388,9 @@ const OriginalGitProjectStagingModal: FC<
                         setDiscardData={setDiscardData}
                         stageChanges={stageChanges}
                         unstageChanges={unstageChanges}
+                        gitRepository={gitRepository}
+                        selectedCredential={selectedCredential}
+                        selectedProvider={selectedProvider}
                       />
                     )}
                   </div>

--- a/packages/insomnia/src/ui/components/project/git-repo-form.tsx
+++ b/packages/insomnia/src/ui/components/project/git-repo-form.tsx
@@ -15,9 +15,11 @@ import { Icon } from '~/basic-components/icon';
 import { type GitCredentials, models, type ProviderEmail } from '~/insomnia-data';
 import { useAllConnectedReposLoaderFetcher } from '~/routes/git.all-connected-repos';
 import type { useGitProjectInitCloneActionFetcher } from '~/routes/git.init-clone';
+import { useGitValidateCredentialFetcher } from '~/routes/git.validate-credential';
 import type { GitProviderOption } from '~/sync/git/providers/types';
 import { Checkbox } from '~/ui/components/base/checkbox';
 import { Input } from '~/ui/components/base/input';
+import { GitOauthAuthBanner } from '~/ui/components/git/git-oauth-auth-banner';
 import { GitCredentialSetup } from '~/ui/components/git-credentials/credential-setup';
 import { GitRemoteBranchSelect } from '~/ui/components/git-credentials/git-remote-branch-select';
 import { GitRepositorySelect } from '~/ui/components/git-credentials/git-repository-select';
@@ -52,6 +54,7 @@ interface Props {
   credentials: GitCredentials[];
   providers: GitProviderOption[];
   formId: string;
+  onCredentialValidationChange?: (isInvalid: boolean) => void;
 }
 
 export const GitRepoForm: FC<Props> = ({
@@ -63,6 +66,7 @@ export const GitRepoForm: FC<Props> = ({
   credentials,
   providers,
   formId,
+  onCredentialValidationChange,
 }) => {
   const allConnectedReposLoaderFetcher = useAllConnectedReposLoaderFetcher();
   const allConnectedReposLoaderFetcherLoad = allConnectedReposLoaderFetcher.load;
@@ -74,6 +78,7 @@ export const GitRepoForm: FC<Props> = ({
   const allConnectedRepoURIInfoMap = allConnectedReposLoaderFetcher.data;
 
   const [isCredentialSelectOpen, setIsCredentialSelectOpen] = useState(false);
+  const validateCredentialFetcher = useGitValidateCredentialFetcher();
 
   const selectedCredentialsId = projectData.credentialsId || credentials?.[0]?._id;
   const selectedCredential = credentials.find(c => c._id === selectedCredentialsId);
@@ -89,6 +94,18 @@ export const GitRepoForm: FC<Props> = ({
   const availableEmails = getCredentialEmails(selectedCredential);
   const showEmailSelector = availableEmails.length > 1;
   const [isEmailSelectOpen, setIsEmailSelectOpen] = useState(false);
+
+  const isCredentialInvalid =
+    validateCredentialFetcher.state !== 'idle' ||
+    Boolean(
+      validateCredentialFetcher.data &&
+        'errors' in validateCredentialFetcher.data &&
+        validateCredentialFetcher.data.errors,
+    );
+
+  useEffect(() => {
+    onCredentialValidationChange?.(isCredentialInvalid);
+  }, [isCredentialInvalid, onCredentialValidationChange]);
 
   return (
     <ErrorBoundary>
@@ -137,10 +154,9 @@ export const GitRepoForm: FC<Props> = ({
             aria-label="Git Credentials"
             name="credentialsId"
             onSelectionChange={id => {
-              setProjectData(prev => ({
-                ...prev,
-                credentialsId: id as string,
-              }));
+              const newCredentialsId = id as string;
+              setProjectData(prev => ({ ...prev, credentialsId: newCredentialsId }));
+              validateCredentialFetcher.load({ credentialsId: newCredentialsId });
             }}
             defaultSelectedKey={credentials?.[0]?._id}
           >
@@ -208,7 +224,26 @@ export const GitRepoForm: FC<Props> = ({
               </div>
             </Popover>
           </Select>
-          {showEmailSelector && (
+          {validateCredentialFetcher.state !== 'idle' && (
+            <div className="flex items-center gap-2 text-sm">
+              <Icon icon="spinner" className="animate-spin" />
+              <span>Validating credential...</span>
+            </div>
+          )}
+          {selectedProvider && (
+            <GitOauthAuthBanner
+              selectedCredential={selectedCredential}
+              provider={selectedProvider}
+              repoLoadErrors={
+                validateCredentialFetcher.state === 'idle' &&
+                validateCredentialFetcher.data &&
+                'errors' in validateCredentialFetcher.data
+                  ? validateCredentialFetcher.data.errors
+                  : undefined
+              }
+            />
+          )}
+          {showEmailSelector && !isCredentialInvalid && (
             <Select
               onOpenChange={setIsEmailSelectOpen}
               isOpen={isEmailSelectOpen}
@@ -262,7 +297,7 @@ export const GitRepoForm: FC<Props> = ({
               </Popover>
             </Select>
           )}
-          {selectedProvider && (
+          {selectedProvider && !isCredentialInvalid && (
             <>
               {selectedProvider.supportsFetchRepos ? (
                 <GitRepositorySelect
@@ -297,7 +332,9 @@ export const GitRepoForm: FC<Props> = ({
             </>
           )}
 
-          <GitRemoteBranchSelect credentialsId={selectedCredentialsId} url={projectData.uri || ''} isDisabled={false} />
+          {!isCredentialInvalid && (
+            <GitRemoteBranchSelect credentialsId={selectedCredentialsId} url={projectData.uri || ''} isDisabled={false} />
+          )}
         </Form>
       )}
     </ErrorBoundary>

--- a/packages/insomnia/src/ui/components/project/project-create-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-create-form.tsx
@@ -49,6 +49,7 @@ export const ProjectCreateForm: FC<Props> = ({
   }
 
   const [error, setError] = useState<string | null>(null);
+  const [isGitCredentialInvalid, setIsGitCredentialInvalid] = useState(false);
 
   const [projectData, setProjectData] = useState<ProjectData>({
     name: defaultProjectName,
@@ -134,6 +135,7 @@ export const ProjectCreateForm: FC<Props> = ({
               setActiveView={setActiveView}
               credentials={credentials}
               providers={providers}
+              onCredentialValidationChange={setIsGitCredentialInvalid}
             />
           )}
         </div>
@@ -173,7 +175,7 @@ export const ProjectCreateForm: FC<Props> = ({
               <Button
                 type="submit"
                 form={FORMID}
-                isDisabled={!isGitSyncEnabled}
+                isDisabled={!isGitSyncEnabled || isGitCredentialInvalid}
                 className="flex h-full items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"
               >
                 Scan for files

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -205,7 +205,7 @@ export const ProjectSettingsForm: FC<Props> = ({
     }
   }, [showGitConnectionInfo, gitRepository?.uri, gitRepository?._id, project?._id, validateCredentialsFetcher]);
 
-  const gitRepoLoadErrors =
+  const credentialsValidationErrors =
     validateCredentialsFetcher.data && 'errors' in validateCredentialsFetcher.data
       ? validateCredentialsFetcher.data.errors
       : undefined;
@@ -316,10 +316,10 @@ export const ProjectSettingsForm: FC<Props> = ({
               <GitOauthAuthBanner
                 selectedCredential={selectedCredential}
                 gitRepository={gitRepository}
-                repoLoadErrors={gitRepoLoadErrors}
+                repoLoadErrors={credentialsValidationErrors}
                 provider={selectedProvider}
               />
-              {showEmailSelector && !gitRepoLoadErrors ? (
+              {showEmailSelector && !credentialsValidationErrors ? (
                 <div className="flex flex-col gap-2">
                   {isLoadingEmails ? (
                     <div className="flex items-center gap-2 text-sm">
@@ -397,7 +397,7 @@ export const ProjectSettingsForm: FC<Props> = ({
                     </div>
                   )}
                 </div>
-              ) : selectedCredential?.author.email && !gitRepoLoadErrors ? (
+              ) : selectedCredential?.author.email && !credentialsValidationErrors ? (
                 <div className="text-[12px]">
                   <div className="flex">
                     <div className="w-[110px] font-semibold">Author Email</div>
@@ -450,7 +450,9 @@ export const ProjectSettingsForm: FC<Props> = ({
               project?.gitRepositoryId === models.project.EMPTY_GIT_PROJECT_ID ||
               !gitRepository?.credentialsId) ? (
               <Button
-                isDisabled={(!isGitSyncEnabled && isSwitchingStorageType(project!, storageType)) || isGitCredentialInvalid}
+                isDisabled={
+                  (!isGitSyncEnabled && isSwitchingStorageType(project!, storageType)) || isGitCredentialInvalid
+                }
                 form={FORMID}
                 type="submit"
                 className="flex h-full w-[14ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -321,7 +321,7 @@ export const ProjectSettingsForm: FC<Props> = ({
                 repoLoadErrors={credentialsValidationErrors}
                 provider={selectedProvider}
               />
-              {showEmailSelector && !credentialsValidationErrors ? (
+              {showEmailSelector && !credentialsValidationErrors?.length ? (
                 <div className="flex flex-col gap-2">
                   {isLoadingEmails ? (
                     <div className="flex items-center gap-2 text-sm">
@@ -399,7 +399,7 @@ export const ProjectSettingsForm: FC<Props> = ({
                     </div>
                   )}
                 </div>
-              ) : selectedCredential?.author.email && !credentialsValidationErrors ? (
+              ) : selectedCredential?.author.email && !credentialsValidationErrors?.length ? (
                 <div className="text-[12px]">
                   <div className="flex">
                     <div className="w-[110px] font-semibold">Author Email</div>

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -20,7 +20,7 @@ import { LearnMoreLink } from '~/basic-components/link';
 import type { GitCredentials, GitRepository, Project, ProviderEmail } from '~/insomnia-data';
 import { models } from '~/insomnia-data';
 import { useGitProjectInitCloneActionFetcher } from '~/routes/git.init-clone';
-import { useGitProjectRepoFetcher } from '~/routes/git.repo';
+import { useGitValidateCredentialsFetcher } from '~/routes/git.validate-credentials';
 import { useGitProviderEmailsLoaderFetcher } from '~/routes/git-provider.emails';
 import type { GitProviderOption } from '~/sync/git/providers/types';
 import { GitConnectionInfo } from '~/ui/components/git/connection-info';
@@ -110,7 +110,7 @@ export const ProjectSettingsForm: FC<Props> = ({
   });
 
   const initCloneGitRepositoryFetcher = useGitProjectInitCloneActionFetcher();
-  const gitRepoDataFetcher = useGitProjectRepoFetcher();
+  const validateCredentialsFetcher = useGitValidateCredentialsFetcher();
   const updateProjectFetcher = useProjectUpdateActionFetcher();
 
   const insomniaFiles =
@@ -197,15 +197,17 @@ export const ProjectSettingsForm: FC<Props> = ({
       gitRepository?.uri &&
       gitRepository?._id &&
       project?._id &&
-      gitRepoDataFetcher.state === 'idle' &&
-      !gitRepoDataFetcher.data
+      validateCredentialsFetcher.state === 'idle' &&
+      !validateCredentialsFetcher.data
     ) {
-      gitRepoDataFetcher.load({ projectId: project._id });
+      validateCredentialsFetcher.load({ projectId: project._id });
     }
-  }, [showGitConnectionInfo, gitRepository?.uri, gitRepository?._id, project?._id, gitRepoDataFetcher]);
+  }, [showGitConnectionInfo, gitRepository?.uri, gitRepository?._id, project?._id, validateCredentialsFetcher]);
 
   const gitRepoLoadErrors =
-    gitRepoDataFetcher.data && 'errors' in gitRepoDataFetcher.data ? gitRepoDataFetcher.data.errors : undefined;
+    validateCredentialsFetcher.data && 'errors' in validateCredentialsFetcher.data
+      ? validateCredentialsFetcher.data.errors
+      : undefined;
 
   return (
     <>
@@ -316,7 +318,7 @@ export const ProjectSettingsForm: FC<Props> = ({
                 repoLoadErrors={gitRepoLoadErrors}
                 provider={selectedProvider}
               />
-              {showEmailSelector ? (
+              {showEmailSelector && !gitRepoLoadErrors ? (
                 <div className="flex flex-col gap-2">
                   {isLoadingEmails ? (
                     <div className="flex items-center gap-2 text-sm">
@@ -394,7 +396,7 @@ export const ProjectSettingsForm: FC<Props> = ({
                     </div>
                   )}
                 </div>
-              ) : selectedCredential?.author.email ? (
+              ) : selectedCredential?.author.email && !gitRepoLoadErrors ? (
                 <div className="text-[12px]">
                   <div className="flex">
                     <div className="w-[110px] font-semibold">Author Email</div>

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -191,7 +191,7 @@ export const ProjectSettingsForm: FC<Props> = ({
     }
   }, [canFetchEmails, selectedCredential, emailsFetcher]);
 
-  // Load git repo metadata (and surface auth errors) for HTTP 4xx fallback when expiresAt is unknown.
+  // Load credentials data (and surface auth errors) for HTTP 4xx fallback when expiresAt is unknown.
   useEffect(() => {
     if (
       showGitConnectionInfo &&

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -191,19 +191,21 @@ export const ProjectSettingsForm: FC<Props> = ({
     }
   }, [canFetchEmails, selectedCredential, emailsFetcher]);
 
+  const validateCredentialsFetcherLoad = validateCredentialsFetcher.load;
+
   // Load credentials data (and surface auth errors) for HTTP 4xx fallback when expiresAt is unknown.
+  // No data guard here so that a project ID change always re-fetches fresh data.
   useEffect(() => {
-    if (
-      showGitConnectionInfo &&
-      gitRepository?.uri &&
-      gitRepository?._id &&
-      project?._id &&
-      validateCredentialsFetcher.state === 'idle' &&
-      !validateCredentialsFetcher.data
-    ) {
-      validateCredentialsFetcher.load({ projectId: project._id });
+    if (showGitConnectionInfo && gitRepository?.uri && gitRepository?._id && project?._id) {
+      validateCredentialsFetcherLoad({ projectId: project._id });
     }
-  }, [showGitConnectionInfo, gitRepository?.uri, gitRepository?._id, project?._id, validateCredentialsFetcher]);
+  }, [
+    showGitConnectionInfo,
+    gitRepository?.uri,
+    gitRepository?._id,
+    project?._id,
+    validateCredentialsFetcherLoad,
+  ]);
 
   const credentialsValidationErrors =
     validateCredentialsFetcher.data && 'errors' in validateCredentialsFetcher.data

--- a/packages/insomnia/src/ui/components/project/project-settings-form.tsx
+++ b/packages/insomnia/src/ui/components/project/project-settings-form.tsx
@@ -93,6 +93,7 @@ export const ProjectSettingsForm: FC<Props> = ({
   }, [project, storageType]);
 
   const [error, setError] = useState<string | null>(null);
+  const [isGitCredentialInvalid, setIsGitCredentialInvalid] = useState(false);
 
   const [projectData, setProjectData] = useState<{
     name: string;
@@ -416,6 +417,7 @@ export const ProjectSettingsForm: FC<Props> = ({
               credentials={credentials}
               providers={providers}
               formId={FORMID}
+              onCredentialValidationChange={setIsGitCredentialInvalid}
             />
           )}
         </div>
@@ -448,7 +450,7 @@ export const ProjectSettingsForm: FC<Props> = ({
               project?.gitRepositoryId === models.project.EMPTY_GIT_PROJECT_ID ||
               !gitRepository?.credentialsId) ? (
               <Button
-                isDisabled={!isGitSyncEnabled && isSwitchingStorageType(project!, storageType)}
+                isDisabled={(!isGitSyncEnabled && isSwitchingStorageType(project!, storageType)) || isGitCredentialInvalid}
                 form={FORMID}
                 type="submit"
                 className="flex h-full w-[14ch] items-center justify-center gap-2 rounded-md border border-solid border-(--hl-md) bg-(--color-surprise) px-4 py-2 text-sm font-semibold text-(--color-font-surprise) ring-1 ring-transparent transition-all hover:bg-(--color-surprise)/80 focus:ring-(--hl-md) focus:ring-inset aria-pressed:opacity-80"

--- a/packages/insomnia/src/ui/components/toast-notification.tsx
+++ b/packages/insomnia/src/ui/components/toast-notification.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { format } from 'date-fns';
 import React from 'react';
 import {
+  Button,
   Text,
   UNSTABLE_Toast as Toast,
   UNSTABLE_ToastContent as ToastContent,
@@ -36,15 +37,17 @@ export const queue = new ToastQueue<RAToastContent>({
   },
 });
 
-export const showToast = (content: RAToastContent, options?: { timeout?: number }) => {
+export const showToast = (content: RAToastContent, options?: { timeout?: number | null }) => {
   // Add a new toast to the queue.
   if (!content.time) {
     content.time = format(new Date(), 'HH:mm:ss aa');
   }
 
-  const key = queue.add(content, {
-    timeout: options?.timeout ?? 3000,
-  });
+  // Pass timeout: null to keep the toast persistent (no auto-dismiss).
+  const toastOptions: { timeout?: number } =
+    options?.timeout === null ? {} : { timeout: options?.timeout ?? 3000 };
+
+  const key = queue.add(content, toastOptions);
   // Return the key for further reference if needed.
   return key;
 };
@@ -121,6 +124,15 @@ export const Toaster = () => (
             </div>
           </div>
         </ToastContent>
+        {!toast.timer && (
+          <Button
+            onPress={() => queue.close(toast.key)}
+            aria-label="Dismiss"
+            className="ml-1 flex shrink-0 items-center justify-center rounded text-(--hl) transition-opacity hover:opacity-70 focus:outline-none"
+          >
+            <FontAwesomeIcon icon="xmark" className="size-3" />
+          </Button>
+        )}
       </Toast>
     )}
   </ToastRegion>


### PR DESCRIPTION
## Summary

- Adds a `validateCredentials` method to the GitHub and GitLab provider implementations that hits the provider's `GET /user` REST API endpoint — a lightweight, authoritative check that reliably returns HTTP 401 for revoked tokens or uninstalled GitHub Apps (unlike the git wire protocol, which can succeed anonymously on public repos).
- Adds an optional `validateCredentials` method to the `GitRemoteProvider` interface, with a fallback to `fetchRemoteBranches` for providers that don't implement it.
- Exposes a new `validateGitRepositoryCredentials` IPC handler in `git-service.ts` that looks up the stored credential for a project/workspace and delegates to the appropriate validation strategy.
- Adds a `git.validate-credentials` route and a `useGitValidateCredentialsFetcher` hook so the UI can trigger credential validation on demand.
- Credentials are also validated eagerly on `loadGitRepository` (after `GitVCS.init()`) to surface revoked tokens as HTTP 4xx errors, which triggers the existing re-auth banner logic.

## Test plan

- [ ] Connect a project to a GitHub/GitLab repo with a valid token — confirm no error is shown.
- [ ] Revoke the token (or uninstall the GitHub App) and reload the project — confirm the re-auth banner appears.
- [ ] Verify that a project linked to a public GitHub repo with a revoked token still shows the re-auth hint (regression case for the wire-protocol false-positive).
- [ ] Confirm the fallback path works for non-GitHub/GitLab providers (e.g. manual PAT credentials).


<img width="1786" height="923" alt="image" src="https://github.com/user-attachments/assets/bb6af227-daad-4e2f-b87b-a4574cbf89c1" />

<img width="664" height="317" alt="image" src="https://github.com/user-attachments/assets/a52168c2-0f2a-47a3-a103-3fa420c1577c" />

<img width="800" height="532" alt="image" src="https://github.com/user-attachments/assets/478d3ed0-caad-44ee-a7c0-6fd6ac1e5292" />
