### PR TITLE
chore: move konnect sync behind feature flag

### DIFF
--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -112,6 +112,7 @@ export const getMockServiceBinURL = (mockServer: MockServer, path: string) => {
 
 export const getAIServiceURL = () => env.INSOMNIA_AI_URL || 'https://ai-helper.insomnia.rest';
 export const getKonnectApiBaseURL = () => env.KONNECT_API_URL || 'https://global.api.konghq.com';
+export const isKonnectSyncEnabled = () => !!env.KONNECT_SYNC_ENABLED;
 
 // App website
 export const getAppWebsiteBaseURL = () => env.INSOMNIA_APP_WEBSITE_URL || 'https://app.insomnia.rest';

--- a/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project.$projectId._index.tsx
@@ -31,6 +31,7 @@ import {
   dashboardSortOrderName,
   DEFAULT_SIDEBAR_SIZE,
   getAppWebsiteBaseURL,
+  isKonnectSyncEnabled,
 } from '~/common/constants';
 import { database } from '~/common/database';
 import { scopeToBgColorMap, scopeToIconMap, scopeToLabelMap, scopeToTextColorMap } from '~/common/get-workspace-label';
@@ -793,7 +794,7 @@ const Component = () => {
                 projects={projectsWithPresence}
                 storageRules={storageRules}
                 onCreateProject={() => setIsNewProjectModalOpen(true)}
-                konnectSyncEnabled={features.konnectSync.enabled}
+                konnectSyncEnabled={isKonnectSyncEnabled() && features.konnectSync.enabled}
               />
               {activeProject && (
                 <>

--- a/packages/insomnia/src/routes/organization.$organizationId.project._index.tsx
+++ b/packages/insomnia/src/routes/organization.$organizationId.project._index.tsx
@@ -4,7 +4,7 @@ import type { LoaderFunctionArgs } from 'react-router';
 import { href, redirect, useLoaderData, useNavigate, useParams } from 'react-router';
 
 import { logout } from '~/account/session';
-import { DEFAULT_SIDEBAR_SIZE } from '~/common/constants';
+import { DEFAULT_SIDEBAR_SIZE, isKonnectSyncEnabled } from '~/common/constants';
 import type { GitRepository, Project } from '~/insomnia-data';
 import { services } from '~/insomnia-data';
 import { sortProjects } from '~/models/helpers/project';
@@ -122,7 +122,7 @@ const Component = () => {
                 projects={projectsWithPresence}
                 storageRules={storageRules}
                 onCreateProject={() => setIsNewProjectModalOpen(true)}
-                konnectSyncEnabled={features.konnectSync.enabled}
+                konnectSyncEnabled={isKonnectSyncEnabled() && features.konnectSync.enabled}
               />
             </div>
           </Panel>

--- a/packages/insomnia/src/ui/components/modals/settings-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/settings-modal.tsx
@@ -3,7 +3,7 @@ import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 're
 import { Tab, TabList, TabPanel, Tabs } from 'react-aria-components';
 import { useParams } from 'react-router';
 
-import { AI_PLUGIN_NAME } from '~/common/constants';
+import { AI_PLUGIN_NAME, isKonnectSyncEnabled } from '~/common/constants';
 import { isScratchpadOrganizationId } from '~/models/organization';
 import { getBundlePlugins } from '~/plugins';
 import { useRootLoaderData } from '~/root';
@@ -49,7 +49,7 @@ export const SettingsModal = forwardRef<SettingsModalHandle, ModalProps>((props,
       const aiPlugin = plugins.find(p => p.name === AI_PLUGIN_NAME);
       setShouldShowAiSettingsTab(!!aiPlugin && !!userSession.id);
 
-      if (userSession.id && organizationId && !isScratchpadOrganizationId(organizationId)) {
+      if (isKonnectSyncEnabled() && userSession.id && organizationId && !isScratchpadOrganizationId(organizationId)) {
         try {
           const res = await getOrganizationFeatures({ organizationId, sessionId: userSession.id });
           setShouldShowKonnectTab(res?.features?.konnectSync?.enabled ?? false);


### PR DESCRIPTION
Moves the Konnect Sync feature behind a flag while it is in development.