### PR TITLE
refactor: remove route path builtin imports

### DIFF
--- a/packages/insomnia/config/renderer-node-import-baseline.json
+++ b/packages/insomnia/config/renderer-node-import-baseline.json
@@ -161,10 +161,6 @@
       "builtin": "path"
     },
     {
-      "importer": "src/routes/import.scan.tsx",
-      "builtin": "path"
-    },
-    {
       "importer": "src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx",
       "builtin": "fs"
     },
@@ -173,23 +169,11 @@
       "builtin": "path"
     },
     {
-      "importer": "src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.generate-request-collection.tsx",
-      "builtin": "path"
-    },
-    {
-      "importer": "src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx",
-      "builtin": "path"
-    },
-    {
       "importer": "src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx",
       "builtin": "fs"
     },
     {
       "importer": "src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx",
-      "builtin": "path"
-    },
-    {
-      "importer": "src/routes/organization.$organizationId.project.$projectId.workspace.update.tsx",
       "builtin": "path"
     },
     {

--- a/packages/insomnia/src/routes/import.scan.tsx
+++ b/packages/insomnia/src/routes/import.scan.tsx
@@ -79,11 +79,12 @@ export const scanImportResources = async (data: {
     // zip file is for postman data dump
     for (const zipFilePath of zipFilePaths) {
       const postmanDataDumpRawData = await getFilesFromPostmanExportedDataDump(zipFilePath);
+      const zipBaseName = window.path.basename(zipFilePath);
 
       function trans({ contentStr, oriFileName }: ImportEntry): ImportEntry {
         return {
           contentStr,
-          oriFileName: `${oriFileName} in ${window.path.basename(zipFilePath)}`,
+          oriFileName: `${oriFileName} in ${zipBaseName}`,
         };
       }
 

--- a/packages/insomnia/src/routes/import.scan.tsx
+++ b/packages/insomnia/src/routes/import.scan.tsx
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 import { type ActionFunctionArgs, href } from 'react-router';
 
 import type { ImportSourceType, ScanResult } from '~/common/import';
@@ -24,6 +22,7 @@ export const scanImportResources = async (data: {
   postmanArchiveFile?: string | null;
 }): Promise<ScanResult[]> => {
   const { source, postmanArchiveFile } = data;
+  const isZipFilePath = (filePath: string) => filePath.toLowerCase().endsWith('.zip');
 
   invariant(typeof source === 'string', 'Source is required.');
   invariant(IMPORT_SOURCE_TYPES.includes(source), 'Unsupported import type');
@@ -74,8 +73,8 @@ export const scanImportResources = async (data: {
       throw new Error('File is required');
     }
 
-    const zipFilePaths = filePaths.filter(filePath => path.extname(filePath) === '.zip');
-    const nonZipFilePaths = filePaths.filter(filePath => path.extname(filePath) !== '.zip');
+    const zipFilePaths = filePaths.filter(isZipFilePath);
+    const nonZipFilePaths = filePaths.filter(filePath => !isZipFilePath(filePath));
 
     // zip file is for postman data dump
     for (const zipFilePath of zipFilePaths) {
@@ -84,7 +83,7 @@ export const scanImportResources = async (data: {
       function trans({ contentStr, oriFileName }: ImportEntry): ImportEntry {
         return {
           contentStr,
-          oriFileName: `${oriFileName} in ${path.basename(zipFilePath)}`,
+          oriFileName: `${oriFileName} in ${window.path.basename(zipFilePath)}`,
         };
       }
 
@@ -131,7 +130,7 @@ export const scanImportResources = async (data: {
 
       contentList.push({
         contentStr,
-        oriFileName: path.basename(filePath),
+        oriFileName: window.path.basename(filePath),
         oriFilePath: filePath,
       });
     }

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.generate-request-collection.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.generate-request-collection.tsx
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 import type { IRuleResult } from '@stoplight/spectral-core';
 import { href, redirect } from 'react-router';
 
@@ -29,10 +27,12 @@ export async function clientAction({ params }: Route.ClientActionArgs) {
 
   const isLintError = (result: IRuleResult) => result.severity === 0;
 
-  const gitRepositoryId = models.project.isGitProject(project) ? project.gitRepositoryId : workspaceMeta?.gitRepositoryId;
+  const gitRepositoryId = models.project.isGitProject(project)
+    ? project.gitRepositoryId
+    : workspaceMeta?.gitRepositoryId;
 
   const rulesetPath = gitRepositoryId
-    ? path.join(window.app.getPath('userData'), `version-control/git/${gitRepositoryId}/other/.spectral.yaml`)
+    ? window.path.join(window.app.getPath('userData'), `version-control/git/${gitRepositoryId}/other/.spectral.yaml`)
     : '';
 
   const { diagnostics, error } = await window.main.lintSpec({ documentContent: apiSpec.contents, rulesetPath });

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 import { type IRuleResult } from '@stoplight/spectral-core';
 import CodeMirror from 'codemirror';
 import type { OpenAPIV3 } from 'openapi-types';
@@ -86,11 +84,13 @@ export async function clientLoader({ params }: Route.ClientLoaderArgs) {
 
   const workspaceMeta = await services.workspaceMeta.getByParentId(workspaceId);
 
-  const gitRepositoryId = models.project.isGitProject(project) ? project.gitRepositoryId : workspaceMeta?.gitRepositoryId;
+  const gitRepositoryId = models.project.isGitProject(project)
+    ? project.gitRepositoryId
+    : workspaceMeta?.gitRepositoryId;
   // we don't run the lint here because it is expensive and slows first render too much
   // TODO: add this in once we run this loader outside the renderer
   const rulesetPath = gitRepositoryId
-    ? path.join(window.app.getPath('userData'), `version-control/git/${gitRepositoryId}/other/.spectral.yaml`)
+    ? window.path.join(window.app.getPath('userData'), `version-control/git/${gitRepositoryId}/other/.spectral.yaml`)
     : '';
 
   let parsedSpec: OpenAPIV3.Document | undefined;
@@ -373,8 +373,7 @@ const Component = ({ params }: Route.ComponentProps) => {
     let parsedSpec: string | undefined;
     try {
       // yaml parses json correctly
-      parsedSpec = YAML.parse(editorValue)
-
+      parsedSpec = YAML.parse(editorValue);
     } catch {
       showToast({
         title: 'Failed to convert spec format',
@@ -387,8 +386,7 @@ const Component = ({ params }: Route.ComponentProps) => {
     const contents = to === 'json' ? JSON.stringify(parsedSpec, null, 2) : YAML.stringify(parsedSpec);
     editor.current?.setValue(contents);
     updateApiSpec({ organizationId, projectId, workspaceId, contents });
-
-  }
+  };
 
   const specActionList: SpecActionItem[] = [
     {
@@ -417,17 +415,25 @@ const Component = ({ params }: Route.ComponentProps) => {
         setIsSpecPaneOpen(!isSpecPaneOpen);
       },
     },
-    ...(specFormat === 'json' ? [{
-      id: 'convert-to-yaml',
-      name: 'Convert to YAML',
-      icon: <Icon className="w-3" icon="sync-alt" />,
-      action: () => switchFormat('yaml'),
-    }] : specFormat === 'yaml' ? [{
-      id: 'convert-to-json',
-      name: 'Convert to JSON',
-      icon: <Icon className="w-3" icon="sync-alt" />,
-      action: () => switchFormat('json'),
-    }] : []),
+    ...(specFormat === 'json'
+      ? [
+          {
+            id: 'convert-to-yaml',
+            name: 'Convert to YAML',
+            icon: <Icon className="w-3" icon="sync-alt" />,
+            action: () => switchFormat('yaml'),
+          },
+        ]
+      : specFormat === 'yaml'
+        ? [
+            {
+              id: 'convert-to-json',
+              name: 'Convert to JSON',
+              icon: <Icon className="w-3" icon="sync-alt" />,
+              action: () => switchFormat('json'),
+            },
+          ]
+        : []),
   ];
 
   const disabledKeys = specActionList.filter(item => item.isDisabled).map(item => item.id);

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.update.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.update.tsx
@@ -1,5 +1,3 @@
-import path from 'node:path';
-
 import { href } from 'react-router';
 
 import { models, services } from '~/insomnia-data';
@@ -69,15 +67,15 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   if (models.project.isGitProject(project)) {
     const workspaceMeta = await services.workspaceMeta.getOrCreateByParentId(workspace._id);
 
-    const existingPathDir = path.dirname(workspaceMeta.gitFilePath || '');
-    let fileName = path.basename(workspaceMeta.gitFilePath || '');
+    const existingPathDir = window.path.dirname(workspaceMeta.gitFilePath || '');
+    let fileName = window.path.basename(workspaceMeta.gitFilePath || '');
 
     if (patch.fileName && typeof patch.fileName === 'string') {
       fileName = patch.fileName;
     }
 
     await services.workspaceMeta.update(workspaceMeta, {
-      gitFilePath: path.join(existingPathDir, safeToUseInsomniaFileNameWithExt(fileName)),
+      gitFilePath: window.path.join(existingPathDir, safeToUseInsomniaFileNameWithExt(fileName)),
     });
   }
 


### PR DESCRIPTION
Plan: https://github.com/Kong/insomnia/pull/9803

## Purpose
- Remove route-local `node:path` usage from the first route-only migration slice.
- Switch these routes to the existing `window.path` preload bridge without changing route behavior.

## Files in scope
- `packages/insomnia/src/routes/import.scan.tsx`
- `packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.update.tsx`
- `packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx`
- `packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.generate-request-collection.tsx`
- `packages/insomnia/config/renderer-node-import-baseline.json`

## Baseline entries expected to be removed
- `src/routes/import.scan.tsx -> path`
- `src/routes/organization.$organizationId.project.$projectId.workspace.update.tsx -> path`
- `src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx -> path`
- `src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.generate-request-collection.tsx -> path`

## Any new preload or IPC surface added
- None. This PR reuses the existing `window.path` preload API.

## Any deliberate deferrals to later PRs
- Routes that still need privileged file reads or writes are deferred to PR 2.
- Shared helper cleanup and renderer-to-main boundary extraction are deferred to PR 3 and PR 4.
