### PR TITLE
fix: import state and project scan

### DIFF
--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -283,8 +283,8 @@ export async function scanResources(importEntries: ImportEntry[]): Promise<ScanR
     retObj.status === 'fulfilled'
       ? retObj.value
       : {
-          errors: [retObj.reason.toString()],
-        },
+        errors: [retObj.reason.toString()],
+      },
   );
 }
 
@@ -478,13 +478,13 @@ export const importResourcesToWorkspace = async ({
       const baseEnvironmentDataFromResources = baseEnvironmentFromResources.data;
       const newData = overrideBaseEnvironmentData
         ? {
-            ...originalEnvironmentData,
-            ...baseEnvironmentDataFromResources,
-          }
+          ...originalEnvironmentData,
+          ...baseEnvironmentDataFromResources,
+        }
         : {
-            ...baseEnvironmentDataFromResources,
-            ...originalEnvironmentData,
-          };
+          ...baseEnvironmentDataFromResources,
+          ...originalEnvironmentData,
+        };
       const { object, map } = orderedJSON.parse(JSON.stringify(newData), JSON_ORDER_PREFIX, JSON_ORDER_SEPARATOR);
       if (environmentType === 'kv') {
         const originKVPairData = baseEnvironment.kvPairData || [];
@@ -748,27 +748,50 @@ function getOasTitleAndVersion(content: string): { title: string; version: strin
   }
 }
 
-export async function findExistingImportedSpec(projectId: string): Promise<
+export async function findExistingImportedSpec(
+  projectId?: string,
+  organizationId?: string,
+): Promise<
   | {
-      workspace: Workspace;
-      apiSpec: ApiSpec;
-    }
+    workspace: Workspace;
+    apiSpec: ApiSpec;
+  }
   | undefined
 > {
+  const allProjects = await models.project.all();
+  const filteredProjects = organizationId ? allProjects.filter(p => p.parentId === organizationId) : allProjects;
+
+  // match active project first, then look in rest
+  const projectIds = new Set<string>();
+  if (projectId) {
+    projectIds.add(projectId);
+  }
+  for (const p of filteredProjects) {
+    projectIds.add(p._id);
+  }
+
   for (const cache of resourceCacheList) {
     if (!isApiSpecImport(cache.importer)) continue;
+
     const incoming = getOasTitleAndVersion(cache.content);
     if (!incoming) continue;
-    const workspaces = await models.workspace.findByParentId(projectId);
-    const designWorkspaces = workspaces.filter(w => w.scope === 'design');
-    for (const ws of designWorkspaces) {
-      const expectedName = `${incoming.title} ${incoming.version}`;
-      if (ws.name !== expectedName) continue;
-      const apiSpec = await services.apiSpec.getByParentId(ws._id);
-      if (!apiSpec) continue;
-      const stored = getOasTitleAndVersion(apiSpec.contents);
-      if (!stored || stored.title !== incoming.title || stored.version !== incoming.version) continue;
-      return { workspace: ws, apiSpec };
+
+    for (const pid of projectIds) {
+      const workspaces = await models.workspace.findByParentId(pid);
+      const designWorkspaces = workspaces.filter(w => w.scope === 'design');
+
+      for (const ws of designWorkspaces) {
+        const expectedName = `${incoming.title} ${incoming.version}`;
+        if (ws.name !== expectedName) continue;
+
+        const apiSpec = await services.apiSpec.getByParentId(ws._id);
+        if (!apiSpec) continue;
+
+        const stored = getOasTitleAndVersion(apiSpec.contents);
+        if (!stored || stored.title !== incoming.title || stored.version !== incoming.version) continue;
+
+        return { workspace: ws, apiSpec };
+      }
     }
   }
   return undefined;

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -29,7 +29,10 @@ import { useAuthorizeActionFetcher } from '~/routes/auth.authorize';
 import { useDefaultBrowserRedirectActionFetcher } from '~/routes/auth.default-browser-redirect';
 import { useLogoutFetcher } from '~/routes/auth.logout';
 import { useCreateCloudCredentialActionFetcher } from '~/routes/cloud-credentials.create';
-import { GIT_PROVIDER_COMPLETE_SIGN_IN_FETCHER_KEY, useGitProviderCompleteSignInFetcher } from '~/routes/git-credentials.complete-sign-in';
+import {
+  GIT_PROVIDER_COMPLETE_SIGN_IN_FETCHER_KEY,
+  useGitProviderCompleteSignInFetcher,
+} from '~/routes/git-credentials.complete-sign-in';
 import { SegmentEvent } from '~/ui/analytics';
 import { getLoginUrl } from '~/ui/auth-session-provider.client';
 import { CopyButton } from '~/ui/components/base/copy-button';
@@ -314,7 +317,9 @@ const Root = () => {
   const { submit: authorizeSubmit } = useAuthorizeActionFetcher();
   const { submit: logoutSubmit } = useLogoutFetcher();
   const { submit: redirectToDefaultBrowserSubmit } = useDefaultBrowserRedirectActionFetcher();
-  const { submit: gitProviderCompleteSignInSubmit } = useGitProviderCompleteSignInFetcher({ key: GIT_PROVIDER_COMPLETE_SIGN_IN_FETCHER_KEY });
+  const { submit: gitProviderCompleteSignInSubmit } = useGitProviderCompleteSignInFetcher({
+    key: GIT_PROVIDER_COMPLETE_SIGN_IN_FETCHER_KEY,
+  });
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -363,6 +368,7 @@ const Root = () => {
             endpoint: params.endpoint,
             operationId: params.operationId,
             autoScan: true,
+            startedAt: Date.now(),
           });
         }
         if (params.mcp) {
@@ -371,6 +377,7 @@ const Root = () => {
             defaultValue: params.mcp,
             origin: sanitizeUrlAndExtractOrigin(params.origin),
             autoScan: true,
+            startedAt: Date.now(),
           });
         }
         if (params.curl) {
@@ -382,6 +389,7 @@ const Root = () => {
             endpoint: params.endpoint,
             operationId: params.operationId,
             autoScan: isValid,
+            startedAt: Date.now(),
           });
         }
       }
@@ -597,6 +605,7 @@ const Root = () => {
       {/* triggered by insomnia://app/import */}
       {importObject.defaultValue && (
         <ImportModal
+          key={importObject.startedAt}
           onHide={() => setImportObject({ type: 'clipboard', defaultValue: '' })}
           defaultProjectId={projectId}
           organizationId={organizationId}

--- a/packages/insomnia/src/routes/import.resources.tsx
+++ b/packages/insomnia/src/routes/import.resources.tsx
@@ -71,7 +71,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
     invariant(typeof projectId === 'string', 'ProjectId is required.');
 
     if (!workspaceId && data.skipImportIfDuplicate) {
-      const existing = await findExistingImportedSpec(projectId);
+      const existing = await findExistingImportedSpec(projectId, organizationId);
       if (existing) {
         const matchedRequest = await findRequestInExistingWorkspace(
           existing.workspace,
@@ -83,6 +83,7 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
           done: true,
           singleImportedWorkspace: existing.workspace,
           singleImportedRequest: matchedRequest,
+          singleImportedProjectId: existing.workspace.parentId,
         };
       }
     }

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -180,6 +180,7 @@ export interface ImportSource {
   endpoint?: string;
   operationId?: string;
   autoScan?: boolean;
+  startedAt?: number;
 }
 
 interface ImportModalProps extends ModalProps {

--- a/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/import-modal/import-modal.tsx
@@ -243,12 +243,13 @@ export const ImportModal: FC<ImportModalProps> = ({
     const valid = scanResourcesFetcherData?.some(({ errors }) => !errors.length);
     if (!valid) return;
     dupCheckRef.current = true;
-    findExistingImportedSpec(defaultProjectId).then(existing => {
+    findExistingImportedSpec(defaultProjectId, organizationId).then(existing => {
       if (!existing) return setShowForm(true);
       findRequestInExistingWorkspace(existing.workspace, from.endpoint, from.operationId).then(req => {
+        const targetProjectId = existing.workspace.parentId || defaultProjectId;
         const path = req
-          ? `/organization/${organizationId}/project/${defaultProjectId}/workspace/${existing.workspace._id}/debug/request/${req._id}`
-          : `/organization/${organizationId}/project/${defaultProjectId}/workspace/${existing.workspace._id}/${scopeToActivity(existing.workspace.scope)}`;
+          ? `/organization/${organizationId}/project/${targetProjectId}/workspace/${existing.workspace._id}/debug/request/${req._id}`
+          : `/organization/${organizationId}/project/${targetProjectId}/workspace/${existing.workspace._id}/${scopeToActivity(existing.workspace.scope)}`;
         clearResourceCache();
         navigate(path);
         modalRef.current?.hide();
@@ -277,7 +278,7 @@ export const ImportModal: FC<ImportModalProps> = ({
       });
       const workspace = importFetcher?.data?.singleImportedWorkspace;
       const request = importFetcher?.data?.singleImportedRequest;
-      const targetProjectId = createdProjectId || defaultProjectId;
+      const targetProjectId = importFetcher?.data?.singleImportedProjectId || createdProjectId || defaultProjectId;
       if (workspace && request) {
         navigate(
           `/organization/${organizationId}/project/${targetProjectId}/workspace/${workspace._id}/debug/request/${request._id}`,


### PR DESCRIPTION
Fixes two issues:
- import existence detection now works across projects in the active organization
- import state is reset when a new import object is initialized