### PR TITLE
fix(Git Sync): Fix credential validation causing form loop

### DIFF
--- a/packages/insomnia/src/ui/components/git-credentials/git-repository-select.tsx
+++ b/packages/insomnia/src/ui/components/git-credentials/git-repository-select.tsx
@@ -47,6 +47,7 @@ export const GitRepositorySelect = ({
     <div className="flex flex-col">
       <ComboBox
         aria-label="Repositories"
+        name="uri"
         allowsCustomValue={false}
         className="w-full"
         isRequired

--- a/packages/insomnia/src/ui/components/project/git-repo-form.tsx
+++ b/packages/insomnia/src/ui/components/project/git-repo-form.tsx
@@ -96,7 +96,7 @@ export const GitRepoForm: FC<Props> = ({
   const [isEmailSelectOpen, setIsEmailSelectOpen] = useState(false);
 
   const isCredentialInvalid =
-    validateCredentialFetcher.state !== 'idle' ||
+    (validateCredentialFetcher.state !== 'idle' && !validateCredentialFetcher.data) ||
     Boolean(
       validateCredentialFetcher.data &&
         'errors' in validateCredentialFetcher.data &&
@@ -224,7 +224,7 @@ export const GitRepoForm: FC<Props> = ({
               </div>
             </Popover>
           </Select>
-          {validateCredentialFetcher.state !== 'idle' && (
+          {validateCredentialFetcher.state !== 'idle' && !validateCredentialFetcher.data && (
             <div className="flex items-center gap-2 text-sm">
               <Icon icon="spinner" className="animate-spin" />
               <span>Validating credential...</span>
@@ -297,8 +297,8 @@ export const GitRepoForm: FC<Props> = ({
               </Popover>
             </Select>
           )}
-          {selectedProvider && !isCredentialInvalid && (
-            <>
+          {selectedProvider && (
+            <div className={isCredentialInvalid ? 'hidden' : ''}>
               {selectedProvider.supportsFetchRepos ? (
                 <GitRepositorySelect
                   allConnectedRepoURIInfoMap={allConnectedRepoURIInfoMap}
@@ -329,12 +329,16 @@ export const GitRepoForm: FC<Props> = ({
                   }}
                 />
               )}
-            </>
+            </div>
           )}
 
-          {!isCredentialInvalid && (
-            <GitRemoteBranchSelect credentialsId={selectedCredentialsId} url={projectData.uri || ''} isDisabled={false} />
-          )}
+          <div className={isCredentialInvalid ? 'hidden' : ''}>
+            <GitRemoteBranchSelect
+              credentialsId={selectedCredentialsId}
+              url={projectData.uri || ''}
+              isDisabled={false}
+            />
+          </div>
         </Form>
       )}
     </ErrorBoundary>


### PR DESCRIPTION
## Overview

Fixes an issue where selecting a repository to clone triggers a loop in the git repo form.

## Fix:

- **Credential validation check:** Changed `isCredentialInvalid` to only treat non-idle state as invalid when no prior data exists (`state !== 'idle' && !data`), so revalidation after a successful validation no longer flickers the form.
- **CSS hidden instead of unmount:** Replaced conditional rendering (`{!isCredentialInvalid && <Component>}`) with CSS `hidden` class toggling for `GitRepositorySelect` and `GitRemoteBranchSelect`, keeping them mounted so fetcher state is preserved across revalidation cycles.