### PR TITLE
chore: restrict GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   Test:
     timeout-minutes: 10

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   Test:
     timeout-minutes: 40


### PR DESCRIPTION
* restrict GITHUB_TOKEN permissions in test-cli and test-e2e workflows