### PR TITLE
fix: view transition error - [INS-2316]

### DIFF
--- a/packages/insomnia/src/ui/components/toast-notification.tsx
+++ b/packages/insomnia/src/ui/components/toast-notification.tsx
@@ -27,9 +27,12 @@ export interface RAToastContent {
 export const queue = new ToastQueue<RAToastContent>({
   // Wrap state updates in a CSS view transition.
   wrapUpdate(fn) {
-    if ('startViewTransition' in document) {
-      document.startViewTransition(() => {
+    if ('startViewTransition' in document && document.visibilityState === 'visible') {
+      const transition = document.startViewTransition(() => {
         flushSync(fn);
+      });
+      transition.ready.catch(error => {
+        console.warn('Transition error:', error.message);
       });
     } else {
       fn();

--- a/packages/insomnia/src/ui/components/toast-notification.tsx
+++ b/packages/insomnia/src/ui/components/toast-notification.tsx
@@ -23,17 +23,24 @@ export interface RAToastContent {
   time?: string;
 }
 
+const logTransitionError = (error: unknown) => {
+  console.warn('Transition error:', error);
+};
+
 // Create a global ToastQueue.
 export const queue = new ToastQueue<RAToastContent>({
   // Wrap state updates in a CSS view transition.
   wrapUpdate(fn) {
     if ('startViewTransition' in document && document.visibilityState === 'visible') {
-      const transition = document.startViewTransition(() => {
-        flushSync(fn);
-      });
-      transition.ready.catch(error => {
-        console.warn('Transition error:', error.message);
-      });
+      try {
+        const transition = document.startViewTransition(() => {
+          flushSync(fn);
+        });
+        transition.ready.catch(logTransitionError);
+      } catch (error) {
+        logTransitionError(error);
+        fn();
+      }
     } else {
       fn();
     }


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
Resolve Sentry error: `InvalidStateError: Transition was aborted because of invalid state`
https://konghq.sentry.io/issues/7364582391/events/1bed13f11d74447f80528d961bb8d14e/?environment=production&project=6311804&query=is%3Aunresolved%20transition&referrer=previous-event

This is the spec about the ViewTransition
> https://www.w3.org/TR/css-view-transitions-1/#ViewTransition-prepare
If document’s [visibility state](https://html.spec.whatwg.org/multipage/interaction.html#visibility-state) is "hidden", then [skip](https://www.w3.org/TR/css-view-transitions-1/#skip-the-view-transition) transition with an "[InvalidStateError](https://webidl.spec.whatwg.org/#invalidstateerror)" [DOMException](https://webidl.spec.whatwg.org/#idl-DOMException), and return transition.