### PR TITLE
Refactor:use electron store for oauth session

### DIFF
--- a/packages/insomnia/src/common/__tests__/electron-storage.test.ts
+++ b/packages/insomnia/src/common/__tests__/electron-storage.test.ts
@@ -108,4 +108,13 @@ describe('Test electron storage()', () => {
     expect(fs.readFileSync(path.join(basePath, 'foo'), 'utf8')).toEqual('"bar3"');
     expect(fs.readFileSync(path.join(basePath, 'another'), 'utf8')).toEqual('10');
   });
+
+  it.each(['', '.', '..', 'foo/bar', 'foo\\bar', 'foo\0bar'])('rejects invalid key %j', key => {
+    const basePath = `/tmp/insomnia-electronstorage-${Math.random()}`;
+    const electronStorage = new ElectronStorage(basePath);
+
+    expect(() => electronStorage.getItem(key)).toThrowError('Invalid electron storage key');
+    expect(() => electronStorage.setItem(key, 'value')).toThrowError('Invalid electron storage key');
+    expect(() => electronStorage.deleteItem(key)).toThrowError('Invalid electron storage key');
+  });
 });

--- a/packages/insomnia/src/common/constants.ts
+++ b/packages/insomnia/src/common/constants.ts
@@ -13,6 +13,7 @@ export const INSOMNIA_GITLAB_REDIRECT_URI = env.INSOMNIA_GITLAB_REDIRECT_URI;
 export const INSOMNIA_GITLAB_CLIENT_ID = env.INSOMNIA_GITLAB_CLIENT_ID;
 export const INSOMNIA_GITLAB_API_URL = env.INSOMNIA_GITLAB_API_URL;
 export const PLAYWRIGHT = env.PLAYWRIGHT;
+export const OAUTH_WINDOW_SESSION_ID_KEY = 'current-oauth-session-id';
 
 // App Stuff
 export const getSkipOnboarding = () => env.INSOMNIA_SKIP_ONBOARDING;

--- a/packages/insomnia/src/entry.client.tsx
+++ b/packages/insomnia/src/entry.client.tsx
@@ -129,7 +129,7 @@ if (insomniaSession) {
 const appSettings = await services.settings.getOrCreate();
 
 if (appSettings.clearOAuth2SessionOnRestart) {
-  clearOAuthWindowSessionId();
+  await clearOAuthWindowSessionId();
 }
 
 applyColorScheme(appSettings);

--- a/packages/insomnia/src/entry.client.tsx
+++ b/packages/insomnia/src/entry.client.tsx
@@ -9,15 +9,10 @@ import { HydratedRouter } from 'react-router/dom';
 import { insomniaFetch } from '~/common/insomnia-fetch';
 import { initDatabase, initServices, services } from '~/insomnia-data';
 import { database as clientDatabase } from '~/ui/database.client';
+import { clearOAuthWindowSessionId } from '~/ui/spawn-oauth-window';
 
 import { migrateFromLocalStorage, type SessionData, setSessionData, setVaultSessionData } from './account/session';
-import {
-  getInsomniaSession,
-  getInsomniaVaultKey,
-  getInsomniaVaultSalt,
-  getSkipOnboarding,
-} from './common/constants';
-import { initNewOAuthSession } from './network/o-auth-2/get-token';
+import { getInsomniaSession, getInsomniaVaultKey, getInsomniaVaultSalt, getSkipOnboarding } from './common/constants';
 import { init as initPlugins } from './plugins';
 import { applyColorScheme } from './plugins/misc';
 import { HtmlElementWrapper } from './ui/components/html-element-wrapper';
@@ -134,7 +129,7 @@ if (insomniaSession) {
 const appSettings = await services.settings.getOrCreate();
 
 if (appSettings.clearOAuth2SessionOnRestart) {
-  initNewOAuthSession();
+  clearOAuthWindowSessionId();
 }
 
 applyColorScheme(appSettings);

--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -121,7 +121,6 @@ app.on('ready', async () => {
   await backupIfNewerVersionAvailable();
   sentryWatchAnalyticsEnabled();
   watchProxySettings();
-  windowUtils.init();
 
   await runGitCredentialsMigration();
 

--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -14,6 +14,7 @@ import type { Project, RemoteProject, Stats } from '~/insomnia-data';
 import { database, initDatabase, initServices, services } from '~/insomnia-data';
 import { servicesNodeImpl } from '~/insomnia-data/node';
 import { mainDatabase } from '~/main/database.main';
+import { initElectronStorage } from '~/main/electron-storage';
 import { registerPathHandlers } from '~/main/ipc/path';
 import { registerLLMConfigServiceAPI } from '~/main/llm-config-service';
 import { runGitCredentialsMigration } from '~/sync/git/migrations';
@@ -47,6 +48,8 @@ import * as models from './models/index';
 const dataPath =
   process.env.INSOMNIA_DATA_PATH ||
   path.join(app.getPath('userData'), '../', isDevelopment() ? 'insomnia-app' : userDataFolder);
+
+initElectronStorage(dataPath);
 app.setPath('userData', dataPath);
 
 initializeLogging();

--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -49,8 +49,8 @@ const dataPath =
   process.env.INSOMNIA_DATA_PATH ||
   path.join(app.getPath('userData'), '../', isDevelopment() ? 'insomnia-app' : userDataFolder);
 
-initElectronStorage(dataPath);
 app.setPath('userData', dataPath);
+initElectronStorage(dataPath);
 
 initializeLogging();
 

--- a/packages/insomnia/src/entry.main.ts
+++ b/packages/insomnia/src/entry.main.ts
@@ -26,6 +26,7 @@ import { registerInsomniaProtocols } from './main/api.protocol';
 import { backupIfNewerVersionAvailable } from './main/backup';
 import { registerGitServiceAPI } from './main/git-service';
 import { ipcMainOn, ipcMainOnce, registerElectronHandlers } from './main/ipc/electron';
+import { registerElectronStorageHandlers } from './main/ipc/electron-storage';
 import { registergRPCHandlers } from './main/ipc/grpc';
 import { registerMainHandlers } from './main/ipc/main';
 import { registerSecretStorageHandlers } from './main/ipc/secret-storage';
@@ -89,6 +90,7 @@ app.on('ready', async () => {
   registerCurlHandlers();
   registerMcpHandlers();
   registerSecretStorageHandlers();
+  registerElectronStorageHandlers();
 
   /**
    * There's no option that prevents Electron from fetching spellcheck dictionaries from Chromium's CDN and passing a non-resolving URL is the only known way to prevent it from fetching.

--- a/packages/insomnia/src/entry.preload.ts
+++ b/packages/insomnia/src/entry.preload.ts
@@ -5,6 +5,7 @@ import type { LLMBackend, LLMConfig, LLMConfigServiceAPI } from '~/main/llm-conf
 import type { GenerateMcpSamplingResponseFunction } from '~/plugins/types';
 
 import type { GitServiceAPI } from './main/git-service';
+import type { electronStorageBridgeAPI } from './main/ipc/electron-storage';
 import type { gRPCBridgeAPI } from './main/ipc/grpc';
 import type { secretStorageBridgeAPI } from './main/ipc/secret-storage';
 import type { AIFeatureNames } from './main/llm-config-service';
@@ -108,6 +109,11 @@ const secretStorage: secretStorageBridgeAPI = {
   decryptString: cipherText => ipcRenderer.invoke('secretStorage.decryptString', cipherText),
 };
 
+const electronStorage: electronStorageBridgeAPI = {
+  getItem: key => ipcRenderer.invoke('electronStorage.getItem', key),
+  setItem: (key, value) => ipcRenderer.invoke('electronStorage.setItem', key, value),
+};
+
 const git: GitServiceAPI = {
   loadGitRepository: options => ipcRenderer.invoke('git.loadGitRepository', options),
   getGitBranches: options => ipcRenderer.invoke('git.getGitBranches', options),
@@ -209,6 +215,7 @@ const main: Window['main'] = {
   grpc,
   curl,
   secretStorage,
+  electronStorage,
   trackSegmentEvent: options => ipcRenderer.send('trackSegmentEvent', options),
   trackPageView: options => ipcRenderer.send('trackPageView', options),
   setCurrentOrganizationId: organizationId => ipcRenderer.send('analytics.setOrganizationId', organizationId),

--- a/packages/insomnia/src/main/electron-storage.ts
+++ b/packages/insomnia/src/main/electron-storage.ts
@@ -3,11 +3,22 @@ import path from 'node:path';
 
 import { app } from 'electron';
 
-let electronStorage: ElectronStorage | null = null;
+import { isDevelopment } from '~/common/constants';
+
+import { userDataFolder } from '../../config/config.json';
+
+// resilience against userData folder being changed while the app is running
+// if it changes we just make a new ElectronStorage instance with the new path
+const electronStorageByPath = new Map<string, ElectronStorage>();
 export function getElectronStorage() {
-  const electronStoragePath = path.join(process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'), 'localStorage');
+  const dataPath =
+    process.env.INSOMNIA_DATA_PATH ||
+    path.join(app.getPath('userData'), '../', isDevelopment() ? 'insomnia-app' : userDataFolder);
+  const electronStoragePath = path.join(dataPath, 'localStorage');
+  let electronStorage = electronStorageByPath.get(electronStoragePath);
   if (!electronStorage) {
     electronStorage = new ElectronStorage(electronStoragePath);
+    electronStorageByPath.set(electronStoragePath, electronStorage);
   }
   return electronStorage;
 }

--- a/packages/insomnia/src/main/electron-storage.ts
+++ b/packages/insomnia/src/main/electron-storage.ts
@@ -7,14 +7,8 @@ import { invariant } from '~/utils/invariant';
 let electronStorage: ElectronStorage | null = null;
 export function initElectronStorage(dataPath: string) {
   const electronStoragePath = path.join(dataPath, 'localStorage');
-  if (electronStorage) {
-    // In dev, loud failure > silent no-op
-    invariant(
-      process.env.NODE_ENV !== 'development',
-      `ElectronStorage already initialized. Attempted re-init with: ${electronStoragePath}`,
-    );
-    return;
-  }
+  // Ensure that electronStorage is not yet initialized before creating a new instance. This prevents accidental re-initialization with a different path, which could lead to data loss.
+  invariant(!electronStorage, `ElectronStorage already initialized. Attempted re-init with: ${electronStoragePath}`);
   electronStorage = new ElectronStorage(electronStoragePath);
 }
 export function getElectronStorage() {
@@ -36,24 +30,26 @@ class ElectronStorage {
   }
 
   setItem<T>(key: string, obj?: T) {
-    clearTimeout(this._timeouts[key]);
-    this._buffer[key] = JSON.stringify(obj);
-    this._timeouts[key] = setTimeout(this._flush.bind(this), 100);
+    const storageKey = this._validateKey(key);
+    clearTimeout(this._timeouts[storageKey]);
+    this._buffer[storageKey] = JSON.stringify(obj);
+    this._timeouts[storageKey] = setTimeout(this._flush.bind(this), 100);
   }
 
   getItem<T>(key: string, defaultObj?: T) {
+    const storageKey = this._validateKey(key);
     // Make sure things are flushed before we read
     this._flush();
 
     let contents = JSON.stringify(defaultObj);
 
-    const path = this._getKeyPath(key);
+    const path = this._getKeyPath(storageKey);
 
     try {
       contents = String(fs.readFileSync(path));
     } catch (error) {
       if (error.code === 'ENOENT') {
-        this.setItem(key, defaultObj);
+        this.setItem(storageKey, defaultObj);
       }
     }
 
@@ -66,10 +62,11 @@ class ElectronStorage {
   }
 
   deleteItem(key: string) {
-    clearTimeout(this._timeouts[key]);
-    delete this._buffer[key];
+    const storageKey = this._validateKey(key);
+    clearTimeout(this._timeouts[storageKey]);
+    delete this._buffer[storageKey];
 
-    const path = this._getKeyPath(key);
+    const path = this._getKeyPath(storageKey);
 
     try {
       fs.unlinkSync(path);
@@ -78,6 +75,14 @@ class ElectronStorage {
         console.error(`[localstorage] Failed to delete item from LocalStorage: ${error}`);
       }
     }
+  }
+
+  _validateKey(key: string) {
+    if (!key || key === '.' || key === '..' || key.includes('/') || key.includes('\\') || key.includes('\0')) {
+      throw new Error('Invalid electron storage key');
+    }
+
+    return key;
   }
 
   _flush() {

--- a/packages/insomnia/src/main/electron-storage.ts
+++ b/packages/insomnia/src/main/electron-storage.ts
@@ -1,25 +1,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { app } from 'electron';
-
-import { isDevelopment } from '~/common/constants';
-
-import { userDataFolder } from '../../config/config.json';
-
-// resilience against userData folder being changed while the app is running
-// if it changes we just make a new ElectronStorage instance with the new path
-const electronStorageByPath = new Map<string, ElectronStorage>();
-export function getElectronStorage() {
-  const dataPath =
-    process.env.INSOMNIA_DATA_PATH ||
-    path.join(app.getPath('userData'), '../', isDevelopment() ? 'insomnia-app' : userDataFolder);
+let electronStorage: ElectronStorage | null = null;
+export function initElectronStorage(dataPath: string) {
   const electronStoragePath = path.join(dataPath, 'localStorage');
-  let electronStorage = electronStorageByPath.get(electronStoragePath);
   if (!electronStorage) {
     electronStorage = new ElectronStorage(electronStoragePath);
-    electronStorageByPath.set(electronStoragePath, electronStorage);
   }
+}
+export function getElectronStorage() {
   return electronStorage;
 }
 

--- a/packages/insomnia/src/main/electron-storage.ts
+++ b/packages/insomnia/src/main/electron-storage.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { invariant } from '~/utils/invariant';
+
 let electronStorage: ElectronStorage | null = null;
 export function initElectronStorage(dataPath: string) {
   const electronStoragePath = path.join(dataPath, 'localStorage');
@@ -9,6 +11,7 @@ export function initElectronStorage(dataPath: string) {
   }
 }
 export function getElectronStorage() {
+  invariant(electronStorage, 'ElectronStorage has not been initialized.');
   return electronStorage;
 }
 

--- a/packages/insomnia/src/main/electron-storage.ts
+++ b/packages/insomnia/src/main/electron-storage.ts
@@ -7,9 +7,13 @@ import { invariant } from '~/utils/invariant';
 let electronStorage: ElectronStorage | null = null;
 export function initElectronStorage(dataPath: string) {
   const electronStoragePath = path.join(dataPath, 'localStorage');
+  const resolvedDataPath = path.resolve(dataPath);
+  const resolvedElectronStoragePath = path.resolve(electronStoragePath);
+  const relativePath = path.relative(resolvedDataPath, resolvedElectronStoragePath);
+  invariant(!relativePath.startsWith('..') && !path.isAbsolute(relativePath), `Invalid path`);
   // Ensure that electronStorage is not yet initialized before creating a new instance. This prevents accidental re-initialization with a different path, which could lead to data loss.
-  invariant(!electronStorage, `ElectronStorage already initialized. Attempted re-init with: ${electronStoragePath}`);
-  electronStorage = new ElectronStorage(electronStoragePath);
+  invariant(!electronStorage, `ElectronStorage already initialized. Attempted re-init with: ${resolvedElectronStoragePath}`);
+  electronStorage = new ElectronStorage(resolvedElectronStoragePath);
 }
 export function getElectronStorage() {
   invariant(electronStorage, 'ElectronStorage has not been initialized.');

--- a/packages/insomnia/src/main/electron-storage.ts
+++ b/packages/insomnia/src/main/electron-storage.ts
@@ -1,6 +1,17 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { app } from 'electron';
+
+let electronStorage: ElectronStorage | null = null;
+export function getElectronStorage() {
+  const electronStoragePath = path.join(process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'), 'localStorage');
+  if (!electronStorage) {
+    electronStorage = new ElectronStorage(electronStoragePath);
+  }
+  return electronStorage;
+}
+
 class ElectronStorage {
   _buffer: Record<string, string> = {};
   _timeouts: Record<string, NodeJS.Timeout> = {};

--- a/packages/insomnia/src/main/electron-storage.ts
+++ b/packages/insomnia/src/main/electron-storage.ts
@@ -3,12 +3,19 @@ import path from 'node:path';
 
 import { invariant } from '~/utils/invariant';
 
+// Intentional singleton: initialized once per process via initElectronStorage and shared across the app.
 let electronStorage: ElectronStorage | null = null;
 export function initElectronStorage(dataPath: string) {
   const electronStoragePath = path.join(dataPath, 'localStorage');
-  if (!electronStorage) {
-    electronStorage = new ElectronStorage(electronStoragePath);
+  if (electronStorage) {
+    // In dev, loud failure > silent no-op
+    invariant(
+      process.env.NODE_ENV !== 'development',
+      `ElectronStorage already initialized. Attempted re-init with: ${electronStoragePath}`,
+    );
+    return;
   }
+  electronStorage = new ElectronStorage(electronStoragePath);
 }
 export function getElectronStorage() {
   invariant(electronStorage, 'ElectronStorage has not been initialized.');

--- a/packages/insomnia/src/main/ipc/electron-storage.ts
+++ b/packages/insomnia/src/main/ipc/electron-storage.ts
@@ -1,0 +1,20 @@
+import { getElectronStorage } from '../electron-storage';
+import { ipcMainHandle } from './electron';
+
+export interface electronStorageBridgeAPI {
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<void>;
+}
+
+export function registerElectronStorageHandlers() {
+  ipcMainHandle('electronStorage.getItem', (_, key: string) => {
+    const storage = getElectronStorage();
+    const value = storage.getItem<string>(key);
+    return value ?? null;
+  });
+
+  ipcMainHandle('electronStorage.setItem', (_, key: string, value: string) => {
+    const storage = getElectronStorage();
+    storage.setItem(key, value);
+  });
+}

--- a/packages/insomnia/src/main/ipc/electron-storage.ts
+++ b/packages/insomnia/src/main/ipc/electron-storage.ts
@@ -6,25 +6,15 @@ export interface electronStorageBridgeAPI {
   setItem: (key: string, value: string) => Promise<void>;
 }
 
-function validateElectronStorageKey(key: string): string {
-  if (!key || key === '.' || key === '..' || key.includes('/') || key.includes('\\') || key.includes('\0')) {
-    throw new Error('Invalid electron storage key');
-  }
-
-  return key;
-}
-
 export function registerElectronStorageHandlers() {
   ipcMainHandle('electronStorage.getItem', (_, key: string) => {
-    const storageKey = validateElectronStorageKey(key);
     const storage = getElectronStorage();
-    const value = storage.getItem<string>(storageKey);
+    const value = storage.getItem<string>(key);
     return value ?? null;
   });
 
   ipcMainHandle('electronStorage.setItem', (_, key: string, value: string) => {
-    const storageKey = validateElectronStorageKey(key);
     const storage = getElectronStorage();
-    storage.setItem(storageKey, value);
+    storage.setItem(key, value);
   });
 }

--- a/packages/insomnia/src/main/ipc/electron-storage.ts
+++ b/packages/insomnia/src/main/ipc/electron-storage.ts
@@ -6,15 +6,25 @@ export interface electronStorageBridgeAPI {
   setItem: (key: string, value: string) => Promise<void>;
 }
 
+function validateElectronStorageKey(key: string): string {
+  if (!key || key === '.' || key === '..' || key.includes('/') || key.includes('\\') || key.includes('\0')) {
+    throw new Error('Invalid electron storage key');
+  }
+
+  return key;
+}
+
 export function registerElectronStorageHandlers() {
   ipcMainHandle('electronStorage.getItem', (_, key: string) => {
+    const storageKey = validateElectronStorageKey(key);
     const storage = getElectronStorage();
-    const value = storage.getItem<string>(key);
+    const value = storage.getItem<string>(storageKey);
     return value ?? null;
   });
 
   ipcMainHandle('electronStorage.setItem', (_, key: string, value: string) => {
+    const storageKey = validateElectronStorageKey(key);
     const storage = getElectronStorage();
-    storage.setItem(key, value);
+    storage.setItem(storageKey, value);
   });
 }

--- a/packages/insomnia/src/main/ipc/electron.ts
+++ b/packages/insomnia/src/main/ipc/electron.ts
@@ -120,6 +120,8 @@ export type HandleChannels =
   | 'readDir'
   | 'readOrCreateDataDir'
   | 'restoreBackup'
+  | 'electronStorage.getItem'
+  | 'electronStorage.setItem'
   | 'secretStorage.decryptString'
   | 'secretStorage.deleteSecret'
   | 'secretStorage.encryptString'

--- a/packages/insomnia/src/main/ipc/main.ts
+++ b/packages/insomnia/src/main/ipc/main.ts
@@ -59,6 +59,7 @@ import {
 import type { SocketIOBridgeAPI } from '../network/socket-io';
 import type { WebSocketBridgeAPI } from '../network/websocket';
 import { ipcMainHandle, ipcMainOn, type RendererOnChannels } from './electron';
+import type { electronStorageBridgeAPI } from './electron-storage';
 import extractPostmanDataDumpHandler from './extract-postman-data-dump';
 import type { gRPCBridgeAPI } from './grpc';
 import type { secretStorageBridgeAPI } from './secret-storage';
@@ -160,6 +161,7 @@ export interface RendererToMainBridgeAPI {
   git: GitServiceAPI;
   llm: LLMConfigServiceAPI;
   secretStorage: secretStorageBridgeAPI;
+  electronStorage: electronStorageBridgeAPI;
   trackSegmentEvent: (options: { event: string; properties?: Record<string, unknown> }) => void;
   trackPageView: (options: { name: string }) => void;
   setCurrentOrganizationId: (organizationId: string | undefined) => void;

--- a/packages/insomnia/src/main/ipc/secret-storage.ts
+++ b/packages/insomnia/src/main/ipc/secret-storage.ts
@@ -1,7 +1,6 @@
 import { safeStorage } from 'electron';
 
-import type ElectronStorage from '../electron-storage';
-import { initElectronStorage } from '../window-utils';
+import { getElectronStorage } from '../electron-storage';
 import { ipcMainHandle } from './electron';
 
 export interface secretStorageBridgeAPI {
@@ -19,15 +18,6 @@ export function registerSecretStorageHandlers() {
   ipcMainHandle('secretStorage.encryptString', (_, raw) => encryptString(raw));
   ipcMainHandle('secretStorage.decryptString', (_, raw) => decryptString(raw));
 }
-
-let electronStorage: ElectronStorage | null = null;
-
-const getElectronStorage = () => {
-  if (!electronStorage) {
-    electronStorage = initElectronStorage();
-  }
-  return electronStorage;
-};
 
 const setSecret = async (key: string, secret: string) => {
   try {

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -28,7 +28,6 @@ const DEFAULT_WIDTH = 1280;
 const DEFAULT_HEIGHT = 720;
 const MINIMUM_WIDTH = 500;
 const MINIMUM_HEIGHT = 400;
-const electronStorage = getElectronStorage();
 const browserWindows = new Map<'Insomnia' | 'HiddenBrowserWindow', ElectronBrowserWindow>();
 let hiddenWindowIsBusy = false;
 interface Bounds {
@@ -715,6 +714,7 @@ function saveBounds() {
   }
 
   const fullscreen = browserWindow?.isFullScreen();
+  const electronStorage = getElectronStorage();
 
   // Only save the size if we're not in fullscreen
   if (!fullscreen) {
@@ -732,6 +732,7 @@ function getBounds() {
   let maximize = false;
 
   try {
+    const electronStorage = getElectronStorage();
     bounds = electronStorage?.getItem('bounds', {});
     fullscreen = electronStorage?.getItem('fullscreen', false);
     maximize = electronStorage?.getItem('maximize', false);
@@ -753,6 +754,7 @@ const ZOOM_MIN = 0.05;
 
 const getZoomFactor = () => {
   try {
+    const electronStorage = getElectronStorage();
     return electronStorage?.getItem('zoomFactor', ZOOM_DEFAULT);
   } catch (error) {
     // This should never happen, but if it does...!

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -20,7 +20,7 @@ import { getAppBuildDate, getAppVersion, getProductName, isDevelopment, MNEMONIC
 import { docsBase } from '../common/documentation';
 import { isLinux, isMac } from '../common/platform';
 import { invariant } from '../utils/invariant';
-import ElectronStorage from './electron-storage';
+import { getElectronStorage } from './electron-storage';
 import { ipcMainOn } from './ipc/electron';
 import { getLogDirectory } from './log';
 
@@ -30,9 +30,8 @@ const MINIMUM_WIDTH = 500;
 const MINIMUM_HEIGHT = 400;
 
 const browserWindows = new Map<'Insomnia' | 'HiddenBrowserWindow', ElectronBrowserWindow>();
-let electronStorage: ElectronStorage | null = null;
 let hiddenWindowIsBusy = false;
-
+const electronStorage = getElectronStorage();
 interface Bounds {
   height?: number;
   width?: number;
@@ -40,9 +39,6 @@ interface Bounds {
   y?: number;
 }
 
-export function init() {
-  initElectronStorage();
-}
 const stopAndWaitForHiddenBrowserWindow = async (runningHiddenBrowserWindow: BrowserWindow) => {
   return await new Promise<void>(resolve => {
     // overwrite the closed handler
@@ -779,16 +775,9 @@ export const setZoom = (transformer: (current: number) => number) => () => {
   const actual = Math.min(Math.max(ZOOM_MIN, desired), ZOOM_MAX);
 
   browserWindow.webContents.setZoomLevel(actual);
+  const electronStorage = getElectronStorage();
   electronStorage?.setItem('zoomFactor', actual);
 };
-
-export function initElectronStorage() {
-  const electronStoragePath = path.join(process.env['INSOMNIA_DATA_PATH'] || app.getPath('userData'), 'localStorage');
-  if (!electronStorage) {
-    electronStorage = new ElectronStorage(electronStoragePath);
-  }
-  return electronStorage;
-}
 
 export function createWindowsAndReturnMain() {
   const mainWindow = browserWindows.get('Insomnia') ?? createWindow();

--- a/packages/insomnia/src/main/window-utils.ts
+++ b/packages/insomnia/src/main/window-utils.ts
@@ -28,10 +28,9 @@ const DEFAULT_WIDTH = 1280;
 const DEFAULT_HEIGHT = 720;
 const MINIMUM_WIDTH = 500;
 const MINIMUM_HEIGHT = 400;
-
+const electronStorage = getElectronStorage();
 const browserWindows = new Map<'Insomnia' | 'HiddenBrowserWindow', ElectronBrowserWindow>();
 let hiddenWindowIsBusy = false;
-const electronStorage = getElectronStorage();
 interface Bounds {
   height?: number;
   width?: number;

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -14,6 +14,7 @@ import type {
   Response,
 } from '~/insomnia-data';
 import { database as db, models, services } from '~/insomnia-data';
+import { getElectronStorage } from '~/main/electron-storage';
 import { getBodyBuffer } from '~/models/helpers/response-operations';
 import { encryptOAuthUrl } from '~/network/o-auth-2/utils';
 
@@ -38,17 +39,18 @@ import { type AuthKeys, GRANT_TYPE_AUTHORIZATION_CODE, PKCE_CHALLENGE_S256 } fro
 
 const { isRequestGroup, isRequestGroupId } = models.requestGroup;
 const LOCALSTORAGE_KEY_SESSION_ID = 'insomnia::current-oauth-session-id';
+const electronStorage = getElectronStorage();
 
 export function initNewOAuthSession() {
   // the value of this variable needs to start with 'persist:'
   // otherwise sessions won't be persisted over application-restarts
   const authWindowSessionId = `persist:oauth2_${uuidv4()}`;
-  window.localStorage.setItem(LOCALSTORAGE_KEY_SESSION_ID, authWindowSessionId);
+  electronStorage.setItem(LOCALSTORAGE_KEY_SESSION_ID, authWindowSessionId);
   return authWindowSessionId;
 }
 
 export function getOAuthSession(): string {
-  const token = window.localStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID);
+  const token = electronStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID);
   return token || initNewOAuthSession();
 }
 

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -18,7 +18,7 @@ import { getBodyBuffer } from '~/models/helpers/response-operations';
 import { encryptOAuthUrl } from '~/network/o-auth-2/utils';
 
 import { version } from '../../../package.json';
-import { getOauthRedirectUrl } from '../../common/constants';
+import { getOauthRedirectUrl, OAUTH_WINDOW_SESSION_ID_KEY } from '../../common/constants';
 import { escapeRegex } from '../../common/misc';
 import uiEventBus, { OAUTH2_AUTHORIZATION_STATUS_CHANGE } from '../../ui/event-bus';
 import { invariant } from '../../utils/invariant';
@@ -39,13 +39,12 @@ import { type AuthKeys, GRANT_TYPE_AUTHORIZATION_CODE, PKCE_CHALLENGE_S256 } fro
 const { isRequestGroup, isRequestGroupId } = models.requestGroup;
 
 async function getOAuthWindowHandleSession(): Promise<string> {
-  const LOCALSTORAGE_KEY_SESSION_ID = 'insomnia::current-oauth-session-id';
-  const token = await window.main.electronStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID);
+  const token = await window.main.electronStorage.getItem(OAUTH_WINDOW_SESSION_ID_KEY);
   if (token) {
     return token;
   }
   const authWindowSessionId = `persist:oauth2_${uuidv4()}`;
-  await window.main.electronStorage.setItem(LOCALSTORAGE_KEY_SESSION_ID, authWindowSessionId);
+  await window.main.electronStorage.setItem(OAUTH_WINDOW_SESSION_ID_KEY, authWindowSessionId);
   return authWindowSessionId;
 }
 

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -14,7 +14,6 @@ import type {
   Response,
 } from '~/insomnia-data';
 import { database as db, models, services } from '~/insomnia-data';
-import { getElectronStorage } from '~/main/electron-storage';
 import { getBodyBuffer } from '~/models/helpers/response-operations';
 import { encryptOAuthUrl } from '~/network/o-auth-2/utils';
 
@@ -39,15 +38,14 @@ import { type AuthKeys, GRANT_TYPE_AUTHORIZATION_CODE, PKCE_CHALLENGE_S256 } fro
 
 const { isRequestGroup, isRequestGroupId } = models.requestGroup;
 
-function getOAuthWindowHandleSession(): string {
-  const electronStorage = getElectronStorage();
+async function getOAuthWindowHandleSession(): Promise<string> {
   const LOCALSTORAGE_KEY_SESSION_ID = 'insomnia::current-oauth-session-id';
-  const token = electronStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID);
+  const token = await window.main.electronStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID);
   if (token) {
     return token;
   }
   const authWindowSessionId = `persist:oauth2_${uuidv4()}`;
-  electronStorage.setItem(LOCALSTORAGE_KEY_SESSION_ID, authWindowSessionId);
+  await window.main.electronStorage.setItem(LOCALSTORAGE_KEY_SESSION_ID, authWindowSessionId);
   return authWindowSessionId;
 }
 
@@ -102,7 +100,7 @@ export const getOAuth2Token = async (
         url: implicitUrl.toString(),
         urlSuccessRegex: /(access_token=|id_token=)/,
         urlFailureRegex: /(error=)/,
-        sessionId: getOAuthWindowHandleSession(),
+        sessionId: await getOAuthWindowHandleSession(),
       });
       console.log('[oauth2] Detected redirect ' + redirectedTo);
 
@@ -182,7 +180,7 @@ export const getOAuth2Token = async (
           urlFailureRegex: authentication.redirectUrl
             ? new RegExp(`${escapeRegex(authentication.redirectUrl)}.*([?&]error=)`, 'i')
             : /([?&]error=)/i,
-          sessionId: getOAuthWindowHandleSession(),
+          sessionId: await getOAuthWindowHandleSession(),
         });
       }
 

--- a/packages/insomnia/src/network/o-auth-2/get-token.ts
+++ b/packages/insomnia/src/network/o-auth-2/get-token.ts
@@ -38,20 +38,17 @@ import {
 import { type AuthKeys, GRANT_TYPE_AUTHORIZATION_CODE, PKCE_CHALLENGE_S256 } from './constants';
 
 const { isRequestGroup, isRequestGroupId } = models.requestGroup;
-const LOCALSTORAGE_KEY_SESSION_ID = 'insomnia::current-oauth-session-id';
-const electronStorage = getElectronStorage();
 
-export function initNewOAuthSession() {
-  // the value of this variable needs to start with 'persist:'
-  // otherwise sessions won't be persisted over application-restarts
+function getOAuthWindowHandleSession(): string {
+  const electronStorage = getElectronStorage();
+  const LOCALSTORAGE_KEY_SESSION_ID = 'insomnia::current-oauth-session-id';
+  const token = electronStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID);
+  if (token) {
+    return token;
+  }
   const authWindowSessionId = `persist:oauth2_${uuidv4()}`;
   electronStorage.setItem(LOCALSTORAGE_KEY_SESSION_ID, authWindowSessionId);
   return authWindowSessionId;
-}
-
-export function getOAuthSession(): string {
-  const token = electronStorage.getItem(LOCALSTORAGE_KEY_SESSION_ID);
-  return token || initNewOAuthSession();
 }
 
 // NOTE
@@ -105,7 +102,7 @@ export const getOAuth2Token = async (
         url: implicitUrl.toString(),
         urlSuccessRegex: /(access_token=|id_token=)/,
         urlFailureRegex: /(error=)/,
-        sessionId: getOAuthSession(),
+        sessionId: getOAuthWindowHandleSession(),
       });
       console.log('[oauth2] Detected redirect ' + redirectedTo);
 
@@ -185,7 +182,7 @@ export const getOAuth2Token = async (
           urlFailureRegex: authentication.redirectUrl
             ? new RegExp(`${escapeRegex(authentication.redirectUrl)}.*([?&]error=)`, 'i')
             : /([?&]error=)/i,
-          sessionId: getOAuthSession(),
+          sessionId: getOAuthWindowHandleSession(),
         });
       }
 

--- a/packages/insomnia/src/sync/git/migrations.ts
+++ b/packages/insomnia/src/sync/git/migrations.ts
@@ -26,8 +26,7 @@
 
 import { database } from '~/common/database';
 import { type GitCredentials, type GitRepository, services } from '~/insomnia-data';
-import type ElectronStorage from '~/main/electron-storage';
-import { initElectronStorage } from '~/main/window-utils';
+import { getElectronStorage } from '~/main/electron-storage';
 
 import * as models from '../../models';
 
@@ -35,15 +34,6 @@ const { isGitCredentialsOAuth } = models.gitRepository;
 const { isGitCredentialsV1 } = models.gitCredentials;
 
 const MIGRATION_KEY = 'GIT_CREDENTIALS_MIGRATION';
-
-let electronStorage: ElectronStorage | null = null;
-
-const getElectronStorage = () => {
-  if (!electronStorage) {
-    electronStorage = initElectronStorage();
-  }
-  return electronStorage;
-};
 
 const hasRunMigration = () => {
   const migrationStorage = getElectronStorage();

--- a/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
+++ b/packages/insomnia/src/ui/components/editors/auth/o-auth-2-auth.tsx
@@ -2,6 +2,7 @@ import React, { type ChangeEvent, type FC, type ReactNode, useEffect, useMemo, u
 
 import type { AuthTypeOAuth2, OAuth2ResponseType, OAuth2Token, RequestAuthentication } from '~/insomnia-data';
 import { services } from '~/insomnia-data';
+import { clearOAuthWindowSessionId } from '~/ui/spawn-oauth-window';
 
 import { getOauthRedirectUrl } from '../../../../common/constants';
 import { toKebabCase } from '../../../../common/misc';
@@ -17,7 +18,6 @@ import {
   PKCE_CHALLENGE_S256,
 } from '../../../../network/o-auth-2/constants';
 import { getOAuth2Token } from '../../../../network/o-auth-2/get-token';
-import { initNewOAuthSession } from '../../../../network/o-auth-2/get-token';
 import {
   type RequestLoaderData,
   useRequestLoaderData,
@@ -427,7 +427,7 @@ export const OAuth2Auth = ({ showMcpAuthFlow, disabled }: { showMcpAuthFlow?: bo
                 <div className="pad-top text-right">
                   <button
                     className="h-(--line-height-xs) rounded-md border border-solid border-(--hl-lg) px-(--padding-md) hover:bg-(--hl-xs)"
-                    onClick={initNewOAuthSession}
+                    onClick={clearOAuthWindowSessionId}
                   >
                     Clear OAuth 2 session
                   </button>

--- a/packages/insomnia/src/ui/components/settings/general.tsx
+++ b/packages/insomnia/src/ui/components/settings/general.tsx
@@ -1,6 +1,7 @@
 import React, { type FC, Fragment } from 'react';
 
 import { useRootLoaderData } from '~/root';
+import { clearOAuthWindowSessionId } from '~/ui/spawn-oauth-window';
 
 import {
   EditorKeyMap,
@@ -14,7 +15,6 @@ import { docsKeyMaps } from '../../../common/documentation';
 import { isMac } from '../../../common/platform';
 import { type HttpVersion, HttpVersions, UpdateChannel } from '../../../common/settings';
 import { strings } from '../../../common/strings';
-import { initNewOAuthSession } from '../../../network/o-auth-2/get-token';
 import { Link } from '../base/link';
 import { CheckForUpdatesButton } from '../check-for-updates-button';
 import { BooleanSetting } from './boolean-setting';
@@ -226,7 +226,7 @@ export const General: FC = () => {
         />
         <button
           className="pointer h-(--line-height-xs) rounded-md border border-solid border-(--hl-lg) px-(--padding-sm) hover:bg-(--hl-xs)"
-          onClick={initNewOAuthSession}
+          onClick={clearOAuthWindowSessionId}
         >
           Clear OAuth 2 session
         </button>

--- a/packages/insomnia/src/ui/spawn-oauth-window.ts
+++ b/packages/insomnia/src/ui/spawn-oauth-window.ts
@@ -1,14 +1,15 @@
 import { v4 as uuidv4 } from 'uuid';
 
-export const LOCALSTORAGE_KEY_SESSION_ID = 'insomnia::current-oauth-session-id';
+import { OAUTH_WINDOW_SESSION_ID_KEY } from '~/common/constants';
+
 export async function initNewOAuthSession() {
   // the value of this variable needs to start with 'persist:'
   // otherwise sessions won't be persisted over application-restarts
   const authWindowSessionId = `persist:oauth2_${uuidv4()}`;
-  await window.main.electronStorage.setItem(LOCALSTORAGE_KEY_SESSION_ID, authWindowSessionId);
+  await window.main.electronStorage.setItem(OAUTH_WINDOW_SESSION_ID_KEY, authWindowSessionId);
   return authWindowSessionId;
 }
 
 export const clearOAuthWindowSessionId = async () => {
-  await window.main.electronStorage.setItem(LOCALSTORAGE_KEY_SESSION_ID, '');
+  await window.main.electronStorage.setItem(OAUTH_WINDOW_SESSION_ID_KEY, '');
 };

--- a/packages/insomnia/src/ui/spawn-oauth-window.ts
+++ b/packages/insomnia/src/ui/spawn-oauth-window.ts
@@ -1,14 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
-
 import { OAUTH_WINDOW_SESSION_ID_KEY } from '~/common/constants';
-
-export async function initNewOAuthSession() {
-  // the value of this variable needs to start with 'persist:'
-  // otherwise sessions won't be persisted over application-restarts
-  const authWindowSessionId = `persist:oauth2_${uuidv4()}`;
-  await window.main.electronStorage.setItem(OAUTH_WINDOW_SESSION_ID_KEY, authWindowSessionId);
-  return authWindowSessionId;
-}
 
 export const clearOAuthWindowSessionId = async () => {
   await window.main.electronStorage.setItem(OAUTH_WINDOW_SESSION_ID_KEY, '');

--- a/packages/insomnia/src/ui/spawn-oauth-window.ts
+++ b/packages/insomnia/src/ui/spawn-oauth-window.ts
@@ -1,0 +1,14 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export const LOCALSTORAGE_KEY_SESSION_ID = 'insomnia::current-oauth-session-id';
+export async function initNewOAuthSession() {
+  // the value of this variable needs to start with 'persist:'
+  // otherwise sessions won't be persisted over application-restarts
+  const authWindowSessionId = `persist:oauth2_${uuidv4()}`;
+  await window.main.electronStorage.setItem(LOCALSTORAGE_KEY_SESSION_ID, authWindowSessionId);
+  return authWindowSessionId;
+}
+
+export const clearOAuthWindowSessionId = async () => {
+  await window.main.electronStorage.setItem(LOCALSTORAGE_KEY_SESSION_ID, '');
+};


### PR DESCRIPTION
prep work for oauth PR #9834

This code path is covered by oauth.test.ts

the biggest decision in this PR is the lifespan of the electronStore.

Option 1: Per-request / per-IPC-call (ephemeral)
A new instance is created for each request and discarded after the response. This is the most granular option — cheapest in terms of retained memory, but it means no state persists between calls. Only viable if every caller is fully self-contained and never needs to read back what it wrote.

Option 2: Per-window lifetime
The store instance is tied to a BrowserWindow — created when the window opens, destroyed when it closes. Since localStorage semantics in a renderer are naturally scoped to an origin per window, this maps intuitively to the mental model. Works well if different windows genuinely need isolated state.

Option 3: Application lifetime (singleton)
One instance is created at app startup (in the main process module or a dedicated service), lives for the duration of the process, and is shared across all IPC callers. Destroyed only when the app exits. Optionally flushed to disk for persistence across launches.

Option 4: Persistent / session-restored
Similar to application lifetime, but the store is serialised on quit and rehydrated on launch. Closer to what actual localStorage does — data outlives the process. Adds a write/read cycle around app lifecycle events.


Optimal choice: application lifetime singleton (Option 3)
For an Electron main-process context, the singleton is the right default, and the rationale is straightforward.
The main process is itself a singleton — there's exactly one of it, and it owns IPC. Any state stored there is already implicitly global to the app session. Creating a new store instance per IPC call throws away the entire point of having a store: accumulation and recall within a session. Per-window scoping is semantically correct for renderer-side localStorage, but in the main process you've already crossed the abstraction boundary — you're emulating the storage interface, not the storage scope, so per-window isolation is usually unnecessary overhead unless you have a concrete isolation requirement.
The application lifetime singleton also gives you a natural place to attach flush-on-quit behaviour later (upgrading to Option 4) without changing any caller code — you just add app.on('quit', () => store.flush()). That upgrade path is nearly free; the reverse (collapsing a per-request design into a singleton) requires more surgery.
The one condition that would push you toward Option 2 is if windows have meaningfully different users or security boundaries — for example, a settings window vs. a sandboxed preview window. In Insomnia's case, where windows share the same user session and data model, that boundary doesn't apply, and a singleton is both simpler and more consistent with how the rest of the main-process state is managed.
<!--
Please open an [Issue](https://github.com/kong/insomnia/issues/new) first to discuss new
features or non-trivial changes. Please provide as much detail as possible on the change as
possible including general description, implementation details, potential shortcomings, etc.

If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->
