### PR TITLE
fix(Git Sync): auto-resolve non-YAML file conflicts to remote during merge

### DIFF
--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -55,7 +55,7 @@ import { GitProjectNeDBClient } from '../sync/git/project-ne-db-client';
 import { projectRoutableFSClient } from '../sync/git/project-routable-fs-client';
 import { routableFSClient } from '../sync/git/routable-fs-client';
 import { shallowClone } from '../sync/git/shallow-clone';
-import type { MergeConflict } from '../sync/types';
+import type { AutoResolvedConflict, MergeConflict } from '../sync/types';
 import { invariant } from '../utils/invariant';
 import { SegmentEvent, trackSegmentEvent } from './analytics';
 import { ipcMainHandle } from './ipc/electron';
@@ -2092,12 +2092,14 @@ export const continueMerge = async ({
   projectId,
   workspaceId,
   handledMergeConflicts,
+  autoResolvedConflicts,
   commitMessage,
   commitParent,
 }: {
   projectId: string;
   workspaceId?: string;
   handledMergeConflicts: MergeConflict[];
+  autoResolvedConflicts?: AutoResolvedConflict[];
   commitMessage: string;
   commitParent: string[];
 }) => {
@@ -2107,6 +2109,7 @@ export const continueMerge = async ({
 
     await GitVCS.continueMerge({
       handledMergeConflicts,
+      autoResolvedConflicts,
       commitMessage,
       commitParent,
     });

--- a/packages/insomnia/src/sync/git/__tests__/git-vcs.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/git-vcs.test.ts
@@ -597,5 +597,66 @@ First commit!
         });
       }
     });
+
+    it('should auto-complete merge without throwing when all conflicts are non-YAML', async () => {
+      const fsClient = MemClient.createClient();
+      const gitignoreFile = '.gitignore';
+      const readmeFile = 'README.md';
+
+      // Create initial files (no YAML files that conflict)
+      await fsClient.promises.writeFile(gitignoreFile, 'node_modules\n');
+      await fsClient.promises.writeFile(readmeFile, '# Project\n');
+
+      await GitVCS.init({
+        uri: '',
+        repoId: '',
+        directory: GIT_CLONE_DIR,
+        fs: fsClient,
+        legacyDiff: true,
+      });
+      await GitVCS.setAuthor({ name: 'Karen Brown', email: 'karen@example.com' });
+
+      // Stage and commit all files
+      const status = await GitVCS.status();
+      await GitVCS.stageChanges(status.unstaged);
+      await GitVCS.commit('Initial commit');
+
+      // Create origin/main branch to simulate remote
+      await git.branch({ fs: fsClient, dir: GIT_CLONE_DIR, ref: 'origin/main', checkout: false });
+
+      // Make local changes on main
+      await fsClient.promises.writeFile(gitignoreFile, 'node_modules\ndist\n');
+      await fsClient.promises.writeFile(readmeFile, '# Project\nLocal changes\n');
+      const status2 = await GitVCS.status();
+      await GitVCS.stageChanges(status2.unstaged);
+      await GitVCS.commit('Local changes');
+
+      // Switch to origin/main and make different changes
+      await git.checkout({ fs: fsClient, dir: GIT_CLONE_DIR, ref: 'origin/main' });
+      await fsClient.promises.writeFile(gitignoreFile, 'node_modules\nbuild\n');
+      await fsClient.promises.writeFile(readmeFile, '# Project\nRemote changes\n');
+      await git.add({ fs: fsClient, dir: GIT_CLONE_DIR, filepath: gitignoreFile });
+      await git.add({ fs: fsClient, dir: GIT_CLONE_DIR, filepath: readmeFile });
+      await git.commit({
+        fs: fsClient,
+        dir: GIT_CLONE_DIR,
+        message: 'Remote changes',
+        author: { name: 'Remote User', email: 'remote@example.com' },
+      });
+
+      // Switch back to main
+      await git.checkout({ fs: fsClient, dir: GIT_CLONE_DIR, ref: 'main' });
+
+      // buildManualResolutionFromTrees should NOT throw — all conflicts are non-YAML
+      const result = await GitVCS.buildManualResolutionFromTrees();
+      expect(result).toEqual({ autoResolved: true });
+
+      // Non-YAML files should be resolved to the remote (theirs) version
+      const gitignoreContent = (await fsClient.promises.readFile(gitignoreFile)).toString();
+      expect(gitignoreContent).toBe('node_modules\nbuild\n');
+
+      const readmeContent = (await fsClient.promises.readFile(readmeFile)).toString();
+      expect(readmeContent).toBe('# Project\nRemote changes\n');
+    });
   });
 });

--- a/packages/insomnia/src/sync/git/__tests__/git-vcs.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/git-vcs.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import * as git from 'isomorphic-git';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import GitVCS, { GIT_CLONE_DIR, GIT_INSOMNIA_DIR } from '../git-vcs';
+import GitVCS, { GIT_CLONE_DIR, GIT_INSOMNIA_DIR, MergeConflictError } from '../git-vcs';
 import { MemClient } from '../mem-client';
 
 describe('Git-VCS', () => {
@@ -520,6 +520,82 @@ First commit!
 
       // Nested file should be restored
       expect((await fsClient.promises.readFile(nestedFile)).toString()).toBe(originalContent + '\n');
+    });
+  });
+
+  describe('buildManualResolutionFromTrees()', () => {
+    it('should collect non-YAML conflicts as autoResolvedConflicts and only return YAML conflicts', async () => {
+      const fsClient = MemClient.createClient();
+      const yamlFile = path.join(GIT_INSOMNIA_DIR, 'Environment', 'env_1.yaml');
+      const gitignoreFile = '.gitignore';
+
+      // Create directories
+      await fsClient.promises.mkdir(GIT_INSOMNIA_DIR);
+      await fsClient.promises.mkdir(path.join(GIT_INSOMNIA_DIR, 'Environment'));
+
+      // Create initial files
+      await fsClient.promises.writeFile(yamlFile, 'name: base env\n');
+      await fsClient.promises.writeFile(gitignoreFile, 'node_modules\n');
+
+      await GitVCS.init({
+        uri: '',
+        repoId: '',
+        directory: GIT_CLONE_DIR,
+        fs: fsClient,
+        legacyDiff: true,
+      });
+      await GitVCS.setAuthor({ name: 'Karen Brown', email: 'karen@example.com' });
+
+      // Stage and commit all files
+      const status = await GitVCS.status();
+      await GitVCS.stageChanges(status.unstaged);
+      await GitVCS.commit('Initial commit');
+
+      // Create origin/main branch to simulate remote
+      await git.branch({ fs: fsClient, dir: GIT_CLONE_DIR, ref: 'origin/main', checkout: false });
+
+      // Make local changes on main
+      await fsClient.promises.writeFile(yamlFile, 'name: local env\n');
+      await fsClient.promises.writeFile(gitignoreFile, 'node_modules\ndist\n');
+      const status2 = await GitVCS.status();
+      await GitVCS.stageChanges(status2.unstaged);
+      await GitVCS.commit('Local changes');
+
+      // Switch to origin/main and make different changes
+      await git.checkout({ fs: fsClient, dir: GIT_CLONE_DIR, ref: 'origin/main' });
+      await fsClient.promises.writeFile(yamlFile, 'name: remote env\n');
+      await fsClient.promises.writeFile(gitignoreFile, 'node_modules\nbuild\n');
+      await git.add({ fs: fsClient, dir: GIT_CLONE_DIR, filepath: yamlFile });
+      await git.add({ fs: fsClient, dir: GIT_CLONE_DIR, filepath: gitignoreFile });
+      await git.commit({
+        fs: fsClient,
+        dir: GIT_CLONE_DIR,
+        message: 'Remote changes',
+        author: { name: 'Remote User', email: 'remote@example.com' },
+      });
+
+      // Switch back to main
+      await git.checkout({ fs: fsClient, dir: GIT_CLONE_DIR, ref: 'main' });
+
+      // Call buildManualResolutionFromTrees — it should throw MergeConflictError
+      try {
+        await GitVCS.buildManualResolutionFromTrees();
+        expect.unreachable('Should have thrown MergeConflictError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(MergeConflictError);
+
+        const mergeErr = err as MergeConflictError;
+        // Only YAML conflicts should appear in the conflicts array
+        expect(mergeErr.data.conflicts).toHaveLength(1);
+        expect(mergeErr.data.conflicts[0].key).toBe(yamlFile);
+
+        // Non-YAML files should be in autoResolvedConflicts for deferred staging
+        expect(mergeErr.data.autoResolvedConflicts).toHaveLength(1);
+        expect(mergeErr.data.autoResolvedConflicts[0]).toEqual({
+          filepath: gitignoreFile,
+          action: 'use-theirs',
+        });
+      }
     });
   });
 });

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -1692,6 +1692,7 @@ export class GitVCS {
           ...this._baseOpts,
           ref: commitParent[1],
           filepaths: [autoResolved.filepath],
+          noUpdateHead: true,
           force: true,
         });
         await git.add({ ...this._baseOpts, filepath: autoResolved.filepath });

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -11,7 +11,7 @@ import { GitVCSOperationErrors } from '~/sync/git/git-vcs-operation-errors';
 import type { WriteFileMap } from '~/sync/git/project-routable-fs-client';
 
 import { hasSignificantChanges } from '../../common/significant-diff-detection';
-import { type MergeConflict, RESOLUTION_SOURCE } from '../types';
+import { type AutoResolvedConflict, type MergeConflict, RESOLUTION_SOURCE } from '../types';
 import { httpClient } from './http-client';
 import { convertToPosixSep } from './path-sep';
 import { getAuthorFromGitRepository, gitCallbacks } from './utils';
@@ -1323,6 +1323,7 @@ export class GitVCS {
   async buildManualResolutionFromTrees() {
     const { oursBranch, theirsBranch } = await this.getBranchPair();
     const mergeConflicts: MergeConflict[] = [];
+    const autoResolvedConflicts: AutoResolvedConflict[] = [];
     const conflictPathsObj = await this.findConflictLikeChanges(oursBranch, theirsBranch);
 
     const conflictTypeList: (keyof ConflictPaths)[] = ['bothModified', 'deleteByUs', 'deleteByTheirs'];
@@ -1352,19 +1353,6 @@ export class GitVCS {
         }));
     }
 
-    function readRawBlob(filepath: string, oid: string) {
-      return git
-        .readBlob({
-          ..._baseOpts,
-          oid,
-          filepath,
-        })
-        .then(({ blob, oid: blobId }) => ({
-          rawContent: Buffer.from(blob).toString('utf8'),
-          blobId,
-        }));
-    }
-
     function readOursBlob(filepath: string) {
       return readBlob(filepath, oursHeadCommitOid);
     }
@@ -1381,19 +1369,12 @@ export class GitVCS {
         deleteByTheirs: 'they deleted and you modified',
       }[conflictType];
       for (const conflictPath of conflictPaths) {
-        // Auto-resolve non-YAML files to theirs (remote) since Insomnia only manages YAML files
+        // Auto-resolve non-YAML files to theirs (remote) since Insomnia only manages YAML files.
+        // Collect for deferred staging in continueMerge() so cancel has zero side effects.
         if (!conflictPath.endsWith('.yaml')) {
-          const theirsRaw =
-            conflictType !== 'deleteByTheirs' ? await readRawBlob(conflictPath, theirsHeadCommitOid) : null;
-          mergeConflicts.push({
-            key: conflictPath,
-            name: path.basename(conflictPath),
-            message,
-            mineBlob: null,
-            theirsBlob: theirsRaw?.blobId || null,
-            choose: null,
-            mergeResult: theirsRaw?.rawContent ?? '',
-            resolutionSource: RESOLUTION_SOURCE.MANUAL,
+          autoResolvedConflicts.push({
+            filepath: conflictPath,
+            action: conflictType === 'deleteByTheirs' ? 'delete' : 'use-theirs',
           });
           continue;
         }
@@ -1442,6 +1423,7 @@ export class GitVCS {
 
     throw new MergeConflictError('Need to solve merge conflicts first', {
       conflicts: mergeConflicts,
+      autoResolvedConflicts,
       labels: {
         ours: `${oursBranch} ${oursHeadCommitOid}`,
         theirs: `${theirsBranch} ${theirsHeadCommitOid}`,
@@ -1551,6 +1533,7 @@ export class GitVCS {
     const { filepaths, bothModified, deleteByUs, deleteByTheirs } = mergeConflictError.data;
     if (filepaths.length) {
       const mergeConflicts: MergeConflict[] = [];
+      const autoResolvedConflicts: AutoResolvedConflict[] = [];
       const conflictPathsObj = {
         bothModified,
         deleteByUs,
@@ -1583,19 +1566,6 @@ export class GitVCS {
           }));
       }
 
-      function readRawBlob(filepath: string, oid: string) {
-        return git
-          .readBlob({
-            ..._baseOpts,
-            oid,
-            filepath,
-          })
-          .then(({ blob, oid: blobId }) => ({
-            rawContent: Buffer.from(blob),
-            blobId,
-          }));
-      }
-
       function readOursBlob(filepath: string) {
         return readBlob(filepath, oursHeadCommitOid);
       }
@@ -1612,19 +1582,12 @@ export class GitVCS {
           deleteByTheirs: 'they deleted and you modified',
         }[conflictType];
         for (const conflictPath of conflictPaths) {
-          // Auto-resolve non-YAML files to theirs (remote) since Insomnia only manages YAML files
+          // Auto-resolve non-YAML files to theirs (remote) since Insomnia only manages YAML files.
+          // Collect for deferred staging in continueMerge() so cancel has zero side effects.
           if (!conflictPath.endsWith('.yaml')) {
-            const theirsRaw =
-              conflictType !== 'deleteByTheirs' ? await readRawBlob(conflictPath, theirsHeadCommitOid) : null;
-            mergeConflicts.push({
-              key: conflictPath,
-              name: path.basename(conflictPath),
-              message,
-              mineBlob: null,
-              theirsBlob: theirsRaw?.blobId || null,
-              choose: null,
-              mergeResult: theirsRaw?.rawContent ?? '',
-              resolutionSource: RESOLUTION_SOURCE.MANUAL,
+            autoResolvedConflicts.push({
+              filepath: conflictPath,
+              action: conflictType === 'deleteByTheirs' ? 'delete' : 'use-theirs',
             });
             continue;
           }
@@ -1693,6 +1656,7 @@ export class GitVCS {
 
       throw new MergeConflictError('Need to solve merge conflicts first', {
         conflicts: mergeConflicts,
+        autoResolvedConflicts,
         labels: {
           ours: `${oursBranch} ${oursHeadCommitOid}`,
           theirs: `${theirsBranch} ${theirsHeadCommitOid}`,
@@ -1708,14 +1672,31 @@ export class GitVCS {
   // create a commit after resolving merge conflicts
   async continueMerge({
     handledMergeConflicts,
+    autoResolvedConflicts,
     commitMessage,
     commitParent,
   }: {
     handledMergeConflicts: MergeConflict[];
+    autoResolvedConflicts?: AutoResolvedConflict[];
     commitMessage: string;
     commitParent: string[];
   }) {
     console.log('[git] continue to merge after resolving merge conflicts', await this.getCurrentBranch());
+
+    // Stage auto-resolved non-YAML files (deferred from conflict collection)
+    for (const autoResolved of autoResolvedConflicts ?? []) {
+      if (autoResolved.action === 'delete') {
+        await git.remove({ ...this._baseOpts, filepath: autoResolved.filepath });
+      } else {
+        await git.checkout({
+          ...this._baseOpts,
+          ref: commitParent[1],
+          filepaths: [autoResolved.filepath],
+          force: true,
+        });
+        await git.add({ ...this._baseOpts, filepath: autoResolved.filepath });
+      }
+    }
 
     for (const conflict of handledMergeConflicts) {
       assertIsPromiseFsClient(this._baseOpts.fs);
@@ -2037,6 +2018,7 @@ export class MergeConflictError extends Error {
     msg: string,
     data: {
       conflicts: MergeConflict[];
+      autoResolvedConflicts: AutoResolvedConflict[];
       labels: {
         ours: string;
         theirs: string;

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -1318,6 +1318,8 @@ export class GitVCS {
         commitParent: [oursHeadCommitOid, theirsHeadCommitOid],
       };
     }
+
+    return;
   }
 
   async buildManualResolutionFromTrees() {
@@ -1419,6 +1421,17 @@ export class GitVCS {
           mergeResult: suggestedMergeResult,
         });
       }
+    }
+
+    // If all conflicts were auto-resolved (no YAML conflicts), complete the merge automatically
+    if (mergeConflicts.length === 0 && autoResolvedConflicts.length > 0) {
+      await this.continueMerge({
+        handledMergeConflicts: [],
+        autoResolvedConflicts,
+        commitMessage: `Merge branch '${theirsBranch}' into ${oursBranch}`,
+        commitParent: [oursHeadCommitOid, theirsHeadCommitOid],
+      });
+      return { autoResolved: true };
     }
 
     throw new MergeConflictError('Need to solve merge conflicts first', {
@@ -1652,6 +1665,17 @@ export class GitVCS {
             mergeResult: suggestedMergeResult,
           });
         }
+      }
+
+      // If all conflicts were auto-resolved (no YAML conflicts), complete the merge automatically
+      if (mergeConflicts.length === 0 && autoResolvedConflicts.length > 0) {
+        await this.continueMerge({
+          handledMergeConflicts: [],
+          autoResolvedConflicts,
+          commitMessage: `Merge branch '${theirsBranch}' into ${oursBranch}`,
+          commitParent: [oursHeadCommitOid, theirsHeadCommitOid],
+        });
+        return { autoResolved: true };
       }
 
       throw new MergeConflictError('Need to solve merge conflicts first', {

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -1361,7 +1361,7 @@ export class GitVCS {
     }
 
     for (const conflictType of conflictTypeList) {
-      const conflictPaths = conflictPathsObj[conflictType];
+      const conflictPaths = conflictPathsObj[conflictType].filter(fp => fp.endsWith('.yaml'));
       const message = {
         bothModified: 'both modified',
         deleteByUs: 'you deleted and they modified',
@@ -1562,7 +1562,7 @@ export class GitVCS {
       }
 
       for (const conflictType of conflictTypeList) {
-        const conflictPaths = conflictPathsObj[conflictType];
+        const conflictPaths = conflictPathsObj[conflictType].filter(fp => fp.endsWith('.yaml'));
         const message = {
           bothModified: 'both modified',
           deleteByUs: 'you deleted and they modified',

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -1591,7 +1591,7 @@ export class GitVCS {
             filepath,
           })
           .then(({ blob, oid: blobId }) => ({
-            rawContent: Buffer.from(blob).toString('utf8'),
+            rawContent: Buffer.from(blob),
             blobId,
           }));
       }

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -1352,6 +1352,19 @@ export class GitVCS {
         }));
     }
 
+    function readRawBlob(filepath: string, oid: string) {
+      return git
+        .readBlob({
+          ..._baseOpts,
+          oid,
+          filepath,
+        })
+        .then(({ blob, oid: blobId }) => ({
+          rawContent: Buffer.from(blob).toString('utf8'),
+          blobId,
+        }));
+    }
+
     function readOursBlob(filepath: string) {
       return readBlob(filepath, oursHeadCommitOid);
     }
@@ -1361,13 +1374,30 @@ export class GitVCS {
     }
 
     for (const conflictType of conflictTypeList) {
-      const conflictPaths = conflictPathsObj[conflictType].filter(fp => fp.endsWith('.yaml'));
+      const conflictPaths = conflictPathsObj[conflictType];
       const message = {
         bothModified: 'both modified',
         deleteByUs: 'you deleted and they modified',
         deleteByTheirs: 'they deleted and you modified',
       }[conflictType];
       for (const conflictPath of conflictPaths) {
+        // Auto-resolve non-YAML files to theirs (remote) since Insomnia only manages YAML files
+        if (!conflictPath.endsWith('.yaml')) {
+          const theirsRaw =
+            conflictType !== 'deleteByTheirs' ? await readRawBlob(conflictPath, theirsHeadCommitOid) : null;
+          mergeConflicts.push({
+            key: conflictPath,
+            name: path.basename(conflictPath),
+            message,
+            mineBlob: null,
+            theirsBlob: theirsRaw?.blobId || null,
+            choose: null,
+            mergeResult: theirsRaw?.rawContent ?? '',
+            resolutionSource: RESOLUTION_SOURCE.MANUAL,
+          });
+          continue;
+        }
+
         let mineBlobContent = null;
         let mineBlobId = null;
 
@@ -1553,6 +1583,19 @@ export class GitVCS {
           }));
       }
 
+      function readRawBlob(filepath: string, oid: string) {
+        return git
+          .readBlob({
+            ..._baseOpts,
+            oid,
+            filepath,
+          })
+          .then(({ blob, oid: blobId }) => ({
+            rawContent: Buffer.from(blob).toString('utf8'),
+            blobId,
+          }));
+      }
+
       function readOursBlob(filepath: string) {
         return readBlob(filepath, oursHeadCommitOid);
       }
@@ -1562,13 +1605,30 @@ export class GitVCS {
       }
 
       for (const conflictType of conflictTypeList) {
-        const conflictPaths = conflictPathsObj[conflictType].filter(fp => fp.endsWith('.yaml'));
+        const conflictPaths = conflictPathsObj[conflictType];
         const message = {
           bothModified: 'both modified',
           deleteByUs: 'you deleted and they modified',
           deleteByTheirs: 'they deleted and you modified',
         }[conflictType];
         for (const conflictPath of conflictPaths) {
+          // Auto-resolve non-YAML files to theirs (remote) since Insomnia only manages YAML files
+          if (!conflictPath.endsWith('.yaml')) {
+            const theirsRaw =
+              conflictType !== 'deleteByTheirs' ? await readRawBlob(conflictPath, theirsHeadCommitOid) : null;
+            mergeConflicts.push({
+              key: conflictPath,
+              name: path.basename(conflictPath),
+              message,
+              mineBlob: null,
+              theirsBlob: theirsRaw?.blobId || null,
+              choose: null,
+              mergeResult: theirsRaw?.rawContent ?? '',
+              resolutionSource: RESOLUTION_SOURCE.MANUAL,
+            });
+            continue;
+          }
+
           let mineBlobContent = null;
           let mineBlobId = null;
 

--- a/packages/insomnia/src/sync/types.ts
+++ b/packages/insomnia/src/sync/types.ts
@@ -108,6 +108,11 @@ export interface MergeConflict {
   resolutionSource?: ResolutionSource;
 }
 
+export interface AutoResolvedConflict {
+  filepath: string;
+  action: 'use-theirs' | 'delete';
+}
+
 export type Stage = Record<DocumentKey, StageEntry>;
 
 export interface StatusCandidate {

--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -411,6 +411,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
               .continueMerge({
                 projectId,
                 handledMergeConflicts: conflicts,
+                autoResolvedConflicts: pullResult.autoResolvedConflicts,
                 commitMessage: pullResult.commitMessage,
                 commitParent: pullResult.commitParent,
               })

--- a/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-sync-dropdown.tsx
@@ -217,6 +217,7 @@ export const GitSyncDropdown: FC<Props> = ({ gitRepository, isInsomniaSyncEnable
                             projectId,
                             workspaceId,
                             handledMergeConflicts: conflicts,
+                            autoResolvedConflicts: result.autoResolvedConflicts,
                             commitMessage: result.commitMessage,
                             commitParent: result.commitParent,
                           })

--- a/packages/insomnia/src/ui/components/modals/git-branches-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-branches-modal.tsx
@@ -160,6 +160,7 @@ const LocalBranchItem = ({
                             projectId,
                             workspaceId,
                             handledMergeConflicts: conflicts,
+                            autoResolvedConflicts: result.autoResolvedConflicts,
                             commitMessage: result.commitMessage,
                             commitParent: result.commitParent,
                           })

--- a/packages/insomnia/src/ui/components/modals/git-project-branches-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-branches-modal.tsx
@@ -155,6 +155,7 @@ const LocalBranchItem = ({
                           .continueMerge({
                             projectId,
                             handledMergeConflicts: conflicts,
+                            autoResolvedConflicts: result.autoResolvedConflicts,
                             commitMessage: result.commitMessage,
                             commitParent: result.commitParent,
                           })


### PR DESCRIPTION
# Overview

A YAML parsing error is thrown when pulling from a Git remote that has conflicting non-YAML files (e.g., .gitignore). The merge conflict resolution logic attempts to parse every conflicting file as YAML, regardless of file type, causing a crash when it encounters files like .gitignore containing node_modules.

## Root Cause

`collectMergeConflicts()` and `buildManualResolutionFromTrees()` in `git-vcs.ts` iterate over all conflicting file paths reported by isomorphic-git and call yaml.parse() on their contents. Neither method filters by file extension, so non-YAML files (.gitignore, README.md, etc.) are parsed as YAML, which throws Unexpected scalar token in YAML stream.

## Fix

- Non-YAML files (.gitignore, README.md, etc.) are now excluded from the interactive merge conflict dialog. Instead, they are automatically resolved to the remote version since Insomnia only manages YAML files and never modifies non-YAML files in the repo.
- If the remote deleted a non-YAML file, it is automatically removed locally as well.
- Auto-resolved decisions are deferred — they are only applied when the user confirms the merge, so cancelling the dialog has zero side effects.
- Fixed a bug where staging auto-resolved files caused HEAD to detach from the current branch (`noUpdateHead: true`), which resulted in a "No active branch" error and the Git project appearing disconnected after merge.
- The auto-resolved conflict data is threaded through all merge conflict UI paths (pull, branch merge, project-level sync).

## Tests

- Added a unit test that sets up a repo with both a YAML file and a .gitignore that conflict between local and remote. Verifies that only the YAML file appears in the interactive conflicts list while the .gitignore is collected separately for automatic resolution.
## Reproduction Steps

1. Create a Git repository with a .gitignore and an Insomnia collection YAML file
2. Clone/sync the repo in Insomnia
3. On the remote (e.g., GitHub UI), edit .gitignore (add a line like dist/) and also modify the collection YAML file
4. In Insomnia, make a different change to the same collection and commit locally
5. Pull from the remote
Observe the error: Unexpected scalar token in YAML stream ...

## TODO
- [x] Verify the auto-resolve for remote YAML files will work for any kind of file (e.g. binary formats etc. we need to make sure we don't break anything)

Closes INS-2364