### PR TITLE
fix(UI update logic): revalidation should happen after actions are completed

### DIFF
--- a/packages/insomnia/src/root.tsx
+++ b/packages/insomnia/src/root.tsx
@@ -13,11 +13,13 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  useFetchers,
   useNavigate,
   useParams,
   useRevalidator,
   useRouteLoaderData,
 } from 'react-router';
+import { useLatest } from 'react-use';
 
 import { EXTERNAL_VAULT_PLUGIN_NAME, isDevelopment } from '~/common/constants';
 import type { Settings, UserSession } from '~/insomnia-data';
@@ -323,11 +325,17 @@ const Root = () => {
   const navigate = useNavigate();
 
   const { revalidate } = useRevalidator();
+  const inflightFetchers = useFetchers();
+  const ifInSubmission = inflightFetchers.some(f => f.formMethod === 'POST');
+  const latestInSubmission = useLatest(ifInSubmission);
+
   useEffect(() => {
     return window.main.on('git.db-synced', () => {
-      revalidate();
+      if (!latestInSubmission.current) {
+        revalidate();
+      }
     });
-  }, [revalidate]);
+  }, [latestInSubmission, revalidate]);
 
   useEffect(() => {
     return window.main.on('shell:open', async (_: IpcRendererEvent, url: string) => {
@@ -577,10 +585,10 @@ const Root = () => {
                 <div className="flex flex-col gap-1 text-left">
                   {errorDetailKeys.length > 0
                     ? errorDetailKeys.map(k => (
-                      <span key={k} className="whitespace-normal">
-                        {k}: {restParams[k]}
-                      </span>
-                    ))
+                        <span key={k} className="whitespace-normal">
+                          {k}: {restParams[k]}
+                        </span>
+                      ))
                     : 'Unknown error'}
                 </div>
               ),


### PR DESCRIPTION
## Overview

Calling revalidate with active fetchers can lead to the following bug:
- The component that inits the fetcher hook is unmounted before the fetcher gets a result back
- We rely on redirect or the fetcher's state to update some UI

## Fix

Similar to how we solve this in the event stream context we can only revalidate after all actions have finished:
https://github.com/gatzjames/insomnia/blob/26e40175a5a554f3657d822efd4c40adee930c03/packages/insomnia/src/ui/context/app/insomnia-event-stream-context.tsx#L200-L202