### PR TITLE
fix: prevent duplicate imports during auto-scan

### DIFF
--- a/packages/insomnia/src/common/__tests__/import.test.ts
+++ b/packages/insomnia/src/common/__tests__/import.test.ts
@@ -483,6 +483,21 @@ describe('importRaw()', () => {
     expect(newKvPairData.find(pair => pair.name === 'foo')?.value).toBe('bar');
   });
 
+  it('concurrent scanResources calls should not duplicate the resource cache', async () => {
+    const proj = await project.create();
+    await Promise.all(
+      Array.from({ length: 5 }, (_, i) =>
+        importUtil.scanResources([{ contentStr: `curl -X POST https://${i}.test -d "n=${i}"` }]),
+      ),
+    );
+
+    const workspaces = await importUtil.importResourcesToProject({ projectId: proj._id });
+    expect(workspaces).toHaveLength(1);
+
+    const reqs = await request.findByParentId(workspaces[0]._id);
+    expect(reqs).toHaveLength(1);
+  });
+
   it('should resolve operationId to method and name', async () => {
     const fixturePath = path.join(__dirname, '..', '__fixtures__', 'openapi', 'smoke-test-with-operationIds.yaml');
     const content = fs.readFileSync(fixturePath, 'utf8').toString();

--- a/packages/insomnia/src/common/import.ts
+++ b/packages/insomnia/src/common/import.ts
@@ -175,7 +175,8 @@ export const MODELS_BY_EXPORT_TYPE: Record<AllExportTypes, AllTypes> = {
 export { mcpUrlToInsomniaV5Yaml } from './insomnia-v5';
 
 export async function scanResources(importEntries: ImportEntry[]): Promise<ScanResult[]> {
-  resourceCacheList = [];
+  const sessionCache: ResourceCacheType[] = [];
+  resourceCacheList = sessionCache;
   const results = await Promise.allSettled(
     importEntries.map(async importEntry => {
       const contentStr = importEntry.contentStr;
@@ -242,7 +243,7 @@ export async function scanResources(importEntries: ImportEntry[]): Promise<ScanR
           return { ...model, type: MODELS_BY_EXPORT_TYPE[_type] };
         });
 
-      resourceCacheList.push({
+      sessionCache.push({
         resources,
         importer: type,
         content: contentStr,

--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -570,10 +570,10 @@ const Root = () => {
                 <div className="flex flex-col gap-1 text-left">
                   {errorDetailKeys.length > 0
                     ? errorDetailKeys.map(k => (
-                        <span key={k} className="whitespace-normal">
-                          {k}: {restParams[k]}
-                        </span>
-                      ))
+                      <span key={k} className="whitespace-normal">
+                        {k}: {restParams[k]}
+                      </span>
+                    ))
                     : 'Unknown error'}
                 </div>
               ),


### PR DESCRIPTION
Prevents multiple scan calls occurring simultaneously from storing duplicates in the cache