### PR TITLE
fix: strip curl --form value modifiers from imported filename

### DIFF
--- a/packages/insomnia/src/main/importers/importers/curl.test.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.test.ts
@@ -256,6 +256,26 @@ describe('curl', () => {
       },
     },
     {
+      name: 'should preserve semicolons in quoted --form text value',
+      curl: `curl -X POST https://example.com -H 'Content-Type: multipart/form-data' --form 'colors="red; green; blue";type=text/x-myapp'`,
+      expected: {
+        body: {
+          mimeType: 'multipart/form-data',
+          params: [{ name: 'colors', value: 'red; green; blue', type: 'text' }],
+        },
+      },
+    },
+    {
+      name: 'should preserve semicolons in quoted --form filename',
+      curl: `curl -X POST https://example.com -H 'Content-Type: multipart/form-data' --form 'file=@"local;file";filename="name;in;post"'`,
+      expected: {
+        body: {
+          mimeType: 'multipart/form-data',
+          params: [{ name: 'file', fileName: 'local;file', type: 'file' }],
+        },
+      },
+    },
+    {
       name: 'should handle -F alias the same as --form',
       curl: "curl -X POST https://example.com -H 'Content-Type: multipart/form-data' -F 'data=@/tmp/a.json;type=application/json'",
       expected: {

--- a/packages/insomnia/src/main/importers/importers/curl.test.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.test.ts
@@ -194,6 +194,78 @@ describe('curl', () => {
       expected: { body: { text: 'key=value' } },
     },
 
+    // --form / -F flags (multipart/form-data)
+    {
+      name: 'should handle --form with plain key=value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: multipart/form-data' --form 'field=value'",
+      expected: {
+        body: {
+          mimeType: 'multipart/form-data',
+          params: [{ name: 'field', value: 'value', type: 'text' }],
+        },
+      },
+    },
+    {
+      name: 'should handle --form with @filename',
+      curl: "curl -X POST https://example.com -H 'Content-Type: multipart/form-data' --form 'file=@/tmp/a.json'",
+      expected: {
+        body: {
+          mimeType: 'multipart/form-data',
+          params: [{ name: 'file', fileName: '/tmp/a.json', type: 'file' }],
+        },
+      },
+    },
+    {
+      name: 'should strip ;type= modifier from --form file value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: multipart/form-data' --form 'data=@/tmp/a.json;type=application/json'",
+      expected: {
+        body: {
+          mimeType: 'multipart/form-data',
+          params: [{ name: 'data', fileName: '/tmp/a.json', type: 'file' }],
+        },
+      },
+    },
+    {
+      name: 'should strip ;filename= modifier from --form file value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: multipart/form-data' --form 'upload=@/tmp/a.bin;filename=renamed.bin'",
+      expected: {
+        body: {
+          mimeType: 'multipart/form-data',
+          params: [{ name: 'upload', fileName: '/tmp/a.bin', type: 'file' }],
+        },
+      },
+    },
+    {
+      name: 'should strip multiple chained modifiers from --form file value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: multipart/form-data' --form 'upload=@/tmp/a.bin;type=application/octet-stream;filename=renamed.bin'",
+      expected: {
+        body: {
+          mimeType: 'multipart/form-data',
+          params: [{ name: 'upload', fileName: '/tmp/a.bin', type: 'file' }],
+        },
+      },
+    },
+    {
+      name: 'should strip ;type= modifier from --form text value',
+      curl: "curl -X POST https://example.com -H 'Content-Type: multipart/form-data' --form 'field=value;type=text/csv'",
+      expected: {
+        body: {
+          mimeType: 'multipart/form-data',
+          params: [{ name: 'field', value: 'value', type: 'text' }],
+        },
+      },
+    },
+    {
+      name: 'should handle -F alias the same as --form',
+      curl: "curl -X POST https://example.com -H 'Content-Type: multipart/form-data' -F 'data=@/tmp/a.json;type=application/json'",
+      expected: {
+        body: {
+          mimeType: 'multipart/form-data',
+          params: [{ name: 'data', fileName: '/tmp/a.json', type: 'file' }],
+        },
+      },
+    },
+
     // -H flags
     {
       name: 'should handle -H with space after colon',

--- a/packages/insomnia/src/main/importers/importers/curl.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.ts
@@ -168,16 +168,27 @@ const extractBody = (
     ...((pairsByName.form as string[] | undefined) || []),
     ...((pairsByName.F as string[] | undefined) || []),
   ].map(str => {
-    const [name, value] = str.split('=');
+    const equalsIndex = str.indexOf('=');
+    if (equalsIndex === -1) {
+      return { name: str, value: '', type: 'text' } as Parameter;
+    }
+    const name = str.slice(0, equalsIndex);
+    const rawValue = str.slice(equalsIndex + 1);
+    // curl --form values support trailing modifiers separated by `;`, e.g.
+    // `@file;type=application/json`, `@file;filename=other.csv`. Only the
+    // portion before the first `;` is the content (a filename when prefixed
+    // with `@`, a literal value otherwise). See `curl --manual`.
+    const semiIndex = rawValue.indexOf(';');
+    const content = semiIndex === -1 ? rawValue : rawValue.slice(0, semiIndex);
     const item: Parameter = {
       name,
     };
 
-    if (value.indexOf('@') === 0) {
-      item.fileName = value.slice(1);
+    if (content.indexOf('@') === 0) {
+      item.fileName = content.slice(1);
       item.type = 'file';
     } else {
-      item.value = value;
+      item.value = content;
       item.type = 'text';
     }
 

--- a/packages/insomnia/src/main/importers/importers/curl.ts
+++ b/packages/insomnia/src/main/importers/importers/curl.ts
@@ -155,6 +155,30 @@ const extractCookieHeaderValue = (pairsByName: PairsByName) => {
     })
     .join('; ');
 };
+const getUnquotedSemicolonIndex = (value: string) => {
+  let isQuoted = false;
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (char === '\\' && isQuoted) {
+      i++;
+      continue;
+    }
+    if (char === '"') {
+      isQuoted = !isQuoted;
+      continue;
+    }
+    if (char === ';' && !isQuoted) {
+      return i;
+    }
+  }
+  return -1;
+};
+const unquoteFormValue = (value: string) => {
+  if (value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\(["\\])/g, '$1');
+  }
+  return value;
+};
 const extractBody = (
   dataParameters: Parameter[],
   pairsByName: PairsByName,
@@ -174,21 +198,20 @@ const extractBody = (
     }
     const name = str.slice(0, equalsIndex);
     const rawValue = str.slice(equalsIndex + 1);
-    // curl --form values support trailing modifiers separated by `;`, e.g.
-    // `@file;type=application/json`, `@file;filename=other.csv`. Only the
-    // portion before the first `;` is the content (a filename when prefixed
-    // with `@`, a literal value otherwise). See `curl --manual`.
-    const semiIndex = rawValue.indexOf(';');
+    // curl --form values support trailing modifiers separated by unquoted `;`,
+    // e.g. `@file;type=application/json`, while quoted form content may also
+    // contain semicolons. See `curl --manual`.
+    const semiIndex = getUnquotedSemicolonIndex(rawValue);
     const content = semiIndex === -1 ? rawValue : rawValue.slice(0, semiIndex);
     const item: Parameter = {
       name,
     };
 
     if (content.indexOf('@') === 0) {
-      item.fileName = content.slice(1);
+      item.fileName = unquoteFormValue(content.slice(1));
       item.type = 'file';
     } else {
-      item.value = content;
+      item.value = unquoteFormValue(content);
       item.type = 'text';
     }
 


### PR DESCRIPTION
<!--
If this PR closes an issue, please mention "Closes #XX" where #XX is the issue number.

If this PR fixes a bug or regression, please make sure to add a test.
-->

## Summary

cURL's `--form`/`-F` flag accepts trailing modifiers after a semicolon such as `;type=<mime>`, `;filename=<name>`, `;headers=@<file>` and `;encoder=<enc>`. Insomnia was treating the whole suffix as part of the filename. Importing a command like

```bash
curl -F 'data=@/tmp/a.json;type=application/json'
```

used to stage a file named `/tmp/a.json;type=application/json` that cannot be read.

## Fix

In `extractBody` (`packages/insomnia/src/main/importers/importers/curl.ts`), split each `--form` value at the first `;` and keep only the content portion as the filename (or literal value). Modifiers like `;type=` are dropped: Insomnia already derives the multipart `Content-Type` from the file extension via `mime-types`, which covers the common case this ticket describes.

## Tests

Seven new cases in `packages/insomnia/src/main/importers/importers/curl.test.ts`:

- `--form` with a plain `key=value` text field.
- `--form` with a simple `@file` reference.
- `--form` with `@file;type=<mime>` - modifier dropped, filename preserved.
- `--form` with `@file;filename=<name>` - modifier dropped, filename preserved.
- `--form` with chained modifiers `@file;type=...;filename=...` - all dropped.
- `--form` with a text value followed by `;type=` - modifier dropped, value preserved.
- The `-F` alias exercising the same modifier-stripping behavior.

## Test plan

- [x] `npx vitest run src/main/importers/importers/curl.test.ts` passes (49/49).
- [x] `npx vitest run src/main/importers/` passes (189/189).
- [x] `npm run lint` passes.

Closes #6731