### PR TITLE
feat(Git Sync): Handle non-origin remotes

### DIFF
--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -148,6 +148,7 @@ const git: GitServiceAPI = {
   getGitProviderRepositories: options => ipcRenderer.invoke('git.getGitProviderRepositories', options),
   getGitProviderEmails: options => ipcRenderer.invoke('git.getGitProviderEmails', options),
   getCurrentBranchByRepositoryId: options => ipcRenderer.invoke('git.getCurrentBranchByRepositoryId', options),
+  getBranchRemoteInfo: options => ipcRenderer.invoke('git.getBranchRemoteInfo', options),
 };
 
 const llm: LLMConfigServiceAPI = {

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -494,6 +494,10 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
         branches: await GitVCS.listBranches(),
         gitRepository: gitRepository,
         legacyInsomniaWorkspace,
+        branchRemoteInfo: {
+          ...(await GitVCS.getBranchRemoteInfo()),
+          remotes: await GitVCS.listRemotes(),
+        },
       };
     }
 
@@ -551,6 +555,10 @@ export async function loadGitRepository({ projectId, workspaceId }: { projectId:
       branches: await GitVCS.listBranches(),
       gitRepository,
       legacyInsomniaWorkspace,
+      branchRemoteInfo: {
+        ...(await GitVCS.getBranchRemoteInfo()),
+        remotes: await GitVCS.listRemotes(),
+      },
     };
   } catch (e) {
     const errorMessage = e instanceof Error ? e.message : 'Error while fetching git repository.';
@@ -1851,6 +1859,7 @@ export const createNewGitBranchAction = async ({
 export interface CheckoutGitBranchResult {
   errors?: string[];
   success?: boolean;
+  warnings?: string[];
 }
 
 export const checkoutGitBranchAction = async ({
@@ -1895,6 +1904,18 @@ export const checkoutGitBranchAction = async ({
     });
 
     await database.flushChanges(bufferId);
+
+    const branchRemoteInfo = await GitVCS.getBranchRemoteInfo(branch);
+    if (!branchRemoteInfo.isOrigin) {
+      return {
+        success: true,
+        warnings: [
+          `Branch "${branch}" tracks remote "${branchRemoteInfo.trackingRemote}". ` +
+            `Push, pull, and fetch will not work from Insomnia. Use the git CLI to sync this branch.`,
+        ],
+      };
+    }
+
     return {
       success: true,
     };

--- a/packages/insomnia/src/main/git-service.ts
+++ b/packages/insomnia/src/main/git-service.ts
@@ -278,6 +278,39 @@ export async function getProjectGitFileIssues({
   });
 }
 
+export interface BranchRemoteInfo {
+  trackingRemote: string | null;
+  isOrigin: boolean;
+  remoteUrl: string | null;
+  remotes: { remote: string; url: string }[];
+}
+
+export const getBranchRemoteInfo = async ({
+  projectId,
+  workspaceId,
+}: {
+  projectId: string;
+  workspaceId?: string;
+}): Promise<BranchRemoteInfo> => {
+  await getGitRepository({ projectId, workspaceId });
+  const branchInfo = await GitVCS.getBranchRemoteInfo();
+  const remotes = await GitVCS.listRemotes();
+  return { ...branchInfo, remotes };
+};
+
+async function assertBranchOnOrigin(context: string): Promise<void> {
+  const { trackingRemote, isOrigin, remoteUrl } = await GitVCS.getBranchRemoteInfo();
+  if (!isOrigin) {
+    const branch = await GitVCS.getCurrentBranch();
+    throw new Error(
+      `Cannot ${context}: branch "${branch}" tracks remote "${trackingRemote}" (${remoteUrl}), ` +
+        `but Insomnia only manages the "origin" remote. ` +
+        `Use the git CLI to ${context} this branch, or run: ` +
+        `git branch --set-upstream-to=origin/${branch}`,
+    );
+  }
+}
+
 /**
  * Creates a file system client for Git operations
  * Returns different clients based on whether we're working with a workspace or project
@@ -562,6 +595,7 @@ export const getGitBranches = async ({
 
 export const gitFetchAction = async ({ projectId, workspaceId }: { projectId: string; workspaceId?: string }) => {
   try {
+    await assertBranchOnOrigin('fetch');
     const gitRepository = await getGitRepository({ projectId, workspaceId });
     await GitVCS.fetch({
       singleBranch: true,
@@ -676,6 +710,10 @@ export const canPushLoader = async ({
   workspaceId?: string;
 }): Promise<GitCanPushLoaderData> => {
   try {
+    const { isOrigin } = await GitVCS.getBranchRemoteInfo();
+    if (!isOrigin) {
+      return { canPush: false };
+    }
     let hasUnpushedChanges = false;
     const gitRepository = await getGitRepository({ workspaceId, projectId });
     hasUnpushedChanges = await GitVCS.canPush(gitRepository.credentialsId);
@@ -1633,6 +1671,7 @@ export const commitAndPushToGitRepoAction = async ({
   workspaceId?: string;
   message: string;
 }): Promise<CommitToGitRepoResult> => {
+  await assertBranchOnOrigin('push');
   const repo = await getGitRepository({ workspaceId, projectId });
 
   // Validate credentials before committing to prevent orphaned local commits
@@ -2024,6 +2063,7 @@ export const pushToGitRemoteAction = async ({
   workspaceId?: string;
   force?: boolean;
 }): Promise<PushToGitRemoteResult> => {
+  await assertBranchOnOrigin('push');
   const gitRepository = await getGitRepository({ projectId, workspaceId });
 
   // Flush DB changes to disk before pushing
@@ -2170,6 +2210,7 @@ export async function fetchGitRemoteBranches({
 
 export async function pullFromGitRemote({ projectId, workspaceId }: { projectId: string; workspaceId?: string }) {
   try {
+    await assertBranchOnOrigin('pull');
     const gitRepository = await getGitRepository({ projectId, workspaceId });
     invariant(gitRepository.credentialsId, 'Git Credentials ID is required');
     const credentials = await services.gitCredentials.getById(gitRepository.credentialsId);
@@ -2817,6 +2858,7 @@ export interface GitServiceAPI {
   getGitProviderRepositories: typeof getGitProviderRepositories;
   getGitProviderEmails: typeof getGitProviderEmails;
   listGitProviders: typeof listGitProviders;
+  getBranchRemoteInfo: typeof getBranchRemoteInfo;
 }
 
 export const registerGitServiceAPI = () => {
@@ -2919,5 +2961,8 @@ export const registerGitServiceAPI = () => {
   ipcMainHandle(
     'git.getCurrentBranchByRepositoryId',
     (_, options: Parameters<typeof getCurrentBranchByRepositoryId>[0]) => getCurrentBranchByRepositoryId(options),
+  );
+  ipcMainHandle('git.getBranchRemoteInfo', (_, options: Parameters<typeof getBranchRemoteInfo>[0]) =>
+    getBranchRemoteInfo(options),
   );
 };

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -69,6 +69,7 @@ export type HandleChannels =
   | 'git.pushToGitRemote'
   | 'git.resetGitRepo'
   | 'git.getCurrentBranchByRepositoryId'
+  | 'git.getBranchRemoteInfo'
   | 'git.stageChanges'
   | 'git.unstageChanges'
   | 'git.updateGitRepo'

--- a/packages/insomnia/src/sync/git/__tests__/git-vcs.test.ts
+++ b/packages/insomnia/src/sync/git/__tests__/git-vcs.test.ts
@@ -522,4 +522,134 @@ First commit!
       expect((await fsClient.promises.readFile(nestedFile)).toString()).toBe(originalContent + '\n');
     });
   });
+
+  describe('getBranchTrackingRemote', () => {
+    it('returns null when no tracking remote is set', async () => {
+      const fsClient = MemClient.createClient();
+      await fsClient.promises.mkdir(GIT_INSOMNIA_DIR);
+      await fsClient.promises.writeFile(path.join(GIT_INSOMNIA_DIR, fooTxt), 'foo');
+
+      await GitVCS.init({
+        uri: '',
+        repoId: 'test-remote-info',
+        directory: GIT_CLONE_DIR,
+        fs: fsClient,
+        legacyDiff: true,
+      });
+      await GitVCS.setAuthor({ name: 'Karen Brown', email: 'karen@example.com' });
+
+      const remote = await GitVCS.getBranchTrackingRemote();
+      expect(remote).toBeNull();
+    });
+
+    it('returns the configured tracking remote', async () => {
+      const fsClient = MemClient.createClient();
+      await fsClient.promises.mkdir(GIT_INSOMNIA_DIR);
+      await fsClient.promises.writeFile(path.join(GIT_INSOMNIA_DIR, fooTxt), 'foo');
+
+      await GitVCS.init({
+        uri: '',
+        repoId: 'test-tracking-remote',
+        directory: GIT_CLONE_DIR,
+        fs: fsClient,
+        legacyDiff: true,
+      });
+      await GitVCS.setAuthor({ name: 'Karen Brown', email: 'karen@example.com' });
+
+      // Manually set tracking remote via git config
+      const branch = await GitVCS.getCurrentBranch();
+      await git.setConfig({
+        fs: fsClient,
+        dir: GIT_CLONE_DIR,
+        path: `branch.${branch}.remote`,
+        value: 'upstream',
+      });
+
+      const remote = await GitVCS.getBranchTrackingRemote();
+      expect(remote).toBe('upstream');
+    });
+  });
+
+  describe('getBranchRemoteInfo', () => {
+    it('returns isOrigin true when no tracking remote is set', async () => {
+      const fsClient = MemClient.createClient();
+      await fsClient.promises.mkdir(GIT_INSOMNIA_DIR);
+      await fsClient.promises.writeFile(path.join(GIT_INSOMNIA_DIR, fooTxt), 'foo');
+
+      await GitVCS.init({
+        uri: '',
+        repoId: 'test-branch-info-origin',
+        directory: GIT_CLONE_DIR,
+        fs: fsClient,
+        legacyDiff: true,
+      });
+      await GitVCS.setAuthor({ name: 'Karen Brown', email: 'karen@example.com' });
+
+      const info = await GitVCS.getBranchRemoteInfo();
+      expect(info.trackingRemote).toBeNull();
+      expect(info.isOrigin).toBe(true);
+      expect(info.remoteUrl).toBeNull();
+    });
+
+    it('returns isOrigin true when tracking remote is origin', async () => {
+      const fsClient = MemClient.createClient();
+      await fsClient.promises.mkdir(GIT_INSOMNIA_DIR);
+      await fsClient.promises.writeFile(path.join(GIT_INSOMNIA_DIR, fooTxt), 'foo');
+
+      await GitVCS.init({
+        uri: '',
+        repoId: 'test-branch-info-explicit-origin',
+        directory: GIT_CLONE_DIR,
+        fs: fsClient,
+        legacyDiff: true,
+      });
+      await GitVCS.setAuthor({ name: 'Karen Brown', email: 'karen@example.com' });
+
+      const branch = await GitVCS.getCurrentBranch();
+      await git.setConfig({
+        fs: fsClient,
+        dir: GIT_CLONE_DIR,
+        path: `branch.${branch}.remote`,
+        value: 'origin',
+      });
+
+      const info = await GitVCS.getBranchRemoteInfo();
+      expect(info.trackingRemote).toBe('origin');
+      expect(info.isOrigin).toBe(true);
+    });
+
+    it('returns isOrigin false when tracking a non-origin remote', async () => {
+      const fsClient = MemClient.createClient();
+      await fsClient.promises.mkdir(GIT_INSOMNIA_DIR);
+      await fsClient.promises.writeFile(path.join(GIT_INSOMNIA_DIR, fooTxt), 'foo');
+
+      await GitVCS.init({
+        uri: '',
+        repoId: 'test-branch-info-non-origin',
+        directory: GIT_CLONE_DIR,
+        fs: fsClient,
+        legacyDiff: true,
+      });
+      await GitVCS.setAuthor({ name: 'Karen Brown', email: 'karen@example.com' });
+
+      const branch = await GitVCS.getCurrentBranch();
+      await git.setConfig({
+        fs: fsClient,
+        dir: GIT_CLONE_DIR,
+        path: `branch.${branch}.remote`,
+        value: 'upstream',
+      });
+      await git.setConfig({
+        fs: fsClient,
+        dir: GIT_CLONE_DIR,
+        path: 'remote.upstream.url',
+        value: 'https://github.com/other/repo.git',
+      });
+
+      const info = await GitVCS.getBranchRemoteInfo();
+      expect(info.trackingRemote).toBe('upstream');
+      expect(info.isOrigin).toBe(false);
+      expect(info.remoteUrl).toBe('https://github.com/other/repo.git');
+    });
+  });
 });

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -1058,7 +1058,7 @@ export class GitVCS {
   }
 
   async getBranchTrackingRemote(branch?: string): Promise<string | null> {
-    const currentBranch = branch || await this.getCurrentBranch();
+    const currentBranch = branch || (await this.getCurrentBranch());
     try {
       const remote = await git.getConfig({
         ...this._baseOpts,

--- a/packages/insomnia/src/sync/git/git-vcs.ts
+++ b/packages/insomnia/src/sync/git/git-vcs.ts
@@ -1057,6 +1057,42 @@ export class GitVCS {
     return git.listRemotes({ ...this._baseOpts });
   }
 
+  async getBranchTrackingRemote(branch?: string): Promise<string | null> {
+    const currentBranch = branch || await this.getCurrentBranch();
+    try {
+      const remote = await git.getConfig({
+        ...this._baseOpts,
+        path: `branch.${currentBranch}.remote`,
+      });
+      return remote || null;
+    } catch {
+      return null;
+    }
+  }
+
+  async getRemoteUrl(remoteName: string): Promise<string | null> {
+    try {
+      const url = await git.getConfig({
+        ...this._baseOpts,
+        path: `remote.${remoteName}.url`,
+      });
+      return url || null;
+    } catch {
+      return null;
+    }
+  }
+
+  async getBranchRemoteInfo(branch?: string): Promise<{
+    trackingRemote: string | null;
+    isOrigin: boolean;
+    remoteUrl: string | null;
+  }> {
+    const trackingRemote = await this.getBranchTrackingRemote(branch);
+    const isOrigin = trackingRemote === null || trackingRemote === 'origin';
+    const remoteUrl = trackingRemote ? await this.getRemoteUrl(trackingRemote) : null;
+    return { trackingRemote, isOrigin, remoteUrl };
+  }
+
   async setAuthor(author?: GitAuthor) {
     let name = '';
     let email = '';

--- a/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/git-project-sync-dropdown.tsx
@@ -32,6 +32,7 @@ import { useLoaderDeferData } from '~/ui/hooks/use-loader-defer-data';
 import { DEFAULT_STORAGE_RULES } from '~/ui/organization-utils';
 
 import type { MergeConflict } from '../../../sync/types';
+import { GitNonOriginBranchBanner } from '../git/git-non-origin-branch-banner';
 import { Icon } from '../icon';
 import { showModal } from '../modals';
 import { GitProjectBranchesModal } from '../modals/git-project-branches-modal';
@@ -113,6 +114,13 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
     gitRepoDataFetcher.data.legacyInsomniaWorkspace
       ? gitRepoDataFetcher.data.legacyInsomniaWorkspace
       : null;
+
+  const branchRemoteInfo =
+    gitRepoDataFetcher.data && 'branchRemoteInfo' in gitRepoDataFetcher.data && gitRepoDataFetcher.data.branchRemoteInfo
+      ? gitRepoDataFetcher.data.branchRemoteInfo
+      : null;
+
+  const isNonOriginBranch = branchRemoteInfo ? !branchRemoteInfo.isOrigin : false;
 
   // Only fetch the repo status if we have a repo uri and we don't have the status already
   const shouldFetchGitRepoStatus = Boolean(
@@ -232,11 +240,21 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
         status: 'error',
       });
     } else if (gitCheckoutFetcher.data && 'success' in gitCheckoutFetcher.data && gitCheckoutFetcher.data.success) {
-      showToast({
-        icon,
-        title: `Checkout completed`,
-        status: 'success',
-      });
+      const warnings = 'warnings' in gitCheckoutFetcher.data ? (gitCheckoutFetcher.data.warnings as string[]) : [];
+      if (warnings.length > 0) {
+        showToast({
+          icon,
+          title: 'Checkout completed with warnings',
+          description: warnings.join('\n'),
+          status: 'warning',
+        });
+      } else {
+        showToast({
+          icon,
+          title: `Checkout completed`,
+          status: 'success',
+        });
+      }
     }
   }, [gitCheckoutFetcher.data, icon]);
 
@@ -355,6 +373,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
         closeGitProjectStagingModalRef.current = showModal(GitProjectStagingModal, {
           mode: StagingModalModes.commitAndPull,
           callbackRef: gitProjectStagingModalCallbackPropsRef,
+          isNonOriginBranch,
         });
       } else if ('errors' in pullResult && pullResult.errors) {
         if (pullResult.errors.includes(GitVCSOperationErrors.AuthenticationRequiredError)) {
@@ -504,6 +523,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
             closeGitProjectStagingModalRef.current = showModal(GitProjectStagingModal, {
               mode: StagingModalModes.default,
               callbackRef: gitProjectStagingModalCallbackPropsRef,
+              isNonOriginBranch,
             });
           },
         },
@@ -511,14 +531,14 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
           id: 'pull',
           icon: isPulling ? 'refresh' : 'cloud-download',
           label: 'Pull',
-          isDisabled: false,
+          isDisabled: isNonOriginBranch,
           action: async () => handlePull(),
         },
         {
           id: 'push',
           icon: 'cloud-upload',
           label: 'Push',
-          isDisabled: false,
+          isDisabled: isNonOriginBranch,
           action: () => handlePush({ force: false }),
         },
         {
@@ -531,7 +551,7 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
         {
           id: 'fetch',
           icon: 'refresh',
-          isDisabled: false,
+          isDisabled: isNonOriginBranch,
           label: 'Fetch',
           action: () => {
             setOperationError(null);
@@ -604,6 +624,13 @@ export const GitProjectSyncDropdown: FC<Props> = ({ gitRepository, activeProject
 
   return (
     <>
+      {isNonOriginBranch && branchRemoteInfo?.trackingRemote && currentBranch && (
+        <GitNonOriginBranchBanner
+          trackingRemote={branchRemoteInfo.trackingRemote}
+          remoteUrl={branchRemoteInfo.remoteUrl}
+          currentBranch={currentBranch}
+        />
+      )}
       {operationError && (
         <div className="flex gap-2 bg-[rgba(var(--color-danger-rgb),1)] px-2 py-1 text-xs text-(--color-font-danger)">
           <div className="flex items-center gap-2">

--- a/packages/insomnia/src/ui/components/git/git-non-origin-branch-banner.tsx
+++ b/packages/insomnia/src/ui/components/git/git-non-origin-branch-banner.tsx
@@ -1,0 +1,84 @@
+import type { FC } from 'react';
+import { Button, Dialog, DialogTrigger, Heading, Popover } from 'react-aria-components';
+
+import { CopyButton } from '../base/copy-button';
+import { Icon } from '../icon';
+
+interface Props {
+  trackingRemote: string;
+  remoteUrl: string | null;
+  currentBranch: string;
+}
+
+export const GitNonOriginBranchBanner: FC<Props> = ({ currentBranch }) => {
+  return (
+    <div className="flex w-full items-center gap-3 bg-[rgba(var(--color-warning-rgb),0.1)] px-3 py-1.5 text-xs text-(--color-font)">
+      <Icon icon="triangle-exclamation" className="shrink-0 text-(--color-warning)" />
+      <span className="min-w-0 flex-1 wrap-break-word whitespace-normal">
+        This branch tracks a non-origin remote which is currently unsupported in Insomnia
+      </span>
+      <DialogTrigger>
+        <Button className="flex items-center justify-center gap-2 rounded-sm px-4 py-1 text-sm text-(--color-font) ring-1 ring-(--hl) transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)">
+          How to fix
+        </Button>
+        <Popover
+          offset={8}
+          placement="bottom end"
+          className="max-h-[85vh] max-w-xl overflow-y-auto rounded-md border border-solid border-(--hl-md) bg-(--color-bg) p-6 text-sm text-(--color-font) shadow-lg select-none focus:outline-hidden"
+        >
+          <Dialog className="focus:outline-hidden">
+            <Heading className="mb-4 text-xl font-semibold text-(--color-font)">Set branch upstream to origin</Heading>
+            <p className="mb-4 max-w-2xl text-base">
+              To continue pushing and pulling to the remote repo with this branch, complete the following steps using
+              the git CLI:
+            </p>
+            <ol className="space-y-6">
+              <li>
+                <div className="mb-2 flex items-baseline gap-3 font-semibold text-(--color-font)">
+                  <span>1.</span>
+                  <p>Re-point to origin</p>
+                </div>
+                <div className="flex items-center gap-3 rounded-xl bg-(--hl-xs) px-5 py-4">
+                  <code className="min-w-0 flex-1 border-none bg-transparent wrap-break-word whitespace-normal select-text">
+                    git branch --set-upstream-to=origin/{currentBranch}
+                  </code>
+                  <CopyButton
+                    size="small"
+                    confirmMessage=""
+                    content={`git branch --set-upstream-to=origin/${currentBranch}`}
+                    title="Copy command"
+                    style={{ borderWidth: 0, padding: 0 }}
+                    className="shrink-0 rounded-xl border border-solid border-(--hl-md) bg-(--color-bg) p-2.5"
+                  >
+                    <i className="fa fa-copy" />
+                  </CopyButton>
+                </div>
+              </li>
+              <li>
+                <div className="mb-2 flex items-baseline gap-3">
+                  <span className="font-semibold text-(--color-font)">2.</span>
+                  <p className="font-semibold text-(--color-font)">Push to origin</p>
+                </div>
+                <div className="flex items-center gap-3 rounded-xl bg-(--hl-xs) px-5 py-4">
+                  <code className="min-w-0 flex-1 border-none bg-transparent wrap-break-word whitespace-normal select-text">
+                    git push origin {currentBranch}
+                  </code>
+                  <CopyButton
+                    size="small"
+                    confirmMessage=""
+                    content={`git push origin ${currentBranch}`}
+                    title="Copy command"
+                    style={{ borderWidth: 0, padding: 0 }}
+                    className="shrink-0 rounded-xl border border-solid border-(--hl-md) bg-(--color-bg) p-10"
+                  >
+                    <i className="fa fa-copy" />
+                  </CopyButton>
+                </div>
+              </li>
+            </ol>
+          </Dialog>
+        </Popover>
+      </DialogTrigger>
+    </div>
+  );
+};

--- a/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
+++ b/packages/insomnia/src/ui/components/modals/git-project-staging-modal.tsx
@@ -124,6 +124,7 @@ interface GeneratedCommitsFormProps {
   gitRepository?: GitRepository | null;
   selectedCredential?: GitCredentials | null;
   selectedProvider?: GitProviderOption | null;
+  isNonOriginBranch?: boolean;
 }
 
 interface FileItem {
@@ -288,6 +289,7 @@ const GeneratedCommitsForm: FC<GeneratedCommitsFormProps> = ({
   gitRepository,
   selectedCredential,
   selectedProvider,
+  isNonOriginBranch,
 }) => {
   const commitsFetcher = useGitProjectCommitsActionFetcher();
   const committingActionRef = useRef<'commit' | 'commit-push' | null>(null);
@@ -523,7 +525,7 @@ const GeneratedCommitsForm: FC<GeneratedCommitsFormProps> = ({
 
           <Button
             type="submit"
-            isDisabled={committingActionRef.current === 'commit-push' && isCommitting}
+            isDisabled={isNonOriginBranch || (committingActionRef.current === 'commit-push' && isCommitting)}
             name="push"
             value="true"
             className="flex h-8 flex-1 items-center justify-center gap-2 rounded-xs bg-(--hl-xxs) px-4 text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
@@ -584,6 +586,7 @@ interface ManualCommitFormProps {
   gitRepository?: GitRepository | null;
   selectedCredential?: GitCredentials | null;
   selectedProvider?: GitProviderOption | null;
+  isNonOriginBranch?: boolean;
 }
 
 const ManualCommitForm: FC<ManualCommitFormProps> = ({
@@ -600,6 +603,7 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
   gitRepository,
   selectedCredential,
   selectedProvider,
+  isNonOriginBranch,
 }) => {
   const commitFetcher = useGitProjectCommitActionFetcher();
 
@@ -745,19 +749,38 @@ const ManualCommitForm: FC<ManualCommitFormProps> = ({
               Commit
             </Button>
 
-            <Button
-              type="submit"
-              isDisabled={(committingActionRef.current === 'commit-push' && isCommitting) || stagedCount === 0}
-              name="push"
-              value="true"
-              className="flex h-8 flex-1 items-center justify-center gap-2 rounded-xs bg-(--hl-xxs) px-4 text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
-            >
-              <Icon
-                icon={committingActionRef.current === 'commit-push' && isCommitting ? 'spinner' : 'cloud-arrow-up'}
-                className={`w-5 ${committingActionRef.current === 'commit-push' && isCommitting ? 'animate-spin' : ''}`}
-              />{' '}
-              Commit and push
-            </Button>
+            {isNonOriginBranch ? (
+              <TooltipTrigger>
+                <Button
+                  name="push"
+                  value="true"
+                  onPress={() => {}}
+                  className="flex h-8 flex-1 items-center justify-center gap-2 rounded-xs bg-(--hl-xxs) px-4 text-sm text-(--color-font) opacity-50 ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
+                >
+                  <Icon icon="cloud-arrow-up" className="w-5" /> Commit and push
+                </Button>
+                <Tooltip
+                  offset={8}
+                  className="max-h-[85vh] max-w-xs overflow-y-auto rounded-md border border-solid border-(--hl-sm) bg-(--color-bg) px-4 py-2 text-sm text-(--color-font) shadow-lg select-none focus:outline-hidden"
+                >
+                  Push action is not allowed for branches on non-origin remotes
+                </Tooltip>
+              </TooltipTrigger>
+            ) : (
+              <Button
+                type="submit"
+                isDisabled={committingActionRef.current === 'commit-push' && isCommitting}
+                name="push"
+                value="true"
+                className="flex h-8 flex-1 items-center justify-center gap-2 rounded-xs bg-(--hl-xxs) px-4 text-sm text-(--color-font) ring-1 ring-transparent transition-all hover:bg-(--hl-xs) focus:ring-(--hl-md) focus:ring-inset aria-pressed:bg-(--hl-sm)"
+              >
+                <Icon
+                  icon={committingActionRef.current === 'commit-push' && isCommitting ? 'spinner' : 'cloud-arrow-up'}
+                  className={`w-5 ${committingActionRef.current === 'commit-push' && isCommitting ? 'animate-spin' : ''}`}
+                />{' '}
+                Commit and push
+              </Button>
+            )}
           </div>
         )}
         {operationError && selectedProvider && isGitRepoLoadAuthHttp40Error([operationError]) ? (
@@ -1034,6 +1057,7 @@ export interface GitProjectStagingModalCallbackProps {
 
 export interface GitProjectStagingModalOptions {
   mode?: StagingModalMode;
+  isNonOriginBranch?: boolean;
   /* Why is callbackRef a ref object?
    * The callbacks passed to the modal (onClose, onPullAfterCommit, onPushAfterPull) may change after the show function is called.
    * If we were to pass the callbacks directly, the modal would capture the initial callbacks and not reflect any updates to them.
@@ -1057,8 +1081,8 @@ export const GitProjectStagingModal = forwardRef<GitProjectStagingModalHandle>((
   }, []);
 
   useImperativeHandle(ref, () => ({
-    show: ({ mode: newMode = StagingModalModes.default, callbackRef }) => {
-      setModalOptions({ mode: newMode, callbackRef });
+    show: ({ mode: newMode = StagingModalModes.default, callbackRef, isNonOriginBranch }) => {
+      setModalOptions({ mode: newMode, callbackRef, isNonOriginBranch });
       setIsOpen(true);
     },
     hide,
@@ -1082,6 +1106,7 @@ export const GitProjectStagingModal = forwardRef<GitProjectStagingModalHandle>((
     isOpen && (
       <OriginalGitProjectStagingModal
         mode={modalOptions?.mode}
+        isNonOriginBranch={modalOptions?.isNonOriginBranch}
         onClose={onClose}
         onPullAfterCommit={onPullAfterCommit}
         onPushAfterPull={onPushAfterPull}
@@ -1094,8 +1119,9 @@ GitProjectStagingModal.displayName = 'GitProjectStagingModal';
 const OriginalGitProjectStagingModal: FC<
   {
     mode?: StagingModalMode;
+    isNonOriginBranch?: boolean;
   } & GitProjectStagingModalCallbackProps
-> = ({ mode = StagingModalModes.default, onClose, onPullAfterCommit, onPushAfterPull }) => {
+> = ({ mode = StagingModalModes.default, isNonOriginBranch, onClose, onPullAfterCommit, onPushAfterPull }) => {
   const { projectId } = useParams() as { projectId: string };
 
   const [commitGenerationKey, setCommitGenerationKey] = useState(0);
@@ -1373,6 +1399,7 @@ const OriginalGitProjectStagingModal: FC<
                         gitRepository={gitRepository}
                         selectedCredential={selectedCredential}
                         selectedProvider={selectedProvider}
+                        isNonOriginBranch={isNonOriginBranch}
                       />
                     )}
 
@@ -1391,6 +1418,7 @@ const OriginalGitProjectStagingModal: FC<
                         gitRepository={gitRepository}
                         selectedCredential={selectedCredential}
                         selectedProvider={selectedProvider}
+                        isNonOriginBranch={isNonOriginBranch}
                       />
                     )}
                   </div>


### PR DESCRIPTION
## Overview

Insomnia's git integration is hardcoded to a single remote named origin. Since repos are now stored as canonical git repositories on disk, users can run native git CLI commands, including git remote add. When a user adds a second remote (e.g. upstream) and checks out one of its branches, all Insomnia sync operations (fetch, pull, push, canPush) silently target origin — producing confusing errors or wrong behavior. There is no detection, warning, or graceful handling.


## Goals

1. **Detect** when the current branch tracks a remote other than `origin`
2. **Inform** the user clearly via UI why sync operations won't work
3. **Prevent** broken operations with actionable error messages
4. **Suggest** CLI workarounds so the user isn't stuck

## Non-Goals

- Full multi-remote support
- UI for adding/removing/editing remotes
- Per-remote credential management

## UI/UX Updates

### Display a banner when the current branch is tracking a non-origin remote:
<img width="503" height="400" alt="image" src="https://github.com/user-attachments/assets/b621078d-4f40-4da9-806c-2b3e546b105f" />

### Display a toast warning when checking out a branch that is tracking a non-origin remote:

https://github.com/user-attachments/assets/7dfad3cd-14a7-4882-b9a7-b469a2b25f6a

### Commit still works but commit-and-push is disabled and displays a tooltip with the reason.

<img width="383" height="145" alt="image" src="https://github.com/user-attachments/assets/129a26c9-e732-40f8-9c26-829a789e7733" />

