### PR TITLE
chore: isolate gRPC proto file preparation behind IPC boundary

### DIFF
--- a/packages/insomnia/config/renderer-node-import-baseline.json
+++ b/packages/insomnia/config/renderer-node-import-baseline.json
@@ -81,26 +81,6 @@
       "builtin": "zlib"
     },
     {
-      "importer": "src/network/grpc/proto-directory-loader.tsx",
-      "builtin": "fs"
-    },
-    {
-      "importer": "src/network/grpc/proto-directory-loader.tsx",
-      "builtin": "path"
-    },
-    {
-      "importer": "src/network/grpc/write-proto-file.ts",
-      "builtin": "fs"
-    },
-    {
-      "importer": "src/network/grpc/write-proto-file.ts",
-      "builtin": "os"
-    },
-    {
-      "importer": "src/network/grpc/write-proto-file.ts",
-      "builtin": "path"
-    },
-    {
       "importer": "src/network/network.ts",
       "builtin": "fs"
     },

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -97,6 +97,7 @@ const grpc: gRPCBridgeAPI = {
   closeAll: () => ipcRenderer.send('grpc.closeAll'),
   loadMethods: options => ipcRenderer.invoke('grpc.loadMethods', options),
   loadMethodsFromReflection: options => ipcRenderer.invoke('grpc.loadMethodsFromReflection', options),
+  writeProtoFile: protoFileId => ipcRenderer.invoke('grpc.writeProtoFile', protoFileId),
 };
 
 const secretStorage: secretStorageBridgeAPI = {

--- a/packages/insomnia/src/main/ipc/__tests__/grpc.test.ts
+++ b/packages/insomnia/src/main/ipc/__tests__/grpc.test.ts
@@ -5,10 +5,32 @@ import * as grpcReflection from 'grpc-reflection-js';
 import protobuf from 'protobufjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { loadMethodsFromReflection } from '../grpc';
+import { services } from '~/insomnia-data';
+
+import { loadMethodsFromReflection, writeProtoFileById } from '../grpc';
 
 vi.mock('grpc-reflection-js');
 vi.mock('@connectrpc/connect-node');
+vi.mock('../../../network/grpc/write-proto-file');
+
+describe('writeProtoFileById', () => {
+  it('resolves proto file from services and delegates to writeProtoFile', async () => {
+    const { writeProtoFile } = await import('../../../network/grpc/write-proto-file');
+    const w = await services.workspace.create();
+    const pf = await services.protoFile.create({ parentId: w._id, protoText: 'text' });
+    const expected = { filePath: 'foo.proto', dirs: ['/tmp/insomnia-grpc'] };
+    vi.mocked(writeProtoFile).mockResolvedValue(expected);
+
+    const result = await writeProtoFileById(pf._id);
+
+    expect(writeProtoFile).toHaveBeenCalledWith(expect.objectContaining({ _id: pf._id }));
+    expect(result).toEqual(expected);
+  });
+
+  it('throws when the proto file is not found', async () => {
+    await expect(writeProtoFileById('nonexistent-id')).rejects.toThrow('Proto file nonexistent-id not found');
+  });
+});
 
 describe('loadMethodsFromReflection', () => {
   describe('one service reflection', () => {

--- a/packages/insomnia/src/main/ipc/__tests__/grpc.test.ts
+++ b/packages/insomnia/src/main/ipc/__tests__/grpc.test.ts
@@ -12,10 +12,15 @@ import { loadMethodsFromReflection, writeProtoFileById } from '../grpc';
 vi.mock('grpc-reflection-js');
 vi.mock('@connectrpc/connect-node');
 vi.mock('../../../network/grpc/write-proto-file');
+vi.mock('@grpc/proto-loader', async importOriginal => {
+  const actual = await importOriginal();
+  return { ...actual, load: vi.fn().mockResolvedValue({}) };
+});
 
 describe('writeProtoFileById', () => {
   it('resolves proto file from services and delegates to writeProtoFile', async () => {
     const { writeProtoFile } = await import('../../../network/grpc/write-proto-file');
+    const { load } = await import('@grpc/proto-loader');
     const w = await services.workspace.create();
     const pf = await services.protoFile.create({ parentId: w._id, protoText: 'text' });
     const expected = { filePath: 'foo.proto', dirs: ['/tmp/insomnia-grpc'] };
@@ -24,6 +29,7 @@ describe('writeProtoFileById', () => {
     const result = await writeProtoFileById(pf._id);
 
     expect(writeProtoFile).toHaveBeenCalledWith(expect.objectContaining({ _id: pf._id }));
+    expect(load).toHaveBeenCalledWith('foo.proto', expect.objectContaining({ includeDirs: ['/tmp/insomnia-grpc'] }));
     expect(result).toEqual(expected);
   });
 

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -78,6 +78,7 @@ export type HandleChannels =
   | 'git.getGitProviderEmails'
   | 'grpc.loadMethods'
   | 'grpc.loadMethodsFromReflection'
+  | 'grpc.writeProtoFile'
   | 'insecureReadFile'
   | 'insecureReadFileWithEncoding'
   | 'installPlugin'

--- a/packages/insomnia/src/main/ipc/grpc.ts
+++ b/packages/insomnia/src/main/ipc/grpc.ts
@@ -64,10 +64,23 @@ export interface gRPCBridgeAPI {
   writeProtoFile: (protoFileId: string) => Promise<{ filePath: string; dirs: string[] }>;
 }
 
+const grpcOptions = {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+};
+
 export const writeProtoFileById = async (protoFileId: string): Promise<{ filePath: string; dirs: string[] }> => {
   const protoFile = await services.protoFile.getById(protoFileId);
   invariant(protoFile, `Proto file ${protoFileId} not found`);
-  return writeProtoFile(protoFile);
+  const result = await writeProtoFile(protoFile);
+  await protoLoader.load(result.filePath, {
+    ...grpcOptions,
+    includeDirs: result.dirs,
+  });
+  return result;
 };
 
 export function registergRPCHandlers() {
@@ -81,13 +94,6 @@ export function registergRPCHandlers() {
   ipcMainHandle('grpc.writeProtoFile', (_, protoFileId: string) => writeProtoFileById(protoFileId));
 }
 
-const grpcOptions = {
-  keepCase: true,
-  longs: String,
-  enums: String,
-  defaults: true,
-  oneofs: true,
-};
 const loadMethodsFromFilePath = async (filePath: string, includeDirs: string[]): Promise<MethodDefs[]> => {
   const definition = await protoLoader.load(filePath, {
     ...grpcOptions,

--- a/packages/insomnia/src/main/ipc/grpc.ts
+++ b/packages/insomnia/src/main/ipc/grpc.ts
@@ -61,7 +61,14 @@ export interface gRPCBridgeAPI {
   loadMethods: typeof loadMethods;
   loadMethodsFromReflection: typeof loadMethodsFromReflection;
   closeAll: typeof closeAll;
+  writeProtoFile: (protoFileId: string) => Promise<{ filePath: string; dirs: string[] }>;
 }
+
+export const writeProtoFileById = async (protoFileId: string): Promise<{ filePath: string; dirs: string[] }> => {
+  const protoFile = await services.protoFile.getById(protoFileId);
+  invariant(protoFile, `Proto file ${protoFileId} not found`);
+  return writeProtoFile(protoFile);
+};
 
 export function registergRPCHandlers() {
   ipcMainOn('grpc.start', start);
@@ -71,6 +78,7 @@ export function registergRPCHandlers() {
   ipcMainOn('grpc.closeAll', closeAll);
   ipcMainHandle('grpc.loadMethods', (_, requestId) => loadMethods(requestId));
   ipcMainHandle('grpc.loadMethodsFromReflection', (_, requestId) => loadMethodsFromReflection(requestId));
+  ipcMainHandle('grpc.writeProtoFile', (_, protoFileId: string) => writeProtoFileById(protoFileId));
 }
 
 const grpcOptions = {

--- a/packages/insomnia/src/ui/components/modals/proto-files-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/proto-files-modal.tsx
@@ -8,7 +8,6 @@ import * as models from '~/models';
 
 import { type ChangeBufferEvent, database as db } from '../../../common/database';
 import { selectFileOrFolder } from '../../../common/select-file-or-folder';
-import { writeProtoFile } from '../../../network/grpc/write-proto-file';
 import { Modal, type ModalHandle } from '../base/modal';
 import { ModalBody } from '../base/modal-body';
 import { ModalFooter } from '../base/modal-footer';
@@ -245,15 +244,7 @@ export const ProtoFilesModal: FC<Props> = ({ defaultId, onHide, onSave }) => {
 
       for (const protoFile of loadedFiles) {
         try {
-          const { filePath, dirs } = await writeProtoFile(protoFile);
-          protoLoader.load(filePath, {
-            keepCase: true,
-            longs: String,
-            enums: String,
-            defaults: true,
-            oneofs: true,
-            includeDirs: dirs,
-          });
+          await window.main.grpc.writeProtoFile(protoFile._id);
         } catch (error) {
           showError({
             title: 'Invalid Proto File',


### PR DESCRIPTION
## Purpose
Isolate gRPC proto temp-file creation behind the Electron preload boundary, removing `fs`, `os`, and `path` ownership from the renderer-reachable code path as part of the `nodeIntegration: false` migration.

## Single feature scope
Preparing proto directories and temp proto files for gRPC request execution.

## Implementation notes
- Moves proto temp-file creation behind a main-process IPC boundary.
- Keeps request assembly in the renderer.
- Avoids mixing in generic request execution, OAuth, or response archival work.

## Files in scope
- `packages/insomnia/src/network/grpc/write-proto-file.ts`
- `packages/insomnia/src/main/ipc/grpc.ts`
- `packages/insomnia/src/main/ipc/electron.ts`
- `packages/insomnia/src/entry.preload.ts`
- `packages/insomnia/src/ui/components/modals/proto-files-modal.tsx`
- `packages/insomnia/src/main/ipc/__tests__/grpc.test.ts`
- `packages/insomnia/config/renderer-node-import-baseline.json`

## Baseline entries removed
- `src/network/grpc/proto-directory-loader.tsx -> fs`
- `src/network/grpc/proto-directory-loader.tsx -> path`
- `src/network/grpc/write-proto-file.ts -> fs`
- `src/network/grpc/write-proto-file.ts -> os`
- `src/network/grpc/write-proto-file.ts -> path`

## Test automation plan
- Keeps existing focused coverage for proto file writing.
- Adds IPC contract coverage for the new `grpc.writeProtoFile` bridge.
- Leaves broader gRPC execution behavior unchanged.

## New preload or IPC surface added
- `grpc.writeProtoFile(protoFileId: string)` exposed on `window.main.grpc`

## Deliberate deferrals
- OAuth token helpers
- Generic network file IO
- Response archival helpers
