### PR TITLE
feat: Change default behavior when delete cloud sync workspace

### DIFF
--- a/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-card-dropdown.tsx
@@ -303,7 +303,7 @@ export const WorkspaceCardDropdown: FC<Props> = props => {
                         {getWorkspaceLabel(workspace).singular}
                       </p>
                       {models.project.isRemoteProject(project) && (
-                        <RadioGroup name="localOnly" defaultValue="false" className="mb-2 flex flex-col gap-2">
+                        <RadioGroup name="localOnly" defaultValue="true" className="mb-2 flex flex-col gap-2">
                           <Label className="text-sm text-(--hl)">How do you want to delete it?</Label>
                           <div className="flex gap-2">
                             <Radio

--- a/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
+++ b/packages/insomnia/src/ui/components/dropdowns/workspace-dropdown.tsx
@@ -459,7 +459,7 @@ export const WorkspaceDropdown: FC<{}> = () => {
                         {getWorkspaceLabel(activeWorkspace).singular}
                       </p>
                       {models.project.isRemoteProject(activeProject) && (
-                        <RadioGroup name="localOnly" defaultValue="false" className="mb-2 flex flex-col gap-2">
+                        <RadioGroup name="localOnly" defaultValue="true" className="mb-2 flex flex-col gap-2">
                           <Label className="text-sm text-(--hl)">How do you want to delete it?</Label>
                           <div className="flex gap-2">
                             <Radio


### PR DESCRIPTION
Change default option to delete locally for the modal to delete cloud-sync workspace

[INS-2308](https://konghq.atlassian.net/browse/INS-2308)

[INS-2308]: https://konghq.atlassian.net/browse/INS-2308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ