### PR TITLE
chore: remove node:crypto from renderer-reachable OAuth code

### DIFF
--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -6,6 +6,7 @@ import type { GenerateMcpSamplingResponseFunction } from '~/plugins/types';
 
 import type { GitServiceAPI } from './main/git-service';
 import type { gRPCBridgeAPI } from './main/ipc/grpc';
+import type { OAuthCryptoBridgeAPI } from './main/ipc/oauth';
 import type { secretStorageBridgeAPI } from './main/ipc/secret-storage';
 import type { AIFeatureNames } from './main/llm-config-service';
 import type { CurlBridgeAPI } from './main/network/curl';
@@ -208,6 +209,9 @@ const main: Window['main'] = {
   grpc,
   curl,
   secretStorage,
+  oauthCrypto: {
+    getOAuth1AuthHeader: params => ipcRenderer.invoke('oauthCrypto.getOAuth1AuthHeader', params),
+  } satisfies OAuthCryptoBridgeAPI,
   trackSegmentEvent: options => ipcRenderer.send('trackSegmentEvent', options),
   trackPageView: options => ipcRenderer.send('trackPageView', options),
   setCurrentOrganizationId: organizationId => ipcRenderer.send('analytics.setOrganizationId', organizationId),

--- a/packages/insomnia/src/main/ipc/__tests__/oauth.test.ts
+++ b/packages/insomnia/src/main/ipc/__tests__/oauth.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+
+import { encodePKCE } from '~/network/o-auth-2/get-token';
+
+import { oauth1SignRequest } from '../oauth';
+
+describe('oauth1SignRequest', () => {
+  it('signs with HMAC-SHA1', () => {
+    const result = oauth1SignRequest({
+      url: 'https://insomnia.rest/',
+      method: 'GET',
+      signatureMethod: 'HMAC-SHA1',
+      consumerKey: 'consumerKey',
+      consumerSecret: 'consumerSecret',
+      tokenKey: 'tokenKey',
+      tokenSecret: 'tokenSecret',
+      nonce: 'nonce',
+      timestamp: '1234567890',
+      callback: 'https://insomnia.rest/callback/',
+    });
+
+    expect(result.Authorization).toContain('OAuth');
+    expect(result.Authorization).toContain('oauth_signature_method="HMAC-SHA1"');
+    expect(result.Authorization).toContain('oauth_consumer_key="consumerKey"');
+    expect(result.Authorization).toContain('oauth_signature="muJumAG6rOEUuJmhx5zOcBquqk8%3D"');
+  });
+
+  it('signs with HMAC-SHA256', () => {
+    const result = oauth1SignRequest({
+      url: 'https://insomnia.rest/',
+      method: 'GET',
+      signatureMethod: 'HMAC-SHA256',
+      consumerKey: 'consumerKey',
+      consumerSecret: 'consumerSecret',
+      tokenKey: 'tokenKey',
+      tokenSecret: 'tokenSecret',
+      nonce: 'nonce',
+      timestamp: '1234567890',
+    });
+
+    expect(result.Authorization).toContain('oauth_signature_method="HMAC-SHA256"');
+    expect(result.Authorization).toMatch(/oauth_signature="[^"]+"/);
+  });
+
+  it('signs with PLAINTEXT', () => {
+    const result = oauth1SignRequest({
+      url: 'https://insomnia.rest/',
+      method: 'GET',
+      signatureMethod: 'PLAINTEXT',
+      consumerKey: 'ck',
+      consumerSecret: 'cs',
+      tokenKey: 'tk',
+      tokenSecret: 'ts',
+    });
+
+    expect(result.Authorization).toContain('oauth_signature_method="PLAINTEXT"');
+    expect(result.Authorization).toMatch(/oauth_signature="[^"]+"/);
+  });
+
+  it('signs with RSA-SHA1', () => {
+    const privateKey =
+      '-----BEGIN RSA PRIVATE KEY-----\n' +
+      'MIICXgIBAAKBgQC6jwJjt/KywX4N4ZA3YOLcNFrS9S2+TcArdMyo89yqLZWzC9x9\n' +
+      'MY4gA+1+iOpG+S/jlDM3WuJSCnEzQhzDo9UGtNODC+Qr8nStRcKdjSOhywRXPd4d\n' +
+      '+u6TOae/Flukwqzl0Pw3fsMWqwp0dni6OIc7E2gm2jj4MTLsd4oq/0igCQIDAQAB\n' +
+      'AoGBAJCdHusRwo6SsxYrjdF/xxuPcgApkmX8e0S0a5lkP9+jKnH6ddaOPW/P25/E\n' +
+      'nmaZ72dokDMOvnV+JrXnP8jgDNatJsBqS2aLBNpSI4TsOQDfhB3rPoafc5s2bNVY\n' +
+      '5SRp2kr3QL74BZzLzAsIJzGDpRyKQGRPzMFiPzkQcfJuO7rpAkEA3gZq2v2OUzcV\n' +
+      'iQIoCy7bkvxaKZUlkj6xT0msExqrAt9mtVE6XW3GsHUSyB2ePOzDz6zcKeX90nTq\n' +
+      '79PAGTAm1wJBANcbO+xt9By9Omq8K51RuKkvlESHH8j+meAWW6DoKJvHdy2/+xnA\n' +
+      'XEcDcWb9cV9V5FNWmJ+mMF1jfu/GxTMp9B8CQQDazaQ80KiUZbK5ZQCllLYbcspA\n' +
+      'NJXkPBhtNQN5iEyD9jm38qb8MBUhDR9HS7kH/aUzYv1N5TRxVXu6ggnMSOHdAkBI\n' +
+      'Gojrp6+8MnHydUDpawtLKve4QNMWvME3rEbqmOeD0EjSvReeeix0YWMR8sKeAlyW\n' +
+      '0uA2I67ynvddyHMxw05hAkEAyXuG1xpqs3VYQeHRC67dQjkKw0YbcOeeWHpo1+cn\n' +
+      'F29dI2yG3Ti+28/WlSdfYGe9P9SfeYM7RQbNbUp1MHWrkg==\n' +
+      '-----END RSA PRIVATE KEY-----';
+
+    const result = oauth1SignRequest({
+      url: 'https://insomnia.rest/',
+      method: 'GET',
+      signatureMethod: 'RSA-SHA1',
+      consumerKey: 'consumerKey',
+      consumerSecret: 'consumerSecret',
+      tokenKey: 'tokenKey',
+      privateKey,
+      nonce: 'nonce',
+      timestamp: '1234567890',
+      callback: 'https://insomnia.rest/callback/',
+    });
+
+    expect(result.Authorization).toContain('oauth_signature_method="RSA-SHA1"');
+    expect(result.Authorization).toContain(
+      'oauth_signature="cuJlDLQcyQkIdfs8sIE9Y1769hrPy%2Fkwq8D%2BSQxl5azvk1TimWSgUECf3vJoF7DkgnvcYhFYTnduldj%2FJ9ttaOh8xmfE7krGm8Yh%2FDqYfvLPKnw%2F%2BAaKjd43Y6ulZqptTaf4q5D0%2FM9MhqI8pNRcblk30fI%2FR6JYRyjHVm3YNZo%3D"',
+    );
+  });
+
+  it('throws on unknown signature method', () => {
+    expect(() =>
+      oauth1SignRequest({
+        url: 'https://example.com',
+        method: 'GET',
+        // @ts-expect-error intentional bad value
+        signatureMethod: 'UNKNOWN',
+        consumerKey: 'ck',
+        consumerSecret: 'cs',
+      }),
+    ).toThrow('Invalid signature method UNKNOWN');
+  });
+});
+
+describe('encodePKCE', () => {
+  it('produces URL-safe base64 without padding', () => {
+    const input = Buffer.from('hello world test input for pkce');
+    const result = encodePKCE(input);
+    expect(result).not.toContain('+');
+    expect(result).not.toContain('/');
+    expect(result).not.toContain('=');
+  });
+
+  it('round-trips through window.crypto.getRandomValues bytes', () => {
+    // Simulate what get-token.ts now does: getRandomValues → Buffer.from → encodePKCE
+    const bytes = new Uint8Array(32);
+    // Fill with deterministic values for test stability
+    bytes.fill(0xab);
+    const verifier = encodePKCE(Buffer.from(bytes));
+    expect(verifier).toMatch(/^[A-Za-z0-9\-_]+$/);
+    expect(verifier.length).toBeGreaterThan(0);
+  });
+
+  it('produces correct SHA-256 code challenge (S256 method)', async () => {
+    // Deterministic verifier; use globalThis.crypto (available in Node 18+)
+    const verifier = 'dGhpcyBpcyBhIHRlc3QgdmVyaWZpZXI';
+    const hashBuf = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+    const challenge = encodePKCE(Buffer.from(hashBuf));
+    expect(challenge).not.toContain('+');
+    expect(challenge).not.toContain('/');
+    expect(challenge).not.toContain('=');
+    expect(challenge.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -111,6 +111,7 @@ export type HandleChannels =
   | 'mcp.primitive.unsubscribeResource'
   | 'mcp.readyState'
   | 'multipartBufferToArray'
+  | 'oauthCrypto.getOAuth1AuthHeader'
   | 'onDefaultBrowserOAuthRedirect'
   | 'open-channel-to-hidden-browser-window'
   | 'openPath'

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -60,6 +60,8 @@ import type { WebSocketBridgeAPI } from '../network/websocket';
 import { ipcMainHandle, ipcMainOn, type RendererOnChannels } from './electron';
 import extractPostmanDataDumpHandler from './extract-postman-data-dump';
 import type { gRPCBridgeAPI } from './grpc';
+import type { OAuthCryptoBridgeAPI } from './oauth';
+import { registerOAuthHandlers } from './oauth';
 import type { secretStorageBridgeAPI } from './secret-storage';
 
 let lintProcess: Electron.UtilityProcess | null = null;
@@ -159,6 +161,7 @@ export interface RendererToMainBridgeAPI {
   git: GitServiceAPI;
   llm: LLMConfigServiceAPI;
   secretStorage: secretStorageBridgeAPI;
+  oauthCrypto: OAuthCryptoBridgeAPI;
   trackSegmentEvent: (options: { event: string; properties?: Record<string, unknown> }) => void;
   trackPageView: (options: { name: string }) => void;
   setCurrentOrganizationId: (organizationId: string | undefined) => void;
@@ -212,6 +215,7 @@ export interface RendererToMainBridgeAPI {
 }
 
 export function registerMainHandlers() {
+  registerOAuthHandlers();
   ipcMainOn('addExecutionStep', (_, options: { requestId: string; stepName: string }) => {
     addExecutionStep(options.requestId, options.stepName);
   });

--- a/packages/insomnia/src/main/ipc/oauth.ts
+++ b/packages/insomnia/src/main/ipc/oauth.ts
@@ -1,0 +1,136 @@
+import crypto from 'node:crypto';
+
+import OAuth1 from 'oauth-1.0a';
+
+import type { OAuth1SignatureMethod } from '~/network/o-auth-1/constants';
+import {
+  SIGNATURE_METHOD_HMAC_SHA1,
+  SIGNATURE_METHOD_HMAC_SHA256,
+  SIGNATURE_METHOD_PLAINTEXT,
+  SIGNATURE_METHOD_RSA_SHA1,
+} from '~/network/o-auth-1/constants';
+
+import { ipcMainHandle } from './electron';
+
+function hashFunction(signatureMethod: OAuth1SignatureMethod) {
+  if (signatureMethod === SIGNATURE_METHOD_HMAC_SHA1) {
+    return function (baseString: string, key: string) {
+      return crypto.createHmac('sha1', key).update(baseString).digest('base64');
+    };
+  }
+
+  if (signatureMethod === SIGNATURE_METHOD_HMAC_SHA256) {
+    return function (baseString: string, key: string) {
+      return crypto.createHmac('sha256', key).update(baseString).digest('base64');
+    };
+  }
+
+  if (signatureMethod === SIGNATURE_METHOD_RSA_SHA1) {
+    return function (baseString: string, privatekey: string) {
+      return crypto.createSign('RSA-SHA1').update(baseString).sign(privatekey, 'base64');
+    };
+  }
+
+  if (signatureMethod === SIGNATURE_METHOD_PLAINTEXT) {
+    return function (baseString: string) {
+      return baseString;
+    };
+  }
+
+  throw new Error(`Invalid signature method ${signatureMethod}`);
+}
+
+export interface OAuth1AuthParams {
+  url: string;
+  method: string;
+  signatureMethod: OAuth1SignatureMethod;
+  consumerKey: string;
+  consumerSecret: string;
+  version?: string;
+  realm?: string;
+  tokenKey?: string;
+  tokenSecret?: string;
+  privateKey?: string;
+  nonce?: string;
+  timestamp?: string;
+  verifier?: string;
+  callback?: string;
+  includeBodyHash?: boolean;
+  formParams?: { name: string; value: string }[];
+}
+
+export interface OAuthCryptoBridgeAPI {
+  getOAuth1AuthHeader: (params: OAuth1AuthParams) => Promise<{ Authorization: string }>;
+}
+
+/** Pure signing function used by both the IPC handler and unit tests. */
+export function oauth1SignRequest(params: OAuth1AuthParams): { Authorization: string } {
+  const oauth = new OAuth1({
+    consumer: {
+      key: params.consumerKey,
+      secret: params.consumerSecret,
+    },
+    signature_method: params.signatureMethod,
+    version: params.version,
+    hash_function: hashFunction(params.signatureMethod || 'HMAC-SHA1'),
+    realm: params.realm,
+  });
+
+  const requestData: OAuth1.RequestOptions = {
+    url: params.url,
+    method: params.method,
+    includeBodyHash: false,
+    data: {},
+  };
+
+  if (params.callback) {
+    requestData.data.oauth_callback = params.callback;
+  }
+
+  if (params.nonce) {
+    requestData.data.oauth_nonce = params.nonce;
+  }
+
+  if (params.timestamp) {
+    requestData.data.oauth_timestamp = params.timestamp;
+  }
+
+  if (params.verifier) {
+    requestData.data.oauth_verifier = params.verifier;
+  }
+
+  if (params.includeBodyHash) {
+    requestData.includeBodyHash = true;
+    for (const p of params.formParams || []) {
+      requestData.data[p.name] = p.value;
+    }
+  }
+
+  let token: OAuth1.Token | undefined;
+
+  if (params.tokenKey && params.tokenSecret) {
+    token = { key: params.tokenKey, secret: params.tokenSecret };
+  } else if (params.tokenKey) {
+    // @ts-expect-error -- TSCONVERSION likely needs a `secret: undefined` or the type is not actually correct.
+    token = { key: params.tokenKey };
+  }
+
+  if (params.signatureMethod === SIGNATURE_METHOD_RSA_SHA1) {
+    token = {
+      key: params.tokenKey || '',
+      secret: params.privateKey || '',
+    };
+    oauth.getSigningKey = function (tokenSecret) {
+      return tokenSecret || '';
+    };
+  }
+
+  const data = oauth.authorize(requestData, token);
+  return oauth.toHeader(data);
+}
+
+export function registerOAuthHandlers() {
+  ipcMainHandle('oauthCrypto.getOAuth1AuthHeader', (_, params: OAuth1AuthParams) => {
+    return oauth1SignRequest(params);
+  });
+}

--- a/packages/insomnia/src/main/mcp/oauth-client-provider.ts
+++ b/packages/insomnia/src/main/mcp/oauth-client-provider.ts
@@ -170,14 +170,14 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     if (this.context.abortController.signal.aborted) {
       throw new Error('MCP Connection aborted');
     }
-    const { relayUrl, decryptOAuthResult } = encryptOAuthUrl(authorizationUrl.toString());
+    const { relayUrl, decryptOAuthResult } = await encryptOAuthUrl(authorizationUrl.toString());
     BrowserWindow.getAllWindows().forEach(window => {
       window.webContents.send('show-oauth-authorization-modal', relayUrl);
     });
     const redirectedResult = await authorizeUserInDefaultBrowser({
       url: relayUrl,
     });
-    const redirectedTo = decryptOAuthResult(redirectedResult);
+    const redirectedTo = await decryptOAuthResult(redirectedResult);
     const redirectParams = Object.fromEntries(new URL(redirectedTo).searchParams);
     const { code: authorizationCode, error, error_description, error_uri } = redirectParams;
     if (error) {

--- a/packages/insomnia/src/network/__tests__/authentication.test.ts
+++ b/packages/insomnia/src/network/__tests__/authentication.test.ts
@@ -1,20 +1,29 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { oauth1SignRequest } from '~/main/ipc/oauth';
 
 import { _buildBearerHeader, getAuthHeader, getAuthObjectOrNull, getAuthQueryParams } from '../authentication';
+
+let previousOauthCrypto: any;
 
 beforeEach(() => {
   // Provide a window.main stub so OAuth1 IPC calls resolve via the real signing implementation.
   // In the Node.js test environment window may be undefined; define it on globalThis.
   const g = globalThis as any;
   g.window ??= {};
-  g.window.main = {
-    oauthCrypto: {
-      getOAuth1AuthHeader: (params: Parameters<typeof oauth1SignRequest>[0]) =>
-        Promise.resolve(oauth1SignRequest(params)),
-    },
+  g.window.main ??= {};
+  previousOauthCrypto = g.window.main.oauthCrypto;
+  g.window.main.oauthCrypto = {
+    getOAuth1AuthHeader: (params: Parameters<typeof oauth1SignRequest>[0]) =>
+      Promise.resolve(oauth1SignRequest(params)),
   };
+});
+
+afterEach(() => {
+  const g = globalThis as any;
+  g.window ??= {};
+  g.window.main ??= {};
+  g.window.main.oauthCrypto = previousOauthCrypto;
 });
 
 describe('OAuth 1.0', () => {

--- a/packages/insomnia/src/network/__tests__/authentication.test.ts
+++ b/packages/insomnia/src/network/__tests__/authentication.test.ts
@@ -1,6 +1,21 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { oauth1SignRequest } from '~/main/ipc/oauth';
 
 import { _buildBearerHeader, getAuthHeader, getAuthObjectOrNull, getAuthQueryParams } from '../authentication';
+
+beforeEach(() => {
+  // Provide a window.main stub so OAuth1 IPC calls resolve via the real signing implementation.
+  // In the Node.js test environment window may be undefined; define it on globalThis.
+  const g = globalThis as any;
+  g.window ??= {};
+  g.window.main = {
+    oauthCrypto: {
+      getOAuth1AuthHeader: (params: Parameters<typeof oauth1SignRequest>[0]) =>
+        Promise.resolve(oauth1SignRequest(params)),
+    },
+  };
+});
 
 describe('OAuth 1.0', () => {
   it('Does OAuth 1.0', async () => {

--- a/packages/insomnia/src/network/o-auth-1/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-1/get-token.ts
@@ -2,48 +2,10 @@
  * Get an OAuth1Token object and also handle storing/saving/refreshing
  * @returns {Promise.<void>}
  */
-import crypto from 'node:crypto';
-
-import OAuth1 from 'oauth-1.0a';
-
 import type { RequestAuthentication, RequestBody } from '~/insomnia-data';
 
 import { CONTENT_TYPE_FORM_URLENCODED } from '../../common/constants';
 import type { OAuth1SignatureMethod } from './constants';
-import {
-  SIGNATURE_METHOD_HMAC_SHA1,
-  SIGNATURE_METHOD_HMAC_SHA256,
-  SIGNATURE_METHOD_PLAINTEXT,
-  SIGNATURE_METHOD_RSA_SHA1,
-} from './constants';
-
-function hashFunction(signatureMethod: OAuth1SignatureMethod) {
-  if (signatureMethod === SIGNATURE_METHOD_HMAC_SHA1) {
-    return function (baseString: string, key: string) {
-      return crypto.createHmac('sha1', key).update(baseString).digest('base64');
-    };
-  }
-
-  if (signatureMethod === SIGNATURE_METHOD_HMAC_SHA256) {
-    return function (baseString: string, key: string) {
-      return crypto.createHmac('sha256', key).update(baseString).digest('base64');
-    };
-  }
-
-  if (signatureMethod === SIGNATURE_METHOD_RSA_SHA1) {
-    return function (baseString: string, privatekey: string) {
-      return crypto.createSign('RSA-SHA1').update(baseString).sign(privatekey, 'base64');
-    };
-  }
-
-  if (signatureMethod === SIGNATURE_METHOD_PLAINTEXT) {
-    return function (baseString: string) {
-      return baseString;
-    };
-  }
-
-  throw new Error(`Invalid signature method ${signatureMethod}`);
-}
 
 export default async function getToken(
   url: string,
@@ -51,75 +13,33 @@ export default async function getToken(
   authentication: Extract<RequestAuthentication, { type: 'oauth1' }>,
   body: RequestBody | null = null,
 ) {
-  const oauth = new OAuth1({
-    consumer: {
-      key: authentication.consumerKey || '',
-      secret: authentication.consumerSecret || '',
-    },
-    signature_method: authentication.signatureMethod,
-    version: authentication.version,
-    hash_function: hashFunction(authentication.signatureMethod || 'HMAC-SHA1'),
-    realm: authentication.realm,
-  });
-  const requestData: OAuth1.RequestOptions = {
-    url: url,
-    method: method,
-    includeBodyHash: false,
-    data: {
-      // These are conditionally filled in below
-    },
-  };
-
-  if (authentication.callback) {
-    requestData.data.oauth_callback = authentication.callback;
-  }
-
-  if (authentication.nonce) {
-    requestData.data.oauth_nonce = authentication.nonce;
-  }
-
-  if (authentication.timestamp) {
-    requestData.data.oauth_timestamp = authentication.timestamp;
-  }
-
-  if (authentication.verifier) {
-    requestData.data.oauth_verifier = authentication.verifier;
-  }
+  const formParams: { name: string; value: string }[] = [];
+  let includeBodyHash = false;
 
   if (authentication.includeBodyHash && body && body.mimeType === CONTENT_TYPE_FORM_URLENCODED) {
-    requestData.includeBodyHash = true;
-
+    includeBodyHash = true;
     for (const p of body.params || []) {
-      requestData.data[p.name] = p.value;
+      formParams.push({ name: p.name, value: p.value ?? '' });
     }
   }
 
-  let token: OAuth1.Token | undefined;
-
-  if (authentication.tokenKey && authentication.tokenSecret) {
-    token = {
-      key: authentication.tokenKey,
-      secret: authentication.tokenSecret,
-    };
-  } else if (authentication.tokenKey) {
-    // @ts-expect-error -- TSCONVERSION likely needs a `secret: undefined` or the type is not actually correct.
-    token = {
-      key: authentication.tokenKey,
-    };
-  }
-
-  if (authentication.signatureMethod === SIGNATURE_METHOD_RSA_SHA1) {
-    token = {
-      key: authentication.tokenKey || '',
-      secret: authentication.privateKey || '',
-    };
-
-    // We override getSigningKey for RSA-SHA1 because we don't want ddo/oauth-1.0a to percentEncode the token
-    oauth.getSigningKey = function (tokenSecret) {
-      return tokenSecret || '';
-    };
-  }
-
-  const data = oauth.authorize(requestData, token);
-  return oauth.toHeader(data);
+  return window.main.oauthCrypto.getOAuth1AuthHeader({
+    url,
+    method,
+    signatureMethod: (authentication.signatureMethod || 'HMAC-SHA1') as OAuth1SignatureMethod,
+    consumerKey: authentication.consumerKey || '',
+    consumerSecret: authentication.consumerSecret || '',
+    version: authentication.version,
+    realm: authentication.realm,
+    tokenKey: authentication.tokenKey,
+    tokenSecret: authentication.tokenSecret,
+    privateKey: authentication.privateKey,
+    nonce: authentication.nonce,
+    timestamp: authentication.timestamp,
+    verifier: authentication.verifier,
+    callback: authentication.callback,
+    includeBodyHash,
+    formParams,
+  });
 }
+

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import querystring from 'node:querystring';
 
 import { v4 as uuidv4 } from 'uuid';
@@ -133,10 +132,16 @@ export const getOAuth2Token = async (
       // default to S256 if usePkce is true and pkceMethod is not defined
       const pkceMethod =
         authentication.usePkce && !authentication.pkceMethod ? PKCE_CHALLENGE_S256 : authentication.pkceMethod;
-      const codeVerifier = authentication.usePkce ? encodePKCE(crypto.randomBytes(32)) : '';
+      const codeVerifier = authentication.usePkce
+        ? encodePKCE(Buffer.from(globalThis.crypto.getRandomValues(new Uint8Array(32))))
+        : '';
       const codeChallenge =
         authentication.usePkce && pkceMethod === PKCE_CHALLENGE_S256
-          ? encodePKCE(crypto.createHash('sha256').update(codeVerifier).digest())
+          ? encodePKCE(
+              Buffer.from(
+                await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier)),
+              ),
+            )
           : codeVerifier;
       const authCodeUrl = new URL(authentication.authorizationUrl);
       const responseType: OAuth2ResponseType = 'code';
@@ -160,7 +165,7 @@ export const getOAuth2Token = async (
       let redirectedTo: string | null = null;
       if (authentication.useDefaultBrowser) {
         const authCodeUrlStr = authCodeUrl.toString();
-        const { relayUrl, decryptOAuthResult } = encryptOAuthUrl(authCodeUrlStr);
+        const { relayUrl, decryptOAuthResult } = await encryptOAuthUrl(authCodeUrlStr);
 
         uiEventBus.emit(OAUTH2_AUTHORIZATION_STATUS_CHANGE, {
           status: 'getting_code',
@@ -173,7 +178,7 @@ export const getOAuth2Token = async (
           url: relayUrl,
         });
 
-        redirectedTo = decryptOAuthResult(result);
+        redirectedTo = await decryptOAuthResult(result);
       } else {
         redirectedTo = await window.main.authorizeUserInWindow({
           url: authCodeUrl.toString(),

--- a/packages/insomnia/src/network/o-auth-2/utils.ts
+++ b/packages/insomnia/src/network/o-auth-2/utils.ts
@@ -1,42 +1,62 @@
-import crypto from 'node:crypto';
-
 import { getOauthRelayUrl } from '~/common/constants';
 import type { DefaultBrowserRedirectParam } from '~/common/misc';
 
-export const encryptOAuthUrl = (authCodeUrlStr: string) => {
-  const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', {
-    modulusLength: 3072,
-    publicKeyEncoding: { type: 'spki', format: 'pem' },
-    privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+function arrayBufferToPem(buffer: ArrayBuffer, label: string): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  bytes.forEach(byte => {
+    binary += String.fromCodePoint(byte);
   });
+  const base64 = btoa(binary);
+  const lines = base64.match(/.{1,64}/g)?.join('\n') ?? base64;
+  return `-----BEGIN ${label}-----\n${lines}\n-----END ${label}-----`;
+}
 
-  const relayUrl = `${getOauthRelayUrl()}?authCodeUrl=${encodeURIComponent(authCodeUrlStr)}&publicKey=${encodeURIComponent(publicKey)}`;
+export const encryptOAuthUrl = async (authCodeUrlStr: string) => {
+  const cryptoApi = globalThis.crypto;
+  const keyPair = await cryptoApi.subtle.generateKey(
+    {
+      name: 'RSA-OAEP',
+      modulusLength: 3072,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['encrypt', 'decrypt'],
+  );
 
-  const decryptOAuthResult = (result: DefaultBrowserRedirectParam): string => {
+  const spkiBuffer = await cryptoApi.subtle.exportKey('spki', keyPair.publicKey);
+  const publicKeyPem = arrayBufferToPem(spkiBuffer, 'PUBLIC KEY');
+
+  const relayUrl = `${getOauthRelayUrl()}?authCodeUrl=${encodeURIComponent(authCodeUrlStr)}&publicKey=${encodeURIComponent(publicKeyPem)}`;
+
+  const decryptOAuthResult = async (result: DefaultBrowserRedirectParam): Promise<string> => {
     if ('redirectUrl' in result) {
       return result.redirectUrl;
     }
 
     const { encryptedRedirectUrl, encryptedKey, iv } = result;
-    const aesKey = crypto.privateDecrypt(
-      {
-        key: privateKey,
-        padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
-        oaepHash: 'sha256',
-      },
+
+    // Decrypt the AES key using RSA-OAEP private key
+    const aesKeyBytes = await cryptoApi.subtle.decrypt(
+      { name: 'RSA-OAEP' },
+      keyPair.privateKey,
       Buffer.from(encryptedKey, 'base64'),
     );
-    const encryptedBuf = Buffer.from(encryptedRedirectUrl, 'base64');
-    const authTag = encryptedBuf.slice(-16);
-    const ciphertext = encryptedBuf.slice(0, -16);
-    // nosemgrep: javascript.node-crypto.security.gcm-no-tag-length.gcm-no-tag-length
-    const decipher = crypto.createDecipheriv('aes-256-gcm', aesKey, Buffer.from(iv, 'base64'), {
-      authTagLength: 16,
-    });
-    decipher.setAuthTag(authTag);
 
-    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
-    return decrypted;
+    const importedAesKey = await cryptoApi.subtle.importKey('raw', aesKeyBytes, { name: 'AES-GCM' }, false, [
+      'decrypt',
+    ]);
+
+    // encryptedRedirectUrl is base64(ciphertext || authTag); AES-GCM expects that layout
+    // nosemgrep: javascript.node-crypto.security.gcm-no-tag-length.gcm-no-tag-length
+    const decrypted = await cryptoApi.subtle.decrypt(
+      { name: 'AES-GCM', iv: Buffer.from(iv, 'base64'), tagLength: 128 },
+      importedAesKey,
+      Buffer.from(encryptedRedirectUrl, 'base64'),
+    );
+
+    return new TextDecoder().decode(decrypted);
   };
 
   return {
@@ -44,3 +64,4 @@ export const encryptOAuthUrl = (authCodeUrlStr: string) => {
     decryptOAuthResult,
   };
 };
+

--- a/packages/insomnia/src/network/o-auth-2/utils.ts
+++ b/packages/insomnia/src/network/o-auth-2/utils.ts
@@ -49,7 +49,6 @@ export const encryptOAuthUrl = async (authCodeUrlStr: string) => {
     ]);
 
     // encryptedRedirectUrl is base64(ciphertext || authTag); AES-GCM expects that layout
-    // nosemgrep: javascript.node-crypto.security.gcm-no-tag-length.gcm-no-tag-length
     const decrypted = await cryptoApi.subtle.decrypt(
       { name: 'AES-GCM', iv: Buffer.from(iv, 'base64'), tagLength: 128 },
       importedAesKey,


### PR DESCRIPTION
## Purpose
Remove isolated OAuth crypto usage from renderer-reachable code without pulling in unrelated network or storage work.

## Single feature scope
OAuth token helper crypto operations.

## Implementation notes
- Moves OAuth 1 signing behind a narrow main-process IPC bridge.
- Replaces renderer `node:crypto` PKCE and relay-URL crypto usage with Web Crypto where appropriate.
- Keeps request sending, response handling, and broader network refactors out of scope.

## Files in scope
- `packages/insomnia/src/network/o-auth-1/get-token.ts`
- `packages/insomnia/src/network/o-auth-2/get-token.ts`
- `packages/insomnia/src/network/o-auth-2/utils.ts`
- `packages/insomnia/src/main/ipc/oauth.ts`
- `packages/insomnia/src/main/ipc/electron.ts`
- `packages/insomnia/src/main/ipc/main.ts`
- `packages/insomnia/src/entry.preload.ts`
- `packages/insomnia/src/main/ipc/__tests__/oauth.test.ts`
- `packages/insomnia/src/network/__tests__/authentication.test.ts`
- `packages/insomnia/src/main/mcp/oauth-client-provider.ts`

## Baseline entries removed
- `src/network/o-auth-1/get-token.ts -> crypto`
- `src/network/o-auth-2/get-token.ts -> crypto`
- `src/network/o-auth-2/utils.ts -> crypto`

## Test automation plan
- Extends OAuth unit coverage around signing, PKCE, and token-helper behavior.
- Adds contract coverage for the new OAuth crypto bridge.
- Avoids broad smoke-test expansion.

## New preload or IPC surface added
- `oauthCrypto.getOAuth1AuthHeader(...)` exposed on `window.main.oauthCrypto`

## Deliberate deferrals
- Generic request execution
- Response archival
- Import or sync persistence
