### PR TITLE
feat: support switching spec docs between JSON and YAML

### DIFF
--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
@@ -353,6 +353,18 @@ const Component = ({ params }: Route.ComponentProps) => {
     showCookiesEditor: () => setIsCookieModalOpen(true),
   });
 
+  const specFormat = useMemo((): 'json' | 'yaml' | null => {
+    if (!apiSpec.contents?.trim() || !parsedSpec) {
+      return null;
+    }
+    try {
+      JSON.parse(apiSpec.contents);
+      return 'json';
+    } catch {
+      return 'yaml';
+    }
+  }, [apiSpec.contents, parsedSpec]);
+
   const specActionList: SpecActionItem[] = [
     {
       id: 'generate-request-collection',
@@ -380,6 +392,25 @@ const Component = ({ params }: Route.ComponentProps) => {
         setIsSpecPaneOpen(!isSpecPaneOpen);
       },
     },
+    ...(specFormat === 'json' ? [{
+      id: 'convert-to-yaml',
+      name: 'Convert to YAML',
+      icon: <Icon className="w-3" icon="sync-alt" />,
+      action: () => {
+        const contents = YAML.stringify(JSON.parse(apiSpec.contents));
+        editor.current?.setValue(contents);
+        updateApiSpec({ organizationId, projectId, workspaceId, contents });
+      },
+    }] : specFormat === 'yaml' ? [{
+      id: 'convert-to-json',
+      name: 'Convert to JSON',
+      icon: <Icon className="w-3" icon="sync-alt" />,
+      action: () => {
+        const contents = JSON.stringify(YAML.parse(apiSpec.contents), null, 2);
+        editor.current?.setValue(contents);
+        updateApiSpec({ organizationId, projectId, workspaceId, contents });
+      },
+    }] : []),
   ];
 
   const disabledKeys = specActionList.filter(item => item.isDisabled).map(item => item.id);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
@@ -55,7 +55,7 @@ import { CertificatesModal } from '~/ui/components/modals/workspace-certificates
 import { WorkspaceEnvironmentsEditModal } from '~/ui/components/modals/workspace-environments-edit-modal';
 import { OrganizationTabList } from '~/ui/components/tabs/tab-list';
 import { formatMethodName } from '~/ui/components/tags/method-tag';
-import { showResourceNotFoundToast } from '~/ui/components/toast-notification';
+import { showResourceNotFoundToast, showToast } from '~/ui/components/toast-notification';
 import { INSOMNIA_TAB_HEIGHT } from '~/ui/constant';
 import { useLoaderDeferData } from '~/ui/hooks/use-loader-defer-data';
 import { useAIFeatureStatus } from '~/ui/hooks/use-organization-features';
@@ -354,16 +354,42 @@ const Component = ({ params }: Route.ComponentProps) => {
   });
 
   const specFormat = useMemo((): 'json' | 'yaml' | null => {
-    if (!apiSpec.contents?.trim() || !parsedSpec) {
+    const contents = apiSpec.contents?.trim();
+    if (!contents) {
       return null;
     }
     try {
-      JSON.parse(apiSpec.contents);
+      JSON.parse(contents);
       return 'json';
     } catch {
       return 'yaml';
     }
-  }, [apiSpec.contents, parsedSpec]);
+  }, [apiSpec.contents]);
+
+  const switchFormat = (to: 'json' | 'yaml') => {
+    const editorValue = editor.current?.getValue();
+    if (!editorValue) {
+      return;
+    }
+    let parsedSpec: string | undefined;
+    try {
+      // yaml parses json correctly
+      parsedSpec = YAML.parse(editorValue)
+
+    } catch {
+      showToast({
+        title: 'Failed to convert spec format',
+        icon: 'circle-exclamation',
+        status: 'error',
+        description: `Spec is not valid, cannot convert to ${to.toUpperCase()}`,
+      });
+      return;
+    }
+    const contents = to === 'json' ? JSON.stringify(parsedSpec, null, 2) : YAML.stringify(parsedSpec);
+    editor.current?.setValue(contents);
+    updateApiSpec({ organizationId, projectId, workspaceId, contents });
+
+  }
 
   const specActionList: SpecActionItem[] = [
     {
@@ -396,20 +422,12 @@ const Component = ({ params }: Route.ComponentProps) => {
       id: 'convert-to-yaml',
       name: 'Convert to YAML',
       icon: <Icon className="w-3" icon="sync-alt" />,
-      action: () => {
-        const contents = YAML.stringify(JSON.parse(apiSpec.contents));
-        editor.current?.setValue(contents);
-        updateApiSpec({ organizationId, projectId, workspaceId, contents });
-      },
+      action: () => switchFormat('yaml'),
     }] : specFormat === 'yaml' ? [{
       id: 'convert-to-json',
       name: 'Convert to JSON',
       icon: <Icon className="w-3" icon="sync-alt" />,
-      action: () => {
-        const contents = JSON.stringify(YAML.parse(apiSpec.contents), null, 2);
-        editor.current?.setValue(contents);
-        updateApiSpec({ organizationId, projectId, workspaceId, contents });
-      },
+      action: () => switchFormat('json'),
     }] : []),
   ];
 


### PR DESCRIPTION
UX improvement: drafting a spec in YAML is more ergonomic, allows switching between the two formats
Doesn't preserve YAML comments

https://github.com/user-attachments/assets/ff627c4b-9bab-4d93-be22-5d03cb34d695

