### PR TITLE
feat: konnect integration sanitizes nunjucks templates on sync

### DIFF
--- a/packages/insomnia/src/konnect/__tests__/transform.test.ts
+++ b/packages/insomnia/src/konnect/__tests__/transform.test.ts
@@ -8,6 +8,7 @@ import {
   mergeHeaders,
   mergePathParameters,
   pathParametersChanged,
+  sanitizeRoute,
 } from '../transform';
 
 // ─── extractRegionFromEndpoint ───────────────────────────────────────────────
@@ -43,6 +44,77 @@ describe('extractRegionFromEndpoint', () => {
 
   it('defaults to "us" for an empty string', () => {
     expect(extractRegionFromEndpoint('')).toBe('us');
+  });
+});
+
+// ─── sanitizeRoute ───────────────────────────────────────────────────────────
+
+describe('sanitizeRoute', () => {
+  const base = {
+    id: 'route-1',
+    protocols: ['http'],
+    snis: null,
+    service: null,
+  };
+
+  it('leaves a clean route unchanged', () => {
+    const route = { ...base, name: 'My Route', methods: ['GET'], paths: ['/api/v1'], hosts: ['example.com'], headers: { 'x-foo': ['bar'] }, expression: null };
+    expect(sanitizeRoute(route)).toEqual(route);
+  });
+
+  it('strips {{ }} from name', () => {
+    expect(sanitizeRoute({ ...base, name: 'Route {{ env.SECRET }}', methods: null, paths: null, hosts: null, headers: null, expression: null }).name).toBe('Route ');
+  });
+
+  it('strips {{ }} from paths, keeping partial values', () => {
+    expect(sanitizeRoute({ ...base, name: null, methods: null, paths: ['/api/{{ env.SECRET }}/users'], hosts: null, headers: null, expression: null }).paths).toEqual(['/api//users']);
+  });
+
+  it('strips {{ }} from hosts, keeping partial values', () => {
+    expect(sanitizeRoute({ ...base, name: null, methods: null, paths: null, hosts: ['{{ env.SECRET }}.test.com'], headers: null, expression: null }).hosts).toEqual(['.test.com']);
+  });
+
+  it('sets methods to null when all entries are fully stripped, so the default fallback applies', () => {
+    expect(sanitizeRoute({ ...base, name: null, methods: ['{{ env.SECRET }}'], paths: null, hosts: null, headers: null, expression: null }).methods).toBeNull();
+  });
+
+  it('filters out fully-stripped entries but retains valid ones', () => {
+    expect(sanitizeRoute({ ...base, name: null, methods: ['{{ env.SECRET }}', 'GET'], paths: null, hosts: null, headers: null, expression: null }).methods).toEqual(['GET']);
+  });
+
+  it('drops header entries whose value becomes entirely empty after stripping', () => {
+    expect(sanitizeRoute({ ...base, name: null, methods: null, paths: null, hosts: null, headers: { 'x-leak': ['{{ env.SECRET }}'] }, expression: null }).headers).toEqual({});
+  });
+
+  it('drops header entries whose name becomes entirely empty after stripping', () => {
+    expect(sanitizeRoute({ ...base, name: null, methods: null, paths: null, hosts: null, headers: { '{{ env.SECRET }}': ['val'] }, expression: null }).headers).toEqual({});
+  });
+
+  it('strips {% %} tag syntax', () => {
+    expect(sanitizeRoute({ ...base, name: '{% set x = secret %}Name', methods: null, paths: null, hosts: null, headers: null, expression: null }).name).toBe('Name');
+  });
+
+  it('strips a {% %} tag nested inside {{ }}, preventing injection via delimiter interleaving', () => {
+    expect(sanitizeRoute({ ...base, name: 'before {{% %}} after', methods: null, paths: null, hosts: null, headers: null, expression: null }).name).toBe('before  after');
+    expect(sanitizeRoute({ ...base, name: '{{% %}% TEST %}', methods: null, paths: null, hosts: null, headers: null, expression: null }).name).toBe('');
+  });
+
+  it('strips a {{ }} tag nested inside {% %}, preventing injection via delimiter interleaving', () => {
+    expect(sanitizeRoute({ ...base, name: '{%{{ env.SECRET }}%}', methods: null, paths: null, hosts: null, headers: null, expression: null }).name).toBe('');
+  });
+
+  it('leaves unpaired delimiters intact (not valid Nunjucks, nothing to render)', () => {
+    expect(sanitizeRoute({ ...base, name: 'hello {{ world', methods: null, paths: null, hosts: null, headers: null, expression: null }).name).toBe('hello {{ world');
+    expect(sanitizeRoute({ ...base, name: 'hello {% world', methods: null, paths: null, hosts: null, headers: null, expression: null }).name).toBe('hello {% world');
+  });
+
+  it('strips {{ }} from expression', () => {
+    expect(sanitizeRoute({ ...base, name: null, methods: null, paths: null, hosts: null, headers: null, expression: 'http.path == "{{ env.SECRET }}"' }).expression).toBe('http.path == ""');
+  });
+
+  it('handles null fields without throwing', () => {
+    const route = { ...base, name: null, methods: null, paths: null, hosts: null, headers: null, expression: null };
+    expect(sanitizeRoute(route)).toEqual(route);
   });
 });
 

--- a/packages/insomnia/src/konnect/sync.ts
+++ b/packages/insomnia/src/konnect/sync.ts
@@ -21,6 +21,7 @@ import {
   pathParametersChanged,
   resolvePath,
   routeDisplayName,
+  sanitizeRoute,
 } from './transform';
 
 interface SyncCounts {
@@ -369,7 +370,7 @@ async function syncServiceWorkspace(
   }
   await insoservices.cookieJar.getOrCreateForParentId(workspace._id);
 
-  const incomingRoutes = await fetchRoutesForService(pat, controlPlane.id, service.id, region, signal);
+  const incomingRoutes = (await fetchRoutesForService(pat, controlPlane.id, service.id, region, signal)).map(sanitizeRoute);
   const existingData = await loadExistingRequestData(workspace._id);
   const incomingKeys = new Set<string>();
   const incomingRouteIds = new Set<string>();

--- a/packages/insomnia/src/konnect/transform.ts
+++ b/packages/insomnia/src/konnect/transform.ts
@@ -1,4 +1,54 @@
-import type { KonnectProxyUrl } from './api';
+import type { KonnectProxyUrl, KonnectRoute } from './api';
+
+// ─── Template injection sanitisation ─────────────────────────────────────────
+
+/**
+ * Strips Nunjucks template syntax (`{{ }}`, `{% %}`) from a string
+ * sourced from external API data, preventing template injection when the value
+ * is later rendered by Insomnia's Nunjucks engine.
+ */
+function stripTemplateSyntax(value: string): string {
+  let prev = '';
+  let result = value;
+  while (result !== prev) {
+    prev = result;
+    result = result
+      .replace(/\{\{[\s\S]*?\}\}/g, '')
+      .replace(/\{%[\s\S]*?%\}/g, '');
+  }
+  return result;
+}
+
+/** Strips template syntax from each item, filters empties, and returns null if nothing remains. */
+function sanitizeStringArray(arr: string[] | null): string[] | null {
+  if (arr === null) { return null; }
+  const result = arr.map(stripTemplateSyntax).filter(s => s.trim() !== '');
+  return result.length > 0 ? result : null;
+}
+
+/**
+ * Returns a copy of the route with Nunjucks template syntax stripped from all
+ * string fields that flow into rendered request content. Array fields that
+ * become entirely empty after stripping are set to null so existing fallbacks
+ * (e.g. default HTTP methods) apply correctly.
+ */
+export function sanitizeRoute(route: KonnectRoute): KonnectRoute {
+  return {
+    ...route,
+    name: route.name !== null ? stripTemplateSyntax(route.name) : null,
+    methods: sanitizeStringArray(route.methods),
+    paths: sanitizeStringArray(route.paths),
+    hosts: sanitizeStringArray(route.hosts),
+    headers: route.headers
+      ? Object.fromEntries(
+        Object.entries(route.headers)
+          .map(([k, vs]): [string, string[]] => [stripTemplateSyntax(k), sanitizeStringArray(vs) ?? []])
+          .filter(([k, vs]) => k.trim() !== '' && vs.length > 0),
+      )
+      : null,
+    expression: route.expression !== null ? stripTemplateSyntax(route.expression) : null,
+  };
+}
 
 // ─── Region extraction ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Insomnia uses Nunjucks templating to render request URLs, headers, and other fields at send time — evaluating expressions like {{ _.proxy_host }} against the active environment. This means any string stored on a request that contains {{ }} or {% %} syntax will be executed when the user sends the request.

During a Konnect sync, route data fetched from the Konnect API is written directly into request fields (URL path, headers, request name, etc.). If a route's fields were crafted to contain Nunjucks expressions, those expressions would be silently evaluated the next time the user sends a request.

This PR introduces sanitization to strip {{ }} and {% %} syntax from all route-sourced string fields before they are stored. This happens at a single point in the sync pipeline, after routes are fetched and before any transformation or persistence. {# #} comment blocks are intentionally left alone as they produce no output when rendered.