### PR TITLE
fix: request local network access on macOS

### DIFF
--- a/packages/insomnia/electron-builder.config.js
+++ b/packages/insomnia/electron-builder.config.js
@@ -56,6 +56,8 @@ const config = {
     mergeASARs: false,
     extendInfo: {
       NSRequiresAquaSystemAppearance: false,
+      NSLocalNetworkUsageDescription:
+        'Insomnia needs permission to connect to local APIs and development servers such as localhost, 127.0.0.1, or other LAN hosts.',
     },
     // If this step fails its possible apple has new license terms which need to be accepted by logging into https://developer.apple.com/account
     notarize: true,


### PR DESCRIPTION
We're seeing reports of the inability to connect to localhost on `macOS 26.3.1` with the latest release, this is an attempt to prompt a [local network access request](https://developer.apple.com/documentation/BundleResources/Information-Property-List/NSLocalNetworkUsageDescription) which _should_ unblock those requests