### PR TITLE
refactor: route fs backed cleanup

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,23 @@ import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
 const rendererBuiltinSpecifiers = [...builtinModules, ...builtinModules.map(moduleName => `node:${moduleName}`)];
+const generalRestrictedImportPatterns = [
+  // Shouldn't import packages by relative path
+  {
+    group: ['**/*/insomnia-api/**'],
+    message: "Please use 'insomnia-api' instead of relative paths",
+  },
+  // Block relative paths to insomnia-data
+  {
+    group: ['./**/insomnia-data', './**/insomnia-data/**', '../**/insomnia-data', '../**/insomnia-data/**'],
+    message: "Please use '~/insomnia-data' instead of relative paths",
+  },
+  // Only allow ~/insomnia-data and ~/insomnia-data/node
+  {
+    regex: '^~/insomnia-data/(?!node($|/)).+',
+    message: "Only '~/insomnia-data' and '~/insomnia-data/node' are allowed",
+  },
+];
 const rendererNodeMigrationOffenders = [
   'packages/insomnia/src/common/misc.ts',
   'packages/insomnia/src/common/significant-diff-detection.ts',
@@ -86,23 +103,6 @@ export default defineConfig([
       'playwright/no-wait-for-timeout': 'error',
     },
   },
-  // nodeIntegration: false section
-  {
-    files: [
-      'packages/insomnia/src/ui/**/*.{ts,tsx}',
-      'packages/insomnia/src/routes/**/*.{ts,tsx}',
-      'packages/insomnia/src/common/**/*.{ts,tsx}',
-    ],
-    ignores: rendererNodeRestrictionIgnores,
-    rules: {
-      'no-restricted-imports': [
-        'error',
-        {
-          paths: rendererBuiltinSpecifiers,
-        },
-      ],
-    },
-  },
   // React hooks section
   {
     files: ['packages/insomnia/src/**/*.{ts,tsx}'],
@@ -168,23 +168,25 @@ export default defineConfig([
       'no-restricted-imports': [
         'error',
         {
-          patterns: [
-            // Shouldn't import packages by relative path
-            {
-              group: ['**/*/insomnia-api/**'],
-              message: "Please use 'insomnia-api' instead of relative paths",
-            },
-            // Block relative paths to insomnia-data
-            {
-              group: ['./**/insomnia-data', './**/insomnia-data/**', '../**/insomnia-data', '../**/insomnia-data/**'],
-              message: "Please use '~/insomnia-data' instead of relative paths",
-            },
-            // Only allow ~/insomnia-data and ~/insomnia-data/node
-            {
-              regex: '^~/insomnia-data/(?!node($|/)).+',
-              message: "Only '~/insomnia-data' and '~/insomnia-data/node' are allowed",
-            },
-          ],
+          patterns: generalRestrictedImportPatterns,
+        },
+      ],
+    },
+  },
+  // nodeIntegration: false section
+  {
+    files: [
+      'packages/insomnia/src/ui/**/*.{ts,tsx}',
+      'packages/insomnia/src/routes/**/*.{ts,tsx}',
+      'packages/insomnia/src/common/**/*.{ts,tsx}',
+    ],
+    ignores: rendererNodeRestrictionIgnores,
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: rendererBuiltinSpecifiers,
+          patterns: generalRestrictedImportPatterns,
         },
       ],
     },

--- a/packages/insomnia/NODE_INTEGRATION_MIGRATION_PR_PLAN.md
+++ b/packages/insomnia/NODE_INTEGRATION_MIGRATION_PR_PLAN.md
@@ -469,3 +469,4 @@ This migration is complete when:
 2. The baseline file is empty or reduced to intentionally permitted entries.
 3. Lint restrictions can be tightened by removing temporary offender exclusions.
 4. The main BrowserWindow runs with `nodeIntegration: false` without renderer regressions.
+5. Security audit of changes is complete, including the writeResponseBodyToFile preload function.

--- a/packages/insomnia/config/renderer-node-import-baseline.json
+++ b/packages/insomnia/config/renderer-node-import-baseline.json
@@ -161,19 +161,19 @@
       "builtin": "path"
     },
     {
-      "importer": "src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx",
-      "builtin": "fs"
-    },
-    {
-      "importer": "src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx",
+      "importer": "src/routes/import.scan.tsx",
       "builtin": "path"
     },
     {
-      "importer": "src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx",
-      "builtin": "fs"
+      "importer": "src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.generate-request-collection.tsx",
+      "builtin": "path"
     },
     {
-      "importer": "src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx",
+      "importer": "src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.spec.tsx",
+      "builtin": "path"
+    },
+    {
+      "importer": "src/routes/organization.$organizationId.project.$projectId.workspace.update.tsx",
       "builtin": "path"
     },
     {

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -188,6 +188,7 @@ const main: Window['main'] = {
   curlRequest: options => ipcRenderer.invoke('curlRequest', options),
   cancelCurlRequest: options => ipcRenderer.send('cancelCurlRequest', options),
   writeFile: options => ipcRenderer.invoke('writeFile', options),
+  writeResponseBodyToFile: options => ipcRenderer.invoke('writeResponseBodyToFile', options),
   insecureReadFile: options => ipcRenderer.invoke('insecureReadFile', options),
   insecureReadFileWithEncoding: options => ipcRenderer.invoke('insecureReadFileWithEncoding', options),
   secureReadFile: options => ipcRenderer.invoke('secureReadFile', options),

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -135,7 +135,8 @@ export type HandleChannels =
   | 'webSocket.event.send'
   | 'webSocket.open'
   | 'webSocket.readyState'
-  | 'writeFile';
+  | 'writeFile'
+  | 'writeResponseBodyToFile';
 
 export const ipcMainHandle = (
   channel: HandleChannels,

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -1,6 +1,8 @@
 import fs, { mkdirSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import zlib from 'node:zlib';
 
 import type { ISpectralDiagnostic } from '@stoplight/spectral-core';
 import chardet from 'chardet';
@@ -87,6 +89,28 @@ const readDir = async (_: unknown, options: { path: string }) => {
   }
 };
 
+const writeResponseBodyToFile = async (
+  _: unknown,
+  options: { sourcePath: string; destinationPath: string; bodyCompression?: 'zip' | null },
+) => {
+  try {
+    const dir = path.dirname(options.destinationPath);
+    await fs.promises.mkdir(dir, { recursive: true });
+
+    await (options.bodyCompression === 'zip'
+      ? pipeline(
+          fs.createReadStream(options.sourcePath),
+          zlib.createGunzip(),
+          fs.createWriteStream(options.destinationPath),
+        )
+      : fs.promises.copyFile(options.sourcePath, options.destinationPath));
+
+    return options.destinationPath;
+  } catch (err) {
+    throw new Error(err);
+  }
+};
+
 export interface RendererToMainBridgeAPI {
   loginStateChange: () => void;
   openInBrowser: (url: string) => void;
@@ -105,6 +129,11 @@ export interface RendererToMainBridgeAPI {
   parseImport: typeof convert;
   multipartBufferToArray: (options: { bodyBuffer: Buffer; contentType: string }) => Promise<Part[]>;
   writeFile: (options: { path: string; content: string | Buffer }) => Promise<string>;
+  writeResponseBodyToFile: (options: {
+    sourcePath: string;
+    destinationPath: string;
+    bodyCompression?: 'zip' | null;
+  }) => Promise<string>;
   secureReadFile: (options: { path: string }) => Promise<string>;
   insecureReadFile: (options: { path: string }) => Promise<string>;
   insecureReadFileWithEncoding: (options: {
@@ -252,6 +281,7 @@ export function registerMainHandlers() {
       throw new Error(err);
     }
   });
+  ipcMainHandle('writeResponseBodyToFile', writeResponseBodyToFile);
 
   ipcMainHandle('lintSpec', async (_, options: { documentContent: string; rulesetPath: string }) => {
     const { documentContent, rulesetPath } = options;

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
@@ -1,6 +1,3 @@
-import { createWriteStream } from 'node:fs';
-import path from 'node:path';
-
 import contentDisposition from 'content-disposition';
 import { extension as mimeExtension } from 'mime-types';
 import { href, redirect } from 'react-router';
@@ -18,7 +15,7 @@ import { services } from '~/insomnia-data';
 import type { ResponsePatch } from '~/main/network/libcurl-promise';
 import type { TimingStep } from '~/main/network/request-timing';
 import * as models from '~/models';
-import { getBodyStream } from '~/models/helpers/response-operations';
+import { getBodyBuffer } from '~/models/helpers/response-operations';
 import {
   defaultSendActionRuntime,
   fetchRequestData,
@@ -69,7 +66,7 @@ export interface RunnerContextForRequest {
   responseId: string;
 }
 
-const writeToDownloadPath = (
+const writeToDownloadPath = async (
   downloadPathAndName: string,
   responsePatch: ResponsePatch,
   requestMeta: RequestMeta,
@@ -77,27 +74,20 @@ const writeToDownloadPath = (
 ) => {
   invariant(downloadPathAndName, 'filename should be set by now');
 
-  const to = createWriteStream(downloadPathAndName);
-  const readStream = getBodyStream(responsePatch);
-  if (!readStream || typeof readStream === 'string') {
-    return null;
+  try {
+    const bodyBuffer = await getBodyBuffer(responsePatch);
+    await window.main.writeFile({
+      path: downloadPathAndName,
+      content: typeof bodyBuffer === 'string' ? Buffer.alloc(0) : bodyBuffer,
+    });
+    responsePatch.error = `Saved to ${downloadPathAndName}`;
+  } catch (err) {
+    console.warn('Failed to download request after sending', responsePatch.bodyPath, err);
   }
-  readStream.pipe(to);
 
-  return new Promise(resolve => {
-    readStream.on('end', async () => {
-      responsePatch.error = `Saved to ${downloadPathAndName}`;
-      const response = await services.response.create(responsePatch, maxHistoryResponses);
-      await services.requestMeta.update(requestMeta, { activeResponseId: response._id });
-      resolve(null);
-    });
-    readStream.on('error', async err => {
-      console.warn('Failed to download request after sending', responsePatch.bodyPath, err);
-      const response = await services.response.create(responsePatch, maxHistoryResponses);
-      await services.requestMeta.update(requestMeta, { activeResponseId: response._id });
-      resolve(null);
-    });
-  });
+  const response = await services.response.create(responsePatch, maxHistoryResponses);
+  await services.requestMeta.update(requestMeta, { activeResponseId: response._id });
+  return null;
 };
 
 // Can fail with errors from:
@@ -317,8 +307,8 @@ export const sendActionImplementation = async (options: {
     const name = header
       ? contentDisposition.parse(header.value).parameters.filename
       : `${requestData.request.name.replace(/\s/g, '-').toLowerCase()}.${(responsePatch.contentType && mimeExtension(responsePatch.contentType)) || 'unknown'}`;
-    writeToDownloadPath(
-      path.join(requestMeta.downloadPath, name),
+    await writeToDownloadPath(
+      window.path.join(requestMeta.downloadPath, name),
       responsePatch,
       requestMeta,
       requestData.settings.maxHistoryResponses,
@@ -336,7 +326,7 @@ export const sendActionImplementation = async (options: {
     return { nextRequestIdOrName: postMutatedContext.execution?.nextRequestIdOrName };
   }
   window.localStorage.setItem('insomnia.sendAndDownloadLocation', filePath);
-  writeToDownloadPath(filePath, responsePatch, requestMeta, requestData.settings.maxHistoryResponses);
+  await writeToDownloadPath(filePath, responsePatch, requestMeta, requestData.settings.maxHistoryResponses);
   return { nextRequestIdOrName: postMutatedContext.execution?.nextRequestIdOrName };
 };
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
@@ -15,7 +15,6 @@ import { services } from '~/insomnia-data';
 import type { ResponsePatch } from '~/main/network/libcurl-promise';
 import type { TimingStep } from '~/main/network/request-timing';
 import * as models from '~/models';
-import { getBodyBuffer } from '~/models/helpers/response-operations';
 import {
   defaultSendActionRuntime,
   fetchRequestData,
@@ -66,8 +65,6 @@ export interface RunnerContextForRequest {
   responseId: string;
 }
 
-const DOWNLOAD_READ_FAILURE = '[sendAction] failed to read response body for download';
-
 const writeToDownloadPath = async (
   downloadPathAndName: string,
   responsePatch: ResponsePatch,
@@ -77,14 +74,13 @@ const writeToDownloadPath = async (
   invariant(downloadPathAndName, 'filename should be set by now');
 
   try {
-    const bodyBuffer = await getBodyBuffer(responsePatch, DOWNLOAD_READ_FAILURE);
-
-    if (typeof bodyBuffer === 'string') {
+    if (!responsePatch.bodyPath) {
       responsePatch.error = `Failed to save to ${downloadPathAndName}: unable to read response body`;
     } else {
-      await window.main.writeFile({
-        path: downloadPathAndName,
-        content: bodyBuffer,
+      await window.main.writeResponseBodyToFile({
+        sourcePath: responsePatch.bodyPath,
+        destinationPath: downloadPathAndName,
+        bodyCompression: responsePatch.bodyCompression,
       });
       responsePatch.error = `Saved to ${downloadPathAndName}`;
     }

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx
@@ -66,6 +66,8 @@ export interface RunnerContextForRequest {
   responseId: string;
 }
 
+const DOWNLOAD_READ_FAILURE = '[sendAction] failed to read response body for download';
+
 const writeToDownloadPath = async (
   downloadPathAndName: string,
   responsePatch: ResponsePatch,
@@ -75,13 +77,19 @@ const writeToDownloadPath = async (
   invariant(downloadPathAndName, 'filename should be set by now');
 
   try {
-    const bodyBuffer = await getBodyBuffer(responsePatch);
-    await window.main.writeFile({
-      path: downloadPathAndName,
-      content: typeof bodyBuffer === 'string' ? Buffer.alloc(0) : bodyBuffer,
-    });
-    responsePatch.error = `Saved to ${downloadPathAndName}`;
+    const bodyBuffer = await getBodyBuffer(responsePatch, DOWNLOAD_READ_FAILURE);
+
+    if (typeof bodyBuffer === 'string') {
+      responsePatch.error = `Failed to save to ${downloadPathAndName}: unable to read response body`;
+    } else {
+      await window.main.writeFile({
+        path: downloadPathAndName,
+        content: bodyBuffer,
+      });
+      responsePatch.error = `Saved to ${downloadPathAndName}`;
+    }
   } catch (err) {
+    responsePatch.error = `Failed to save to ${downloadPathAndName}`;
     console.warn('Failed to download request after sending', responsePatch.bodyPath, err);
   }
 

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx
@@ -1,6 +1,3 @@
-import fs from 'node:fs';
-import path from 'node:path';
-
 import { upsertMockbin } from 'insomnia-api';
 import { href, redirect } from 'react-router';
 
@@ -110,7 +107,7 @@ export async function clientAction({ request, params }: Route.ClientActionArgs) 
       const safeToUseFileNameWithExtension = safeToUseInsomniaFileNameWithExt(fileName);
 
       await services.workspaceMeta.update(workspaceMeta, {
-        gitFilePath: path.join(workspaceData.folderPath || '', safeToUseFileNameWithExtension),
+        gitFilePath: window.path.join(workspaceData.folderPath || '', safeToUseFileNameWithExtension),
       });
     }
 
@@ -310,7 +307,16 @@ async function createMockServer(
       if (workspaceData.apiSpecContents) {
         openapiSpec = workspaceData.apiSpecContents;
       } else if (workspaceData.mockServerSpecSource === 'file') {
-        openapiSpec = fs.readFileSync(workspaceData.mockServerOASFilePath!, 'utf8');
+        const { content, error } = await window.main.insecureReadFileWithEncoding({
+          path: workspaceData.mockServerOASFilePath!,
+          encoding: 'utf8',
+        });
+
+        if (error) {
+          throw new Error(String(error));
+        }
+
+        openapiSpec = content;
       } else if (workspaceData.mockServerSpecSource === 'url') {
         specUrl = workspaceData.mockServerSpecURL!;
       } else if (workspaceData.mockServerSpecSource === 'text') {


### PR DESCRIPTION
Plan: https://github.com/Kong/insomnia/pull/9803

## Purpose
- Remove route-level `node:fs` and remaining `node:path` usage in the route slice that still touches downloads and file reads.
- Keep privileged file work in the main process and keep route code on existing or narrowly-scoped preload APIs.

## Files in scope
- `packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx`
- `packages/insomnia/src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx`
- `packages/insomnia/src/entry.preload.ts`
- `packages/insomnia/src/main/ipc/electron.ts`
- `packages/insomnia/src/main/ipc/main.ts`
- `packages/insomnia/config/renderer-node-import-baseline.json`
- `eslint.config.mjs`

## Baseline entries expected to be removed
- `src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx -> fs`
- `src/routes/organization.$organizationId.project.$projectId.workspace.new.tsx -> path`
- `src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx -> fs`
- `src/routes/organization.$organizationId.project.$projectId.workspace.$workspaceId.debug.request.$requestId.send.tsx -> path`

## Any new preload or IPC surface added
- `window.main.writeResponseBodyToFile(...)` for the debug-send route so the main process owns the file-write boundary.
- The route cleanup otherwise reuses existing preload surface such as `window.path` and existing file-read helpers.

## Any deliberate deferrals to later PRs
- Shared helper cleanup remains in PR 3.
- Renderer-to-main extraction for shared pure helpers remains in PR 4.
- Broader network and gRPC privileged boundary work remains in later migration slices.
