### PR TITLE
fix: (git cli)refresh ui after sync

### DIFF
--- a/packages/insomnia/src/insomnia-data/src/models/workspace-meta.ts
+++ b/packages/insomnia/src/insomnia-data/src/models/workspace-meta.ts
@@ -18,6 +18,7 @@ export interface BaseWorkspaceMeta {
   hasUncommittedChanges: boolean;
   hasUnpushedChanges: boolean;
   gitFilePath: string | null;
+  gitFileLastSyncTime: number | null;
 }
 
 export type WorkspaceMeta = BaseWorkspaceMeta & BaseModel;
@@ -33,6 +34,7 @@ export function init(): BaseWorkspaceMeta {
     activeUnitTestSuiteId: null,
     gitRepositoryId: null,
     gitFilePath: null,
+    gitFileLastSyncTime: null,
     parentId: null,
     pushSnapshotOnInitialize: false,
     hasUncommittedChanges: false,

--- a/packages/insomnia/src/sync/git/repo-file-watcher.ts
+++ b/packages/insomnia/src/sync/git/repo-file-watcher.ts
@@ -434,7 +434,7 @@ class RepoFileWatcher {
     }
 
     await this.deleteOrphans(docs);
-    await this.upsertDocs(absPath, normalised, docs);
+    await this.upsertDocs(absPath, normalised, result.mtimeMs, docs);
 
     this.notifyRenderer();
   }
@@ -546,6 +546,7 @@ class RepoFileWatcher {
   private async upsertDocs(
     absPath: string,
     normalised: string,
+    syncTime: number,
     docs: NonNullable<ReturnType<typeof tryImportV5Data>['data']>,
   ): Promise<void> {
     const bufferId = await db.bufferChanges();
@@ -556,6 +557,7 @@ class RepoFileWatcher {
           const workspaceMeta = await services.workspaceMeta.getOrCreateByParentId(doc._id);
           await services.workspaceMeta.update(workspaceMeta, {
             gitFilePath: this.toPosixRelPath(absPath),
+            gitFileLastSyncTime: syncTime,
           });
           this.lastKnownGitFilePath.set(doc._id, normalised);
         }
@@ -668,7 +670,6 @@ class RepoFileWatcher {
   private async removeOrphanedWorkspaces(currentDiskFiles: string[]): Promise<void> {
     const diskFileSet = new Set(currentDiskFiles.map(f => path.normalize(f)));
     const entries = await this.getWorkspacesWithMeta();
-
     for (const { workspace, meta } of entries) {
       if (!meta?.gitFilePath) {
         continue;

--- a/packages/insomnia/src/ui/hooks/use-vcs-version.ts
+++ b/packages/insomnia/src/ui/hooks/use-vcs-version.ts
@@ -1,12 +1,13 @@
 import { useProjectIndexLoaderData } from '../../routes/organization.$organizationId.project.$projectId._index';
 import { useWorkspaceLoaderData } from '../../routes/organization.$organizationId.project.$projectId.workspace.$workspaceId';
 
-// We use this hook to determine if the active workspace has been updated from the Git VCS
-// For example, by pulling a new version from the remote, switching branches, etc.
+// We use this hook to determine if the active workspace should remount editors due to
+// Git/VCS changes or a successful FS watcher sync of the backing YAML file.
 export function useGitVCSVersion() {
   const workspaceData = useWorkspaceLoaderData();
   const projectData = useProjectIndexLoaderData();
   const gitRepository = workspaceData?.gitRepository || projectData?.activeProjectGitRepository;
+  const gitFileLastSyncTime = workspaceData?.activeWorkspaceMeta?.gitFileLastSyncTime;
 
-  return `${gitRepository?.cachedGitLastCommitTime}:${gitRepository?.cachedGitRepositoryBranch}`;
+  return `${gitRepository?.cachedGitLastCommitTime}:${gitRepository?.cachedGitRepositoryBranch}:${gitFileLastSyncTime}`;
 }


### PR DESCRIPTION
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
Add file modified time into workspaceMeta and attach it in `useGitVCSVersion` hook.
So the uniqueKey will change every time we import a file in the file watcher.